### PR TITLE
General Apache Parquet functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdb"
+version = "0.1.0"
+dependencies = [
+ "arrow",
+ "arrow-flight",
+ "dirs",
+ "rustyline",
+ "serde_json",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "mdbd"
+version = "0.1.0"
+dependencies = [
+ "arrow-flight",
+ "async-trait",
+ "datafusion",
+ "datafusion-physical-expr",
+ "futures",
+ "log",
+ "object_store",
+ "paho-mqtt",
+ "proptest",
+ "snmalloc-rs",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,40 +1304,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
-]
-
-[[package]]
-name = "mmdb"
-version = "0.1.0"
-dependencies = [
- "arrow",
- "arrow-flight",
- "dirs",
- "rustyline",
- "serde_json",
- "tokio",
- "tonic",
-]
-
-[[package]]
-name = "mmdbd"
-version = "0.1.0"
-dependencies = [
- "arrow-flight",
- "async-trait",
- "datafusion",
- "datafusion-physical-expr",
- "futures",
- "log",
- "object_store",
- "paho-mqtt",
- "proptest",
- "snmalloc-rs",
- "tokio",
- "tonic",
- "tracing",
- "tracing-futures",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,41 +1308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mmdb"
-version = "0.1.0"
-dependencies = [
- "arrow",
- "arrow-flight",
- "dirs",
- "rustyline",
- "serde_json",
- "tokio",
- "tonic",
-]
-
-[[package]]
-name = "mmdbd"
-version = "0.1.0"
-dependencies = [
- "arrow-flight",
- "async-trait",
- "datafusion",
- "datafusion-physical-expr",
- "futures",
- "log",
- "object_store",
- "paho-mqtt",
- "proptest",
- "snmalloc-rs",
- "tempfile",
- "tokio",
- "tonic",
- "tracing",
- "tracing-futures",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,7 @@ dependencies = [
  "paho-mqtt",
  "proptest",
  "snmalloc-rs",
+ "tempfile",
  "tokio",
  "tonic",
  "tracing",
@@ -1307,6 +1308,7 @@ dependencies = [
 ]
 
 [[package]]
+>>>>>>> c50754d (Added tests for writing batch to Apache Parquet)
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/README.md
+++ b/README.md
@@ -1,22 +1,36 @@
-# MiniModelarDB
-MiniModelarDB is a model-based time series management system that is primarily
-built as a re-design and re-implementation of
-[ModelarDB](https://github.com/ModelarData/ModelarDB). It is implemented in
-[Rust](https://www.rust-lang.org/) and uses
-[DataFusion](https://github.com/apache/arrow-datafusion) as the query engine,
-[Apache Arrow](https://github.com/apache/arrow-rs) as the in-memory format, and
-[Apache Parquet](https://github.com/apache/arrow-rs) as the on-disk format. The
-primary goals of the project are to experiment with low-level optimizations
-that are not easily possible on the JVM, design methods for efficiently
-representing irregular time series using a model-based approach while only
-requiring users to specify an error bound, develop a query optimizer that
-allows queries to automatically exploit the model-based representation, and
-provide a single easy to use relational query interface. MiniModelarDB is
-designed for Unix-like operating systems and is tested on Linux.
+# ModelarDB
+ModelarDB is an efficient high-performance time series management system. It
+provides state-of-the-art lossless compression, lossy compression, and query
+performance by representing time series using multiple different types of models
+such as constant and linear functions. These compressed time series can be
+efficiently queried using a relational interface and SQL without any knowledge
+about the model-based representation. A query optimizer automatically rewrites
+the queries to exploit the model-based representation.
 
-MiniModelarDB intentionally does not gather usage data. So, all users are highly
+ModelarDB is designed to be cross-platform and is tested on Microsoft Windows,
+macOS, and Ubuntu. It is implemented in [Rust](https://www.rust-lang.org/) and
+uses [Apache Arrow
+Flight](https://github.com/apache/arrow-rs/tree/master/arrow-flight) for
+communicating with clients, [Apache Arrow
+DataFusion](https://github.com/apache/arrow-datafusion) as its query engine,
+[Apache Arrow](https://github.com/apache/arrow-rs) as its in-memory data format,
+and [Apache Parquet](https://github.com/apache/arrow-rs/tree/master/parquet) as
+its on-disk data format.
+
+The first prototype of ModelarDB was implemented using [Apache
+Spark](https://www.h2database.com/html/main.html), [Apache
+Cassandra](https://cassandra.apache.org/_/index.html), and
+[H2](https://www.h2database.com/html/main.html) and was developed as part of a
+[research project](https://github.com/skejserjensen/ModelarDB) at Aalborg
+University and later as an [open-source
+project](https://github.com/ModelarData/ModelarDB). While this JVM-based
+prototype validated the benefits of using a model-based representation for time
+series, it has been superseded by this much more efficient Rust-based
+implementation.
+
+ModelarDB intentionally does not gather usage data. So, all users are highly
 encouraged to post comments, suggestions, and bugs as GitHub issues, especially
-if a limitation of MiniModelarDB prevents it from being used in a particular domain.
+if a limitation of ModelarDB prevents it from being used in a particular domain.
 
 ## Installation
 ### Linux
@@ -44,9 +58,9 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
    * Debug Build: `cargo build`
    * Release Build: `cargo build --release`
    * Run Tests: `cargo test`
-   * Run Server: `cargo run --bin mmdbd path_to_data_folder`
-   * Run Client: `cargo run --bin mmdb [server_address] [query_file]`
-5. Move `mmdbd` and `mmdb` from the `target` directory to any directory.
+   * Run Server: `cargo run --bin mdbd path_to_data_folder`
+   * Run Client: `cargo run --bin mdb [server_address] [query_file]`
+5. Move `mdbd` and `mdb` from the `target` directory to any directory.
 
 ## Development
 All code must be formatted according to the [Rust Style Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md)
@@ -72,8 +86,8 @@ used for purposes such as logging, where multiple crates provide similar functio
 - Property-based Testing - [proptest](https://crates.io/crates/proptest)
 
 ## Contributions
-Contributions to all aspects of MiniModelarDB are highly appreciated and do not
-need to be in the form of code. For example, contributions can be:
+Contributions to all aspects of ModelarDB are highly appreciated and do not need
+to be in the form of code. For example, contributions can be:
 
 - Helping other users.
 - Writing documentation.
@@ -88,5 +102,5 @@ in the appropriate GitHub issue if one exists, e.g., the bug report if it is a
 bugfix, and as a new GitHub issue otherwise.
 
 ## License
-MiniModelarDB is licensed under version 2.0 of the Apache License and a copy of the
+ModelarDB is licensed under version 2.0 of the Apache License and a copy of the
 license is bundled with the program.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mmdb"
+name = "mdb"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"

--- a/client/src/helper.rs
+++ b/client/src/helper.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ fn repl(rt: Runtime, mut fsc: FlightServiceClient<Channel>) -> Result<()> {
     let mut editor = Editor::<ClientHelper>::new()?;
     let table_names = retrieve_table_names(&rt, &mut fsc)?;
     editor.set_helper(Some(ClientHelper::new(table_names)));
-    let history_file_name = ".mmdbc_history";
+    let history_file_name = ".mdb_history";
     if let Some(mut home) = dirs::home_dir() {
         home.push(history_file_name);
         let _ = editor.load_history(&home);

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mmdbd"
+name = "mdbd"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,3 +30,4 @@ paho-mqtt = { version = "0.11", default-features = false, features = ["bundled"]
 
 [dev-dependencies]
 proptest = "1.0.0"
+tempfile = "3"

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -273,7 +273,7 @@ impl ModelTableMetadata {
         // members are shifted by one as the time series ids start at one.
         let time_series_file = folder_path.clone() + "/time_series.parquet";
         let path = Path::new(&time_series_file);
-        if let Ok(rows) = StorageEngine::read_batch_from_apache_parquet_file(path) {
+        if let Ok(rows) = StorageEngine::read_entire_apache_parquet_file(path) {
             let sampling_intervals = Self::extract_and_shift_int32_array(&rows, 2)?;
             let denormalized_dimensions = // Columns with metadata as strings.
                 Self::extract_and_shift_denormalized_dimensions(&rows, 4)?;

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -18,7 +18,7 @@
 //! models.
 
 use std::fs::{read_dir, DirEntry};
-use std::io::{Error, ErrorKind, Read};
+use std::io::{Error, ErrorKind};
 use std::str;
 use std::sync::Arc;
 use std::{fs::File, path::Path};
@@ -28,17 +28,13 @@ use datafusion::arrow::array::{
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::parquet::arrow::{ArrowReader, ParquetFileArrowReader};
 use datafusion::parquet::errors::ParquetError;
 use datafusion::parquet::file::reader::{FileReader, SerializedFileReader};
 use datafusion::parquet::record::RowAccessor;
 use object_store::path::Path as ObjectStorePath;
 use tracing::{error, info, warn};
 
-/// The expected [first four bytes of any Apache Parquet file].
-///
-/// [first four bytes of any Apache Parquet file]: https://en.wikipedia.org/wiki/List_of_file_signatures
-const APACHE_PARQUET_FILE_SIGNATURE: &[u8] = &[80, 65, 82, 49]; // PAR1.
+use crate::storage::StorageEngine;
 
 /// Metadata for the tables and model tables in the data folder.
 pub struct Catalog {
@@ -163,12 +159,13 @@ impl Catalog {
     /// Return `true` if `path` is a readable table, otherwise `false`.
     fn is_path_a_table(path: &Path) -> bool {
         if path.is_file() {
-            Self::is_path_an_apache_parquet_file(&path)
+            StorageEngine::is_path_an_apache_parquet_file(&path)
         } else if path.is_dir() {
             let table_folder = read_dir(&path);
             table_folder.is_ok()
                 && table_folder.unwrap().all(|result| {
-                    result.is_ok() && Self::is_path_an_apache_parquet_file(&result.unwrap().path())
+                    result.is_ok() &&
+                        StorageEngine::is_path_an_apache_parquet_file(&result.unwrap().path())
                 })
         } else {
             false
@@ -193,24 +190,13 @@ impl Catalog {
             let segment = segment.as_path();
             let segment_folder = read_dir(&segment);
 
-            Self::is_path_an_apache_parquet_file(model_type)
-                && Self::is_path_an_apache_parquet_file(time_series)
+            StorageEngine::is_path_an_apache_parquet_file(model_type)
+                && StorageEngine::is_path_an_apache_parquet_file(time_series)
                 && segment_folder.is_ok()
                 && segment_folder.unwrap().all(|result| {
-                    result.is_ok() && Self::is_path_an_apache_parquet_file(&result.unwrap().path())
+                    result.is_ok() &&
+                        StorageEngine::is_path_an_apache_parquet_file(&result.unwrap().path())
                 })
-        } else {
-            false
-        }
-    }
-
-    /// Return `true` if `path` is a readable Apache Parquet file, otherwise
-    /// `false`.
-    fn is_path_an_apache_parquet_file(path: &Path) -> bool {
-        if let Ok(mut file) = File::open(path) {
-            let mut first_four_bytes = vec![0u8; 4];
-            let _ = file.read_exact(&mut first_four_bytes);
-            first_four_bytes == APACHE_PARQUET_FILE_SIGNATURE
         } else {
             false
         }
@@ -287,8 +273,7 @@ impl ModelTableMetadata {
         // members are shifted by one as the time series ids start at one.
         let time_series_file = folder_path.clone() + "/time_series.parquet";
         let path = Path::new(&time_series_file);
-        if let Ok(file) = File::open(&path) {
-            let rows = Self::read_entire_apache_parquet_file(&folder_name, file)?;
+        if let Ok(rows) = StorageEngine::read_batch_from_apache_parquet_file(path) {
             let sampling_intervals = Self::extract_and_shift_int32_array(&rows, 2)?;
             let denormalized_dimensions = // Columns with metadata as strings.
                 Self::extract_and_shift_denormalized_dimensions(&rows, 4)?;
@@ -317,28 +302,6 @@ impl ModelTableMetadata {
         let path = Path::new(&segment_folder);
         ObjectStorePath::from_filesystem_path(path)
             .map_err(|error| ParquetError::General(error.to_string()))
-    }
-
-    /// Read all rows in the Apache Parquet `file` for the model table with
-    /// `table_name`.
-    fn read_entire_apache_parquet_file(
-        table_name: &String,
-        file: File,
-    ) -> Result<RecordBatch, ParquetError> {
-        let reader = SerializedFileReader::new(file)?;
-        let apache_parquet_metadata = reader.metadata();
-        let row_count = apache_parquet_metadata
-            .row_groups()
-            .iter()
-            .map(|rg| rg.num_rows())
-            .sum::<i64>() as usize;
-
-        let mut arrow_reader = ParquetFileArrowReader::new(Arc::new(reader));
-        let mut record_batch_reader = arrow_reader.get_record_reader(row_count)?;
-        let rows = record_batch_reader.next().ok_or_else(|| {
-            ParquetError::General(format!("No metadata exists for table '{}'.", *table_name))
-        })??;
-        Ok(rows)
     }
 
     /// Check that the model table only use supported model types.

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/errors.rs
+++ b/server/src/errors.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,17 +25,17 @@ use std::fmt::{Display, Formatter};
 
 /// Error type used throughout the system.
 #[derive(Debug)]
-pub enum MiniModelarDBError {
+pub enum ModelarDBError {
     /// Error returned by the model types.
     CompressionError(String),
 }
 
-impl Error for MiniModelarDBError {}
+impl Error for ModelarDBError {}
 
-impl Display for MiniModelarDBError {
+impl Display for ModelarDBError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-	match self {
-	    MiniModelarDBError::CompressionError(reason) => write!(f, "Compression Error: {}", reason),
-	}
+        match self {
+            ModelarDBError::CompressionError(reason) => write!(f, "Compression Error: {}", reason),
+        }
     }
 }

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/macros.rs
+++ b/server/src/macros.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-//! Implementation of MiniModelarDB's main function and a `Context` type that
+//! Implementation of ModelarDB's main function and a `Context` type that
 //! provides access to the system's configuration and components throughout the
 //! system.
 

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ use std::cmp::{Ordering, PartialOrd};
 
 use datafusion::arrow::array::{Int32Array, Int64Array};
 
-use crate::errors::MiniModelarDBError;
+use crate::errors::ModelarDBError;
 use crate::types::{
     TimeSeriesId, TimeSeriesIdArray, TimeSeriesIdBuilder, Timestamp, TimestampBuilder, Value,
     ValueBuilder,
@@ -50,9 +50,9 @@ struct ErrorBound(f32);
 impl ErrorBound {
     /// Return `ErrorBound` if `error_bound` is a positive finite value,
     /// otherwise `CompressionError`.
-    fn try_new(error_bound: f32) -> Result<Self, MiniModelarDBError> {
+    fn try_new(error_bound: f32) -> Result<Self, ModelarDBError> {
         if error_bound < 0.0 || error_bound.is_infinite() || error_bound.is_nan() {
-            Err(MiniModelarDBError::CompressionError(
+            Err(ModelarDBError::CompressionError(
                 "Error bound cannot be negative, infinite, or NAN.".to_owned(),
             ))
         } else {

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/optimizer/mod.rs
+++ b/server/src/optimizer/mod.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/optimizer/model_simple_aggregates.rs
+++ b/server/src/optimizer/model_simple_aggregates.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/storage/data_point.rs
+++ b/server/src/storage/data_point.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -273,7 +273,7 @@ impl StorageEngine {
     pub fn is_path_an_apache_parquet_file(path: &Path) -> bool {
         if let Ok(mut file) = File::open(path) {
             let mut first_four_bytes = vec![0u8; 4];
-            file.read_exact(&mut first_four_bytes);
+            let _ = file.read_exact(&mut first_four_bytes);
             first_four_bytes == APACHE_PARQUET_FILE_SIGNATURE
         } else {
             false

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -280,11 +280,6 @@ impl StorageEngine {
         }
     }
 
-    /// Return `true` if `path` is a viable Apache Parquet file path, otherwise `false`.
-    fn is_path_a_viable_apache_parquet_path(path: &Path) -> bool {
-        path.extension().is_some() && path.extension().unwrap().to_str().unwrap() == "parquet"
-    }
-
     /// Move `segment_builder` to the queue of finished segments.
     fn enqueue_segment(&mut self, key: String, segment_builder: SegmentBuilder) {
         let finished_segment = FinishedSegment {

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -23,6 +23,7 @@ mod time_series;
 
 use std::collections::vec_deque::VecDeque;
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -216,7 +217,7 @@ impl StorageEngine {
         );
 
         // Check if the extension of the given path is correct.
-        if path.extension().is_some() && path.extension().unwrap().to_str().unwrap() == "parquet" {
+        if path.extension().and_then(OsStr::to_str) == Some("parquet") {
             if let Ok(file) = File::create(path) {
                 let props = WriterProperties::builder()
                     .set_dictionary_enabled(false)

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -515,11 +515,23 @@ mod tests {
 
     // Tests for Apache Parquet.
     #[test]
-    fn test_write_batch_to_new_apache_parquet_file() {
+    fn test_write_batch_to_apache_parquet_file() {
         let temp_dir = tempdir().unwrap();
         let batch = test_util::get_compressed_segment_record_batch();
 
         let parquet_path = temp_dir.path().join("test.parquet");
+        StorageEngine::write_batch_to_apache_parquet_file(batch, parquet_path.as_path());
+
+        assert!(parquet_path.exists());
+    }
+
+    #[test]
+    fn test_write_empty_batch_to_apache_parquet_file() {
+        let schema = Schema::new(vec![]);
+        let batch = RecordBatch::new_empty(Arc::new(schema));
+
+        let temp_dir = tempdir().unwrap();
+        let parquet_path = temp_dir.path().join("empty.parquet");
         StorageEngine::write_batch_to_apache_parquet_file(batch, parquet_path.as_path());
 
         assert!(parquet_path.exists());
@@ -536,22 +548,6 @@ mod tests {
 
         assert!(result.is_err());
         assert!(!parquet_path.exists());
-    }
-
-    #[test]
-    fn test_write_batch_to_existing_apache_parquet_file() {
-        let temp_dir = tempdir().unwrap();
-        let batch = test_util::get_compressed_segment_record_batch();
-
-        let parquet_path = temp_dir.path().join("test.parquet");
-        StorageEngine::write_batch_to_apache_parquet_file(batch.clone(), parquet_path.as_path());
-
-        // The file should just be truncated.
-        let result =
-            StorageEngine::write_batch_to_apache_parquet_file(batch, parquet_path.as_path());
-
-        assert!(result.is_ok());
-        assert!(parquet_path.exists());
     }
 
     #[test]

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -24,17 +24,14 @@ use std::sync::Arc;
 use std::{fmt, fs, mem};
 
 use datafusion::arrow::array::ArrayBuilder;
-use datafusion::arrow::datatypes::{ArrowPrimitiveType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::parquet::arrow::{ArrowReader, ParquetFileArrowReader, ProjectionMask};
 use datafusion::parquet::file::reader::{FileReader, SerializedFileReader};
 use tracing::info;
 
 use crate::storage::data_point::DataPoint;
-use crate::storage::{write_batch_to_apache_parquet, INITIAL_BUILDER_CAPACITY, StorageEngine};
-use crate::types::{
-    ArrowTimestamp, ArrowValue, Timestamp, TimestampArray, TimestampBuilder, Value, ValueBuilder,
-};
+use crate::storage::{INITIAL_BUILDER_CAPACITY, StorageEngine};
+use crate::types::{Timestamp, TimestampArray, TimestampBuilder, Value, ValueBuilder};
 
 /// Shared functionality between different types of uncompressed segments, such as segment builders
 /// and spilled segments.
@@ -147,7 +144,7 @@ impl SpilledSegment {
         let timestamps: &TimestampArray = batch.column(0).as_any().downcast_ref().unwrap();
         let path = format!("{}/{}.parquet", folder_path, timestamps.value(0));
 
-        write_batch_to_apache_parquet(batch, path.clone());
+        StorageEngine::write_batch_to_apache_parquet_file(batch, path.clone());
 
         Self { path }
     }

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -22,6 +22,7 @@ use std::fs::File;
 use std::io::ErrorKind::Other;
 use std::sync::Arc;
 use std::{fmt, fs, mem};
+use std::path::Path;
 
 use datafusion::arrow::array::ArrayBuilder;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -144,7 +145,7 @@ impl SpilledSegment {
         let timestamps: &TimestampArray = batch.column(0).as_any().downcast_ref().unwrap();
         let path = format!("{}/{}.parquet", folder_path, timestamps.value(0));
 
-        StorageEngine::write_batch_to_apache_parquet_file(batch, path.clone());
+        StorageEngine::write_batch_to_apache_parquet_file(batch, Path::new(&path.clone()));
 
         Self { path }
     }

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -18,7 +18,6 @@
 //! storing uncompressed data in Apache Parquet files.
 
 use std::fmt::Formatter;
-use std::fs::File;
 use std::io::ErrorKind::Other;
 use std::sync::Arc;
 use std::{fmt, fs, mem};
@@ -26,9 +25,7 @@ use std::path::Path;
 
 use datafusion::arrow::array::ArrayBuilder;
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::parquet::arrow::{ArrowReader, ParquetFileArrowReader, ProjectionMask};
 use datafusion::parquet::errors::ParquetError;
-use datafusion::parquet::file::reader::{FileReader, SerializedFileReader};
 use tracing::info;
 
 use crate::storage::data_point::DataPoint;

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -31,7 +31,7 @@ use datafusion::parquet::file::reader::{FileReader, SerializedFileReader};
 use tracing::info;
 
 use crate::storage::data_point::DataPoint;
-use crate::storage::{write_batch_to_apache_parquet, INITIAL_BUILDER_CAPACITY};
+use crate::storage::{write_batch_to_apache_parquet, INITIAL_BUILDER_CAPACITY, StorageEngine};
 use crate::types::{
     ArrowTimestamp, ArrowValue, Timestamp, TimestampArray, TimestampBuilder, Value, ValueBuilder,
 };
@@ -110,10 +110,7 @@ impl UncompressedSegment for SegmentBuilder {
         let timestamps = self.timestamps.finish();
         let values = self.values.finish();
 
-        let schema = Schema::new(vec![
-            Field::new("timestamps", ArrowTimestamp::DATA_TYPE, false),
-            Field::new("values", ArrowValue::DATA_TYPE, false),
-        ]);
+        let schema = StorageEngine::get_uncompressed_segment_schema();
 
         RecordBatch::try_new(
             Arc::new(schema),

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -17,6 +17,7 @@
 
 use std::fs;
 use std::io::ErrorKind::Other;
+use std::path::Path;
 use std::sync::Arc;
 
 use datafusion::arrow::record_batch::RecordBatch;
@@ -79,7 +80,7 @@ impl CompressedTimeSeries {
             let start_times: &TimestampArray = batch.column(2).as_any().downcast_ref().unwrap();
             let path = format!("{}/{}.parquet", folder_path, start_times.value(0));
 
-            StorageEngine::write_batch_to_apache_parquet_file(batch, path.clone());
+            StorageEngine::write_batch_to_apache_parquet_file(batch, Path::new(&path.clone()));
 
             Ok(())
         }

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 
-use crate::storage::write_batch_to_apache_parquet;
+use crate::storage::{StorageEngine, write_batch_to_apache_parquet};
 use crate::types::{ArrowTimestamp, ArrowValue, TimestampArray};
 
 /// A single compressed time series, containing one or more compressed segments and providing
@@ -47,7 +47,7 @@ impl CompressedTimeSeries {
         let segment_size = Self::get_size_of_segment(&segment);
 
         debug_assert!(
-            segment.schema() == Arc::new(Self::get_compressed_segment_schema()),
+            segment.schema() == Arc::new(StorageEngine::get_compressed_segment_schema()),
             "Schema of record batch does not match compressed segment schema."
         );
 
@@ -67,7 +67,7 @@ impl CompressedTimeSeries {
             ))
         } else {
             // Combine the segments into a single record batch.
-            let schema = Self::get_compressed_segment_schema();
+            let schema = StorageEngine::get_compressed_segment_schema();
             let batch = RecordBatch::concat(&Arc::new(schema), &*self.compressed_segments).unwrap();
 
             // TODO: "storage" should be replaced by a user-defined storage folder.
@@ -96,20 +96,6 @@ impl CompressedTimeSeries {
         }
 
         total_size
-    }
-
-    /// Return the record batch schema used for compressed segments.
-    fn get_compressed_segment_schema() -> Schema {
-        Schema::new(vec![
-            Field::new("model_type_id", DataType::UInt8, false),
-            Field::new("timestamps", DataType::Binary, false),
-            Field::new("start_time", ArrowTimestamp::DATA_TYPE, false),
-            Field::new("end_time", ArrowTimestamp::DATA_TYPE, false),
-            Field::new("values", DataType::Binary, false),
-            Field::new("min_value", ArrowValue::DATA_TYPE, false),
-            Field::new("max_value", ArrowValue::DATA_TYPE, false),
-            Field::new("error", DataType::Float32, false),
-        ])
     }
 }
 
@@ -178,6 +164,7 @@ pub mod test_util {
     use datafusion::arrow::datatypes::DataType::UInt8;
     use datafusion::arrow::datatypes::{Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
+    use crate::storage::StorageEngine;
 
     use crate::storage::time_series::CompressedTimeSeries;
     use crate::types::{TimestampArray, ValueArray};
@@ -204,7 +191,7 @@ pub mod test_util {
         let max_value = ValueArray::from(vec![20.2, 12.2, 34.2]);
         let error = Float32Array::from(vec![0.2, 0.5, 0.1]);
 
-        let schema = CompressedTimeSeries::get_compressed_segment_schema();
+        let schema = StorageEngine::get_compressed_segment_schema();
 
         RecordBatch::try_new(
             Arc::new(schema),

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -19,11 +19,10 @@ use std::fs;
 use std::io::ErrorKind::Other;
 use std::sync::Arc;
 
-use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 
-use crate::storage::{StorageEngine, write_batch_to_apache_parquet};
-use crate::types::{ArrowTimestamp, ArrowValue, TimestampArray};
+use crate::storage::StorageEngine;
+use crate::types::TimestampArray;
 
 /// A single compressed time series, containing one or more compressed segments and providing
 /// functionality for appending segments and saving all segments to a single Apache Parquet file.
@@ -80,7 +79,7 @@ impl CompressedTimeSeries {
             let start_times: &TimestampArray = batch.column(2).as_any().downcast_ref().unwrap();
             let path = format!("{}/{}.parquet", folder_path, start_times.value(0));
 
-            write_batch_to_apache_parquet(batch, path.clone());
+            StorageEngine::write_batch_to_apache_parquet_file(batch, path.clone());
 
             Ok(())
         }

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -1,4 +1,4 @@
-/* Copyright 2021 The MiniModelarDB Contributors
+/* Copyright 2021 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The MiniModelarDB Contributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Since reading from, writing to, and identifying Apache Parquet files is needed multiple places in the system, it was decided to add this functionality in the storage engine. This PR includes three new functions in the storage engine that allows interaction with Apache Parquet files. The functions are tested using the [tempfile](https://crates.io/crates/tempfile) crate that can create a temporary directory which is deleted once out of scope. 

The places in the storage engine and catalog that used their own versions of this Apache Parquet functionality has been replaced by the shared functionality. 

It should also be noted that two basic functions to retrieve the schemas used for uncompressed and compressed data has been added to the storage engine. 