### PR TITLE
Add compression of regular time series

### DIFF
--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -1,0 +1,423 @@
+/* Copyright 2022 The ModelarDB Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Compress time series
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{BinaryBuilder, Float32Builder, UInt8Array, UInt8Builder};
+use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+
+use crate::models;
+use crate::models::{gorilla::Gorilla, pmcmean::PMCMean, swing::Swing, ErrorBound};
+use crate::types::{
+    ArrowTimestamp, ArrowValue, Timestamp, TimestampArray, TimestampBuilder, Value, ValueArray,
+    ValueBuilder,
+};
+
+pub fn compress(error_bound: &ErrorBound, record_batch: &RecordBatch) -> RecordBatch {
+    // Extract the timestamps and values to compress.
+    let uncompressed_timestamps = record_batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<TimestampArray>()
+        .unwrap();
+    let uncompressed_values = record_batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<ValueArray>()
+        .unwrap();
+
+    // num_rows is allocated to not reallocate as one model is created per data
+    // point in the worst cast, however, usually significantly fewer is used.
+    let num_rows = record_batch.num_rows();
+    let mut compressed_record_batch_builder = CompressedRecordBatchBuilder::new(num_rows);
+
+    // Compress the timestamps and values.
+    let mut current_index = 0;
+
+    while current_index < num_rows {
+        let compressed_segment_builder = build_next_segment(
+            current_index,
+            num_rows,
+            error_bound,
+            &uncompressed_timestamps,
+            &uncompressed_values,
+        );
+
+        let compressed_segment_builder_length = compressed_segment_builder.length;
+
+        compressed_segment_builder.finish(
+            current_index,
+            &uncompressed_timestamps,
+            &uncompressed_values,
+            &mut compressed_record_batch_builder,
+        );
+        current_index += compressed_segment_builder_length;
+    }
+    compressed_record_batch_builder.finnish()
+}
+
+fn build_next_segment(
+    mut current_index: usize,
+    end_index: usize,
+    error_bound: &ErrorBound,
+    timestamps: &TimestampArray,
+    values: &ValueArray,
+) -> CompressedSegmentBuilder {
+    let mut compressed_segment_builder = CompressedSegmentBuilder::new(error_bound.clone());
+    while compressed_segment_builder.can_fit_more() && current_index < end_index {
+        let timestamp = timestamps.value(current_index);
+        let value = values.value(current_index);
+        compressed_segment_builder.fit_data_point(timestamp, value);
+        current_index += 1;
+    }
+    compressed_segment_builder
+}
+
+struct CompressedSegmentBuilder {
+    length: usize,
+    pmc_mean: PMCMean,
+    pmc_mean_has_fit_all: bool,
+    swing: Swing,
+    swing_has_fit_all: bool,
+    gorilla: Gorilla,
+    gorilla_maximum_length: usize, // TODO: remove temporary maximum length.
+}
+
+impl CompressedSegmentBuilder {
+    fn new(error_bound: ErrorBound) -> Self {
+        Self {
+            length: 0,
+            pmc_mean: PMCMean::new(error_bound),
+            pmc_mean_has_fit_all: true,
+            swing: Swing::new(error_bound),
+            swing_has_fit_all: true,
+            gorilla: Gorilla::new(),
+            gorilla_maximum_length: 50, // Temporary maximum length.
+        }
+    }
+
+    fn fit_data_point(&mut self, timestamp: Timestamp, value: Value) {
+        self.pmc_mean_has_fit_all = self.pmc_mean_has_fit_all && self.pmc_mean.fit_value(value);
+        self.swing_has_fit_all =
+            self.swing_has_fit_all && self.swing.fit_data_point(timestamp, value);
+        self.gorilla.compress_value(value); // Gorilla is lossless.
+        self.length += 1;
+    }
+
+    fn can_fit_more(&self) -> bool {
+        self.pmc_mean_has_fit_all
+            || self.swing_has_fit_all
+            || self.length < self.gorilla_maximum_length
+    }
+
+    fn finish(
+        self,
+        start_index: usize,
+        uncompressed_timestamps: &TimestampArray,
+        uncompressed_values: &ValueArray,
+        compressed_record_batch_builder: &mut CompressedRecordBatchBuilder,
+    ) {
+        let end_index = start_index + self.length;
+
+        // Timestamps
+        let start_time = uncompressed_timestamps.value(start_index);
+        let end_time = uncompressed_timestamps.value(end_index - 1);
+        let timestamps = &[]; // TODO: compress irregular timestamps.
+
+        // The model that uses the fewest number of bytes per value is stored.
+        let (model_type_id, min_value, max_value, values) = models::select_model(
+            self.pmc_mean,
+            self.swing,
+            self.gorilla,
+            &uncompressed_values.values()[start_index..end_index],
+        );
+
+        // TODO: compute and store the actual error.
+        let error = 10.0;
+
+        compressed_record_batch_builder.append_segment(
+            model_type_id,
+            timestamps,
+            start_time,
+            end_time,
+            &values,
+            min_value,
+            max_value,
+            error,
+        );
+    }
+}
+
+struct CompressedRecordBatchBuilder {
+    model_type_ids: UInt8Builder,
+    timestamps: BinaryBuilder,
+    start_times: TimestampBuilder,
+    end_times: TimestampBuilder,
+    values: BinaryBuilder,
+    min_values: ValueBuilder,
+    max_values: ValueBuilder,
+    error: Float32Builder,
+}
+
+impl CompressedRecordBatchBuilder {
+    fn new(capacity: usize) -> Self {
+        Self {
+            model_type_ids: UInt8Builder::new(capacity),
+            timestamps: BinaryBuilder::new(capacity),
+            start_times: TimestampBuilder::new(capacity),
+            end_times: TimestampBuilder::new(capacity),
+            values: BinaryBuilder::new(capacity),
+            min_values: ValueBuilder::new(capacity),
+            max_values: ValueBuilder::new(capacity),
+            error: Float32Builder::new(capacity),
+        }
+    }
+
+    fn append_segment(
+        &mut self,
+        model_type_id: u8,
+        timestamps: &[u8],
+        start_time: Timestamp,
+        end_time: Timestamp,
+        values: &[u8],
+        min_value: Value,
+        max_value: Value,
+        error: f32,
+    ) {
+        // unwrap() is used as append_value() never returns Error for
+        // PrimitiveBuilder.
+        self.model_type_ids.append_value(model_type_id).unwrap();
+        self.timestamps.append_value(timestamps).unwrap();
+        self.start_times.append_value(start_time).unwrap();
+        self.end_times.append_value(end_time).unwrap();
+        self.values.append_value(values).unwrap();
+        self.min_values.append_value(min_value).unwrap();
+        self.max_values.append_value(max_value).unwrap();
+        self.error.append_value(error).unwrap();
+    }
+
+    fn finnish(mut self) -> RecordBatch {
+        RecordBatch::try_new(
+            CompressedRecordBatchBuilder::get_compressed_segment_schema_ref(),
+            vec![
+                Arc::new(self.model_type_ids.finish()),
+                Arc::new(self.timestamps.finish()),
+                Arc::new(self.start_times.finish()),
+                Arc::new(self.end_times.finish()),
+                Arc::new(self.values.finish()),
+                Arc::new(self.min_values.finish()),
+                Arc::new(self.max_values.finish()),
+                Arc::new(self.error.finish()),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn get_compressed_segment_schema_ref() -> SchemaRef {
+        // TODO: share with time_series.rs when refactoring `StorageEngine`.
+        Arc::new(Schema::new(vec![
+            Field::new("model_type_id", DataType::UInt8, false),
+            Field::new("timestamps", DataType::Binary, false),
+            Field::new("start_time", ArrowTimestamp::DATA_TYPE, false),
+            Field::new("end_time", ArrowTimestamp::DATA_TYPE, false),
+            Field::new("values", DataType::Binary, false),
+            Field::new("min_value", ArrowValue::DATA_TYPE, false),
+            Field::new("max_value", ArrowValue::DATA_TYPE, false),
+            Field::new("error", DataType::Float32, false),
+        ]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::{collection, prop_assert, prop_assert_eq, prop_assume, proptest};
+
+    // Tests compress.
+    #[test]
+    fn test_compress_empty_time_series() {
+        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let uncompressed_data = create_uncompressed_record_batch(&[], &[]);
+        let compressed_data = compress(&error_bound, &uncompressed_data);
+        assert_eq!(0, compressed_data.num_rows())
+    }
+
+    #[test]
+    fn test_compress_regular_constant_time_series() {
+        let timestamps = Vec::from_iter((100..1000).step_by(100));
+        let values = vec![10.0; timestamps.len()];
+        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        assert_compressed_record_batch_with_segments_from_regular_time_series(
+            &uncompressed_record_batch,
+            &compressed_record_batch,
+            &[models::PMC_MEAN_ID],
+        )
+    }
+
+    #[test]
+    fn test_compress_regular_almost_constant_time_series() {
+        let timestamps = Vec::from_iter((100..1000).step_by(100));
+        let values = vec![10.1, 10.0, 10.2, 10.2, 10.0, 10.1, 10.0, 10.0, 10.0];
+        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+        let error_bound = ErrorBound::try_new(5.0).unwrap();
+        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        assert_compressed_record_batch_with_segments_from_regular_time_series(
+            &uncompressed_record_batch,
+            &compressed_record_batch,
+            &[models::PMC_MEAN_ID],
+        )
+    }
+
+    #[test]
+    fn test_compress_regular_linear_time_series() {
+        let timestamps = Vec::from_iter((100..1000).step_by(100));
+        let values = Vec::from_iter((10..100).step_by(10).map(|v| v as f32));
+        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        assert_compressed_record_batch_with_segments_from_regular_time_series(
+            &uncompressed_record_batch,
+            &compressed_record_batch,
+            &[models::SWING_ID],
+        )
+    }
+
+    #[test]
+    fn test_compress_regular_almost_linear_time_series() {
+        let timestamps = Vec::from_iter((100..1000).step_by(100));
+        let values = vec![10.0, 20.0, 30.1, 40.8, 51.0, 60.2, 70.1, 80.7, 90.4];
+        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+        let error_bound = ErrorBound::try_new(5.0).unwrap();
+        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        assert_compressed_record_batch_with_segments_from_regular_time_series(
+            &uncompressed_record_batch,
+            &compressed_record_batch,
+            &[models::SWING_ID],
+        )
+    }
+
+    #[test]
+    fn test_compress_regular_random_time_series() {
+        let timestamps = Vec::from_iter((100..1000).step_by(100));
+        let values = vec![7.47, 13.34, 14.50, 4.88, 7.84, 6.69, 8.63, 5.109, 2.16];
+        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        assert_compressed_record_batch_with_segments_from_regular_time_series(
+            &uncompressed_record_batch,
+            &compressed_record_batch,
+            &[models::GORILLA_ID],
+        )
+    }
+
+    #[test]
+    fn test_compress_regular_random_linear_constant_time_series() {
+        let mut constant = vec![10.0; 100];
+        let mut linear = Vec::from_iter((10..1000).step_by(10).map(|v| v as f32));
+        let mut random = vec![7.47, 13.34, 14.50, 4.88, 7.84, 6.69, 8.63, 5.109, 2.16];
+
+        let mut values = vec![];
+        values.append(&mut random);
+        values.append(&mut linear);
+        values.append(&mut constant);
+
+        // TODO: make all tests use an auto generated set of timestamps based on the length of values.
+        let timestamps = Vec::from_iter((100..(values.len() + 1) as i64 * 100).step_by(100));
+        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+
+        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        assert_compressed_record_batch_with_segments_from_regular_time_series(
+            &uncompressed_record_batch,
+            &compressed_record_batch,
+            &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
+        )
+    }
+
+    fn create_uncompressed_record_batch(timestamps: &[Timestamp], values: &[Value]) -> RecordBatch {
+        let schema = Schema::new(vec![
+            Field::new("timestamps", ArrowTimestamp::DATA_TYPE, false),
+            Field::new("values", ArrowValue::DATA_TYPE, false),
+        ]);
+
+        let mut timestamps_builder = TimestampBuilder::new(timestamps.len());
+        timestamps_builder.append_slice(timestamps).unwrap();
+        let mut values_builder = ValueBuilder::new(values.len());
+        values_builder.append_slice(values).unwrap();
+
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(timestamps_builder.finish()),
+                Arc::new(values_builder.finish()),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn assert_compressed_record_batch_with_segments_from_regular_time_series(
+        uncompressed_record_batch: &RecordBatch,
+        compressed_record_batch: &RecordBatch,
+        expected_model_type_ids: &[u8],
+    ) {
+        let uncompressed_timestamps = uncompressed_record_batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampArray>()
+            .unwrap();
+        let sampling_interval = uncompressed_timestamps.value(1) - uncompressed_timestamps.value(0);
+
+        assert_eq!(
+            expected_model_type_ids.len(),
+            compressed_record_batch.num_rows()
+        );
+
+        let mut total_compressed_length = 0;
+        for segment in 0..expected_model_type_ids.len() {
+            let expected_model_type_id = expected_model_type_ids[segment];
+            let model_type_id = compressed_record_batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .unwrap()
+                .value(segment);
+            assert_eq!(expected_model_type_id, model_type_id);
+
+            let start_time = compressed_record_batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<TimestampArray>()
+                .unwrap()
+                .value(segment);
+            let end_time = compressed_record_batch
+                .column(3)
+                .as_any()
+                .downcast_ref::<TimestampArray>()
+                .unwrap()
+                .value(segment);
+            total_compressed_length +=
+                models::length(start_time, end_time, sampling_interval as i32);
+        }
+        assert_eq!(
+            uncompressed_record_batch.num_rows(),
+            total_compressed_length
+        );
+    }
+}

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -13,144 +13,188 @@
  * limitations under the License.
  */
 
-//! Compress time series
+//! Compress `UncompressedSegment`s provided by `StorageEngine` using the model
+//! types in `models` to produce compressed segments which are returned to
+//! `StorageEngine`.
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::{BinaryBuilder, Float32Builder, UInt8Array, UInt8Builder};
-use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::array::{BinaryBuilder, Float32Builder, UInt8Builder};
 use datafusion::arrow::record_batch::RecordBatch;
 
+use crate::errors::ModelarDBError;
 use crate::models;
 use crate::models::{gorilla::Gorilla, pmcmean::PMCMean, swing::Swing, ErrorBound};
-use crate::types::{
-    ArrowTimestamp, ArrowValue, Timestamp, TimestampArray, TimestampBuilder, Value, ValueArray,
-    ValueBuilder,
-};
+use crate::storage::StorageEngine;
+use crate::types::{Timestamp, TimestampArray, TimestampBuilder, Value, ValueArray, ValueBuilder};
 
-pub fn compress(error_bound: &ErrorBound, record_batch: &RecordBatch) -> RecordBatch {
-    // Extract the timestamps and values to compress.
-    let uncompressed_timestamps = record_batch
-        .column(0)
-        .as_any()
-        .downcast_ref::<TimestampArray>()
-        .unwrap();
-    let uncompressed_values = record_batch
-        .column(1)
-        .as_any()
-        .downcast_ref::<ValueArray>()
-        .unwrap();
+// TODO: use Gorilla as a fallback to remove GORILLA_MAXIMUM_LENGTH.
+/// Maximum number of data points that models of type Gorilla can represent per
+/// compressed segment. As models of type Gorilla use lossless compression they
+/// will never exceed the user-defined error bounds.
+const GORILLA_MAXIMUM_LENGTH: u32 = 50; // TODO: use usize instead of u32 for lengths.
 
-    // num_rows is allocated to not reallocate as one model is created per data
-    // point in the worst cast, however, usually significantly fewer is used.
-    let num_rows = record_batch.num_rows();
-    let mut compressed_record_batch_builder = CompressedRecordBatchBuilder::new(num_rows);
-
-    // Compress the timestamps and values.
-    let mut current_index = 0;
-
-    while current_index < num_rows {
-        let compressed_segment_builder = build_next_segment(
-            current_index,
-            num_rows,
-            error_bound,
-            &uncompressed_timestamps,
-            &uncompressed_values,
-        );
-
-        let compressed_segment_builder_length = compressed_segment_builder.length;
-
-        compressed_segment_builder.finish(
-            current_index,
-            &uncompressed_timestamps,
-            &uncompressed_values,
-            &mut compressed_record_batch_builder,
-        );
-        current_index += compressed_segment_builder_length;
+// TODO: support irregular univariate time series.
+/// Compress the regular `uncompressed_timestamps` using a start time, end time,
+/// and a sampling interval, and `uncompressed_values` within `error_bound`
+/// using the model types in `models`. Returns `CompressionError` if
+/// `uncompressed_timestamps` and `uncompressed_values` have different lengths,
+/// otherwise the resulting compressed segments are returned as a `RecordBatch`
+/// with the schema provided by `get_compressed_segment_schema_ref()`.
+pub fn try_compress(
+    uncompressed_timestamps: &TimestampArray,
+    uncompressed_values: &ValueArray,
+    error_bound: ErrorBound,
+) -> Result<RecordBatch, ModelarDBError> {
+    // The uncompressed data must be passed as arrays instead of a RecordBatch
+    // as a TimestampArray and a ValueArray is the only supported input.
+    // However, as a result it is necessary to verify they have the same length.
+    if uncompressed_timestamps.len() != uncompressed_values.len() {
+        return Err(ModelarDBError::CompressionError(
+            "Uncompressed timestamps and uncompressed values have different lengths.".to_owned(),
+        ));
     }
-    compressed_record_batch_builder.finnish()
+
+    // num_data points is allocated to not reallocate as one model is created
+    // per data point in the worst cast, however, usually a lot fewer are used.
+    let num_data_points = uncompressed_timestamps.len();
+    let mut compressed_record_batch_builder = CompressedRecordBatchBuilder::new(num_data_points);
+
+    // Compress the uncompressed timestamps and uncompressed values.
+    let mut current_row = 0;
+    while current_row < num_data_points {
+        // Create a compressed segment that represents the timestamps and values
+        // from current_row to row_n within error_bound where row_n <= num_rows.
+        let compressed_segment_builder = create_next_compressed_segment(
+            current_row,
+            num_data_points,
+            &uncompressed_timestamps,
+            &uncompressed_values,
+            error_bound,
+        );
+        current_row += compressed_segment_builder.finish(&mut compressed_record_batch_builder);
+    }
+    Ok(compressed_record_batch_builder.finnish())
 }
 
-fn build_next_segment(
-    mut current_index: usize,
+/// Create a compressed segment that represents the regular timestamps in
+/// `uncompressed_timestamps` and the values in `uncompressed_values` from
+/// `start_index` to index_n within `error_bound` where index_n <= `end_index`.
+fn create_next_compressed_segment<'a>(
+    start_index: usize,
     end_index: usize,
-    error_bound: &ErrorBound,
-    timestamps: &TimestampArray,
-    values: &ValueArray,
-) -> CompressedSegmentBuilder {
-    let mut compressed_segment_builder = CompressedSegmentBuilder::new(error_bound.clone());
+    uncompressed_timestamps: &'a TimestampArray,
+    uncompressed_values: &'a ValueArray,
+    error_bound: ErrorBound,
+) -> CompressedSegmentBuilder<'a> {
+    let mut compressed_segment_builder =
+        CompressedSegmentBuilder::new(uncompressed_timestamps, uncompressed_values, error_bound);
+
+    let mut current_index = start_index;
     while compressed_segment_builder.can_fit_more() && current_index < end_index {
-        let timestamp = timestamps.value(current_index);
-        let value = values.value(current_index);
-        compressed_segment_builder.fit_data_point(timestamp, value);
+        let timestamp = uncompressed_timestamps.value(current_index);
+        let value = uncompressed_values.value(current_index);
+        compressed_segment_builder.try_to_update_models(timestamp, value);
         current_index += 1;
     }
     compressed_segment_builder
 }
 
-struct CompressedSegmentBuilder {
-    length: usize,
+/// A single compressed segment being build from an uncompressed segment using
+/// the model types in `models`.
+struct CompressedSegmentBuilder<'a> {
+    /// The regular timestamps of the uncompressed segment the compressed
+    /// segment is being build from.
+    uncompressed_timestamps: &'a TimestampArray,
+    /// The values of the uncompressed segment the compressed segment is being
+    /// build from.
+    uncompressed_values: &'a ValueArray,
+    /// Index of the first data point in `self.uncompressed_timestamps` and
+    /// `self.uncompressed_values` the compressed segment represents.
+    start_index: usize,
+    /// Constant function that represents the values in
+    /// `self.uncompressed_values` from `self.start_index` to `self.start_index`
+    /// + `self.pmc_mean.length`.
     pmc_mean: PMCMean,
+    /// Indicates if `self.pmc_mean` could represent all values in
+    /// `self.uncompressed_values` from `self.start_index` to `self.start_index`
+    /// + `self.length`.
     pmc_mean_has_fit_all: bool,
+    /// Linear function that represents the values in `self.uncompressed_values`
+    /// from `self.start_index` to `self.start_index` + `self.swing.length`.
     swing: Swing,
+    /// Indicates if `self.swing` could represent all data points in
+    /// `self.uncompressed_timestamps` and `self.uncompressed_values` from
+    /// `self.start_index` to `self.start_index` + `self.length`.
     swing_has_fit_all: bool,
+    /// Values in `self.uncompressed_values` from `self.start_index` to
+    /// `self.start_index` + `self.gorilla.length` compressed using lossless
+    /// compression.
     gorilla: Gorilla,
-    gorilla_maximum_length: usize, // TODO: remove temporary maximum length.
 }
 
-impl CompressedSegmentBuilder {
-    fn new(error_bound: ErrorBound) -> Self {
+impl<'a> CompressedSegmentBuilder<'a> {
+    fn new(
+        uncompressed_timestamps: &'a TimestampArray,
+        uncompressed_values: &'a ValueArray,
+        error_bound: ErrorBound,
+    ) -> Self {
         Self {
-            length: 0,
+            uncompressed_timestamps,
+            uncompressed_values,
+            start_index: 0,
             pmc_mean: PMCMean::new(error_bound),
             pmc_mean_has_fit_all: true,
             swing: Swing::new(error_bound),
             swing_has_fit_all: true,
             gorilla: Gorilla::new(),
-            gorilla_maximum_length: 50, // Temporary maximum length.
         }
     }
 
-    fn fit_data_point(&mut self, timestamp: Timestamp, value: Value) {
+    /// Attempt to update the current models to also represent the `value` of
+    /// the data point collected at `timestamp`.
+    fn try_to_update_models(&mut self, timestamp: Timestamp, value: Value) {
         self.pmc_mean_has_fit_all = self.pmc_mean_has_fit_all && self.pmc_mean.fit_value(value);
+
         self.swing_has_fit_all =
             self.swing_has_fit_all && self.swing.fit_data_point(timestamp, value);
-        self.gorilla.compress_value(value); // Gorilla is lossless.
-        self.length += 1;
+
+        // Gorilla uses lossless compression and cannot exceed the error bound.
+        if self.gorilla.length < GORILLA_MAXIMUM_LENGTH {
+            self.gorilla.compress_value(value);
+        }
     }
 
+    /// Return `true` if any of the current models can represent additional
+    /// values, otherwise `false`.
     fn can_fit_more(&self) -> bool {
         self.pmc_mean_has_fit_all
             || self.swing_has_fit_all
-            || self.length < self.gorilla_maximum_length
+            || self.gorilla.length < GORILLA_MAXIMUM_LENGTH
     }
 
-    fn finish(
-        self,
-        start_index: usize,
-        uncompressed_timestamps: &TimestampArray,
-        uncompressed_values: &ValueArray,
-        compressed_record_batch_builder: &mut CompressedRecordBatchBuilder,
-    ) {
-        let end_index = start_index + self.length;
-
-        // Timestamps
-        let start_time = uncompressed_timestamps.value(start_index);
-        let end_time = uncompressed_timestamps.value(end_index - 1);
-        let timestamps = &[]; // TODO: compress irregular timestamps.
-
-        // The model that uses the fewest number of bytes per value is stored.
-        let (model_type_id, min_value, max_value, values) = models::select_model(
+    /// Store the model that requires the smallest number of bits per value in
+    /// `compressed_record_batch_builder`. Returns the index of the value in
+    /// `uncompressed_values` the selected model could not represent.
+    fn finish(self, compressed_record_batch_builder: &mut CompressedRecordBatchBuilder) -> usize {
+        // The model that uses the fewest number of bytes per value is selected.
+        let (model_type_id, end_index, min_value, max_value, values) = models::select_model(
+            self.start_index,
             self.pmc_mean,
             self.swing,
             self.gorilla,
-            &uncompressed_values.values()[start_index..end_index],
+            self.uncompressed_values,
         );
 
-        // TODO: compute and store the actual error.
-        let error = 10.0;
+        // Timestamps
+        let start_time = self.uncompressed_timestamps.value(self.start_index);
+        let end_time = self.uncompressed_timestamps.value(end_index);
+        let timestamps = &[]; // TODO: compress irregular timestamps.
 
-        compressed_record_batch_builder.append_segment(
+        // TODO: compute and store the actual error.
+        let error = f32::NAN;
+
+        compressed_record_batch_builder.append_compressed_segment(
             model_type_id,
             timestamps,
             start_time,
@@ -160,17 +204,30 @@ impl CompressedSegmentBuilder {
             max_value,
             error,
         );
+        end_index + 1
     }
 }
 
+/// A batch of compressed segments being build.
 struct CompressedRecordBatchBuilder {
+    /// Model type ids of each compressed segment in the batch.
     model_type_ids: UInt8Builder,
+    /// Data required in addition to `start_times` and `end_times` to
+    /// reconstruct the timestamps of each compressed segment in the batch.
     timestamps: BinaryBuilder,
+    /// First timestamp of each compressed segment in the batch.
     start_times: TimestampBuilder,
+    /// Last timestamp of each compressed segment in the batch.
     end_times: TimestampBuilder,
+    /// Data required in addition to `min_value` and `max_value` to reconstruct
+    /// the values of each compressed segment in the batch within an error
+    /// bound.
     values: BinaryBuilder,
+    /// Minimum value of each compressed segment in the batch.
     min_values: ValueBuilder,
+    /// Maximum value of each compressed segment in the batch.
     max_values: ValueBuilder,
+    /// Actual error of each compressed segment in the batch.
     error: Float32Builder,
 }
 
@@ -188,7 +245,8 @@ impl CompressedRecordBatchBuilder {
         }
     }
 
-    fn append_segment(
+    /// Append a compressed segment to the builder.
+    fn append_compressed_segment(
         &mut self,
         model_type_id: u8,
         timestamps: &[u8],
@@ -211,9 +269,10 @@ impl CompressedRecordBatchBuilder {
         self.error.append_value(error).unwrap();
     }
 
+    /// Return `RecordBatch` of compressed segments and consume the builder.
     fn finnish(mut self) -> RecordBatch {
         RecordBatch::try_new(
-            CompressedRecordBatchBuilder::get_compressed_segment_schema_ref(),
+            Arc::new(StorageEngine::get_compressed_segment_schema()),
             vec![
                 Arc::new(self.model_type_ids.finish()),
                 Arc::new(self.timestamps.finish()),
@@ -227,45 +286,37 @@ impl CompressedRecordBatchBuilder {
         )
         .unwrap()
     }
-
-    fn get_compressed_segment_schema_ref() -> SchemaRef {
-        // TODO: share with time_series.rs when refactoring `StorageEngine`.
-        Arc::new(Schema::new(vec![
-            Field::new("model_type_id", DataType::UInt8, false),
-            Field::new("timestamps", DataType::Binary, false),
-            Field::new("start_time", ArrowTimestamp::DATA_TYPE, false),
-            Field::new("end_time", ArrowTimestamp::DATA_TYPE, false),
-            Field::new("values", DataType::Binary, false),
-            Field::new("min_value", ArrowValue::DATA_TYPE, false),
-            Field::new("max_value", ArrowValue::DATA_TYPE, false),
-            Field::new("error", DataType::Float32, false),
-        ]))
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::{collection, prop_assert, prop_assert_eq, prop_assume, proptest};
+    use datafusion::arrow::array::UInt8Array;
+    // TODO: add tests with random time series and where the selected model is
+    // not the longest.
 
     // Tests compress.
     #[test]
     fn test_compress_empty_time_series() {
         let error_bound = ErrorBound::try_new(0.0).unwrap();
-        let uncompressed_data = create_uncompressed_record_batch(&[], &[]);
-        let compressed_data = compress(&error_bound, &uncompressed_data);
-        assert_eq!(0, compressed_data.num_rows())
+        let (uncompressed_timestamps, uncompressed_values) =
+            create_uncompressed_time_series(&[], &[]);
+        let compressed_record_batch =
+            try_compress(&uncompressed_timestamps, &uncompressed_values, error_bound).unwrap();
+        assert_eq!(0, compressed_record_batch.num_rows())
     }
 
     #[test]
     fn test_compress_regular_constant_time_series() {
         let timestamps = Vec::from_iter((100..1000).step_by(100));
         let values = vec![10.0; timestamps.len()];
-        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+        let (uncompressed_timestamps, uncompressed_values) =
+            create_uncompressed_time_series(&timestamps, &values);
         let error_bound = ErrorBound::try_new(0.0).unwrap();
-        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        let compressed_record_batch =
+            try_compress(&uncompressed_timestamps, &uncompressed_values, error_bound).unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
-            &uncompressed_record_batch,
+            &uncompressed_timestamps,
             &compressed_record_batch,
             &[models::PMC_MEAN_ID],
         )
@@ -275,11 +326,13 @@ mod tests {
     fn test_compress_regular_almost_constant_time_series() {
         let timestamps = Vec::from_iter((100..1000).step_by(100));
         let values = vec![10.1, 10.0, 10.2, 10.2, 10.0, 10.1, 10.0, 10.0, 10.0];
-        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+        let (uncompressed_timestamps, uncompressed_values) =
+            create_uncompressed_time_series(&timestamps, &values);
         let error_bound = ErrorBound::try_new(5.0).unwrap();
-        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        let compressed_record_batch =
+            try_compress(&uncompressed_timestamps, &uncompressed_values, error_bound).unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
-            &uncompressed_record_batch,
+            &uncompressed_timestamps,
             &compressed_record_batch,
             &[models::PMC_MEAN_ID],
         )
@@ -289,11 +342,13 @@ mod tests {
     fn test_compress_regular_linear_time_series() {
         let timestamps = Vec::from_iter((100..1000).step_by(100));
         let values = Vec::from_iter((10..100).step_by(10).map(|v| v as f32));
-        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+        let (uncompressed_timestamps, uncompressed_values) =
+            create_uncompressed_time_series(&timestamps, &values);
         let error_bound = ErrorBound::try_new(0.0).unwrap();
-        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        let compressed_record_batch =
+            try_compress(&uncompressed_timestamps, &uncompressed_values, error_bound).unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
-            &uncompressed_record_batch,
+            &uncompressed_timestamps,
             &compressed_record_batch,
             &[models::SWING_ID],
         )
@@ -303,11 +358,13 @@ mod tests {
     fn test_compress_regular_almost_linear_time_series() {
         let timestamps = Vec::from_iter((100..1000).step_by(100));
         let values = vec![10.0, 20.0, 30.1, 40.8, 51.0, 60.2, 70.1, 80.7, 90.4];
-        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+        let (uncompressed_timestamps, uncompressed_values) =
+            create_uncompressed_time_series(&timestamps, &values);
         let error_bound = ErrorBound::try_new(5.0).unwrap();
-        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        let compressed_record_batch =
+            try_compress(&uncompressed_timestamps, &uncompressed_values, error_bound).unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
-            &uncompressed_record_batch,
+            &uncompressed_timestamps,
             &compressed_record_batch,
             &[models::SWING_ID],
         )
@@ -317,11 +374,13 @@ mod tests {
     fn test_compress_regular_random_time_series() {
         let timestamps = Vec::from_iter((100..1000).step_by(100));
         let values = vec![7.47, 13.34, 14.50, 4.88, 7.84, 6.69, 8.63, 5.109, 2.16];
-        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+        let (uncompressed_timestamps, uncompressed_values) =
+            create_uncompressed_time_series(&timestamps, &values);
         let error_bound = ErrorBound::try_new(0.0).unwrap();
-        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        let compressed_record_batch =
+            try_compress(&uncompressed_timestamps, &uncompressed_values, error_bound).unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
-            &uncompressed_record_batch,
+            &uncompressed_timestamps,
             &compressed_record_batch,
             &[models::GORILLA_ID],
         )
@@ -340,48 +399,35 @@ mod tests {
 
         // TODO: make all tests use an auto generated set of timestamps based on the length of values.
         let timestamps = Vec::from_iter((100..(values.len() + 1) as i64 * 100).step_by(100));
-        let uncompressed_record_batch = create_uncompressed_record_batch(&timestamps, &values);
+        let (uncompressed_timestamps, uncompressed_values) =
+            create_uncompressed_time_series(&timestamps, &values);
 
         let error_bound = ErrorBound::try_new(0.0).unwrap();
-        let compressed_record_batch = compress(&error_bound, &uncompressed_record_batch);
+        let compressed_record_batch =
+            try_compress(&uncompressed_timestamps, &uncompressed_values, error_bound).unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
-            &uncompressed_record_batch,
+            &uncompressed_timestamps,
             &compressed_record_batch,
             &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
         )
     }
 
-    fn create_uncompressed_record_batch(timestamps: &[Timestamp], values: &[Value]) -> RecordBatch {
-        let schema = Schema::new(vec![
-            Field::new("timestamps", ArrowTimestamp::DATA_TYPE, false),
-            Field::new("values", ArrowValue::DATA_TYPE, false),
-        ]);
-
+    fn create_uncompressed_time_series(
+        timestamps: &[Timestamp],
+        values: &[Value],
+    ) -> (TimestampArray, ValueArray) {
         let mut timestamps_builder = TimestampBuilder::new(timestamps.len());
         timestamps_builder.append_slice(timestamps).unwrap();
         let mut values_builder = ValueBuilder::new(values.len());
         values_builder.append_slice(values).unwrap();
-
-        RecordBatch::try_new(
-            Arc::new(schema),
-            vec![
-                Arc::new(timestamps_builder.finish()),
-                Arc::new(values_builder.finish()),
-            ],
-        )
-        .unwrap()
+        (timestamps_builder.finish(), values_builder.finish())
     }
 
     fn assert_compressed_record_batch_with_segments_from_regular_time_series(
-        uncompressed_record_batch: &RecordBatch,
+        uncompressed_timestamps: &TimestampArray,
         compressed_record_batch: &RecordBatch,
         expected_model_type_ids: &[u8],
     ) {
-        let uncompressed_timestamps = uncompressed_record_batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<TimestampArray>()
-            .unwrap();
         let sampling_interval = uncompressed_timestamps.value(1) - uncompressed_timestamps.value(0);
 
         assert_eq!(
@@ -415,9 +461,6 @@ mod tests {
             total_compressed_length +=
                 models::length(start_time, end_time, sampling_interval as i32);
         }
-        assert_eq!(
-            uncompressed_record_batch.num_rows(),
-            total_compressed_length
-        );
+        assert_eq!(uncompressed_timestamps.len(), total_compressed_length);
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -18,6 +18,7 @@
 //! system.
 
 mod catalog;
+mod compression;
 mod errors;
 mod ingestion;
 mod macros;

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -43,7 +43,7 @@ pub struct Gorilla {
     /// Values compressed using XOR and a variable length binary encoding.
     compressed_values: BitVecBuilder,
     /// The number of values stored in `compressed_values`.
-    pub length: u32, // TODO: use Gorilla as a fallback to remove pub.
+    pub length: usize, // TODO: use Gorilla as a fallback to remove pub.
 }
 
 impl Gorilla {
@@ -114,7 +114,7 @@ impl Gorilla {
 
     /// Return the number of values currently compressed using XOR and a
     /// variable length binary encoding.
-    pub fn get_length(&self) -> u32 {
+    pub fn get_length(&self) -> usize {
 	self.length
     }
 

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -43,7 +43,7 @@ pub struct Gorilla {
     /// Values compressed using XOR and a variable length binary encoding.
     compressed_values: BitVecBuilder,
     /// The number of values stored in `compressed_values`.
-    length: u32,
+    pub length: u32, // TODO: use Gorilla as a fallback to remove pub.
 }
 
 impl Gorilla {
@@ -110,6 +110,12 @@ impl Gorilla {
         }
         self.last_value = value;
         self.length += 1;
+    }
+
+    /// Return the number of values currently compressed using XOR and a
+    /// variable length binary encoding.
+    pub fn get_length(&self) -> u32 {
+	self.length
     }
 
     /// Return the number of bytes currently used per data point on average.

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -58,7 +58,7 @@ impl Gorilla {
     }
 
     /// Compress `value` using XOR and a variable length binary encoding and
-    /// append the compressed value to an internal buffer in `Gorilla`.
+    /// append the compressed value to an internal buffer in [`Gorilla`].
     pub fn compress_value(&mut self, value: Value) {
         let value_as_integer = value.to_bits();
         let last_value_as_integer = self.last_value.to_bits();
@@ -115,7 +115,7 @@ impl Gorilla {
     /// Return the number of values currently compressed using XOR and a
     /// variable length binary encoding.
     pub fn get_length(&self) -> usize {
-	self.length
+        self.length
     }
 
     /// Return the number of bytes currently used per data point on average.
@@ -248,14 +248,14 @@ fn decompress_values(
     }
 }
 
-/// Read one or multiple bits from a `[u8]`. `BitReader` is implemented based on
-/// [code published by Ilkka Rauta] dual-licensed under MIT and Apache2.
+/// Read one or multiple bits from a `[u8]`. [`BitReader`] is implemented based
+/// on [code published by Ilkka Rauta] dual-licensed under MIT and Apache2.
 ///
 /// [code published by Ilkka Rauta]: https://github.com/irauta/bitreader
 struct BitReader<'a> {
-    /// Next bit to read from `self.bytes`.
+    /// Next bit to read from `bytes`.
     next_bit: u64,
-    /// Bits packed into one or more `u8`s.
+    /// Bits packed into one or more [`u8s`](u8).
     bytes: &'a [u8],
 }
 
@@ -268,12 +268,12 @@ impl<'a> BitReader<'a> {
         }
     }
 
-    /// Read the next bit from the `BitReader`.
+    /// Read the next bit from the [`BitReader`].
     fn read_bit(&mut self) -> bool {
         self.read_bits(1) == 1
     }
 
-    /// Read the next `number_of_bits` bits from the `BitReader`.
+    /// Read the next `number_of_bits` bits from the [`BitReader`].
     fn read_bits(&mut self, number_of_bits: u8) -> u32 {
         let mut value: u64 = 0;
         let start_bit = self.next_bit;
@@ -290,13 +290,13 @@ impl<'a> BitReader<'a> {
     }
 }
 
-/// Append one or multiple bits to a `vec<u8>`.
+/// Append one or multiple bits to a [`Vec<u8>`].
 struct BitVecBuilder {
-    /// `u8` currently used for storing the bits.
+    /// [`u8`] currently used for storing the bits.
     current_byte: u8,
     /// Bits remaining in `current_byte`.
     remaining_bits: u8,
-    /// Bits packed into one or more `u8`s.
+    /// Bits packed into one or more [`u8s`](u8).
     bytes: Vec<u8>,
 }
 
@@ -309,17 +309,17 @@ impl BitVecBuilder {
         }
     }
 
-    /// Append a zero bit to the `BitVecBuilder`.
+    /// Append a zero bit to the [`BitVecBuilder`].
     fn append_a_zero_bit(&mut self) {
         self.append_bits(0, 1)
     }
 
-    /// Append a one bit to the `BitVecBuilder`.
+    /// Append a one bit to the [`BitVecBuilder`].
     fn append_a_one_bit(&mut self) {
         self.append_bits(1, 1)
     }
 
-    /// Append `number_of_bits` from `bits` to the `BitVecBuilder`.
+    /// Append `number_of_bits` from `bits` to the [`BitVecBuilder`].
     fn append_bits(&mut self, bits: u32, number_of_bits: u8) {
         let mut number_of_bits = number_of_bits;
 
@@ -344,8 +344,8 @@ impl BitVecBuilder {
         }
     }
 
-    /// Return `true` if no bits have been appended to the `BitVecBuilder`,
-    /// otherwise `false`.
+    /// Return [`true`] if no bits have been appended to the [`BitVecBuilder`],
+    /// otherwise [`false`].
     fn is_empty(&self) -> bool {
         self.bytes.is_empty()
     }
@@ -355,8 +355,8 @@ impl BitVecBuilder {
         self.bytes.len() + (self.remaining_bits != 8) as usize
     }
 
-    /// Consume the `BitVecBuilder` and return the appended bits packed into a
-    /// `Vec<u8>`.
+    /// Consume the [`BitVecBuilder`] and return the appended bits packed into a
+    /// [`Vec<u8>`].
     fn finish(mut self) -> Vec<u8> {
         if self.remaining_bits != 8 {
             self.bytes.push(self.current_byte);
@@ -568,49 +568,49 @@ mod tests {
 
     #[test]
     fn test_empty_bit_vec_builder_length() {
-        assert!(BitVecBuilder::new().length() == 0);
+        assert_eq!(BitVecBuilder::new().length(), 0);
     }
 
     #[test]
     fn test_one_one_bit_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         bit_vec_builder.append_a_one_bit();
-        assert!(bit_vec_builder.length() == 1);
+        assert_eq!(bit_vec_builder.length(), 1);
     }
 
     #[test]
     fn test_one_zero_bit_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         bit_vec_builder.append_a_zero_bit();
-        assert!(bit_vec_builder.length() == 1);
+        assert_eq!(bit_vec_builder.length(), 1);
     }
 
     #[test]
     fn test_eight_one_bits_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         (0..8).for_each(|_| bit_vec_builder.append_a_one_bit());
-        assert!(bit_vec_builder.length() == 1);
+        assert_eq!(bit_vec_builder.length(), 1);
     }
 
     #[test]
     fn test_eight_zero_bits_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         (0..8).for_each(|_| bit_vec_builder.append_a_zero_bit());
-        assert!(bit_vec_builder.length() == 1);
+        assert_eq!(bit_vec_builder.length(), 1);
     }
 
     #[test]
     fn test_nine_one_bits_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         (0..9).for_each(|_| bit_vec_builder.append_a_one_bit());
-        assert!(bit_vec_builder.length() == 2);
+        assert_eq!(bit_vec_builder.length(), 2);
     }
 
     #[test]
     fn test_nine_zero_bits_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         (0..9).for_each(|_| bit_vec_builder.append_a_zero_bit());
-        assert!(bit_vec_builder.length() == 2);
+        assert_eq!(bit_vec_builder.length(), 2);
     }
 
     // Tests combining BitReader and BitVecBuilder.

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -125,7 +125,6 @@ pub fn select_model(
     gorilla: Gorilla,
     uncompressed_values: &ValueArray,
 ) -> SelectedModel {
-    // TODO: include the metadata as it is amortized over the values.
     let bytes_per_value = [
         (PMC_MEAN_ID, pmc_mean.get_bytes_per_value()),
         (SWING_ID, swing.get_bytes_per_value()),
@@ -142,16 +141,16 @@ pub fn select_model(
     match model_type_id {
         PMC_MEAN_ID => {
             let value = pmc_mean.get_model();
-            let end_index = start_index + pmc_mean.get_length();
+            let end_index = start_index + pmc_mean.get_length() - 1;
             SelectedModel::new(PMC_MEAN_ID, end_index, value, value, vec![])
         }
         SWING_ID => {
             let (min_value, max_value) = swing.get_model();
-            let end_index = start_index + swing.get_length();
+            let end_index = start_index + swing.get_length() - 1;
             SelectedModel::new(SWING_ID, end_index, min_value, max_value, vec![])
         }
         GORILLA_ID => {
-            let end_index = start_index + gorilla.get_length();
+            let end_index = start_index + gorilla.get_length() - 1;
             let uncompressed_values = &uncompressed_values.values()[start_index..end_index];
             let min_value = uncompressed_values
                 .iter()

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -28,7 +28,7 @@ use crate::types::{
 
 /// The state the PMC-Mean model type needs while fitting a model to a time
 /// series segment.
-struct PMCMean {
+pub struct PMCMean {
     /// Maximum relative error for the value of each data point.
     error_bound: ErrorBound,
     /// Minimum value in the segment the current model is fitted to.
@@ -42,7 +42,7 @@ struct PMCMean {
 }
 
 impl PMCMean {
-    fn new(error_bound: ErrorBound) -> Self {
+    pub fn new(error_bound: ErrorBound) -> Self {
         Self {
             error_bound,
             min_value: Value::NAN,
@@ -55,7 +55,7 @@ impl PMCMean {
     /// Attempt to update the current model of type PMC-Mean to also represent
     /// `value`. Returns `true` if the model can also represent `value`,
     /// otherwise `false`.
-    fn fit_value(&mut self, value: Value) -> bool {
+    pub fn fit_value(&mut self, value: Value) -> bool {
         let next_min_value = Value::min(self.min_value, value);
         let next_max_value = Value::max(self.max_value, value);
         let next_sum_of_values = self.sum_of_values + value as f64;
@@ -74,9 +74,14 @@ impl PMCMean {
         }
     }
 
+    /// Return the number of bytes the current model uses per data point on average.
+    pub fn get_bytes_per_value(&self) -> f32 {
+        models::VALUE_SIZE_IN_BYTES as f32 / self.length as f32
+    }
+
     /// Return the current model. For a model of type PMC-Mean, its coefficient
     /// is the average value of the time series segment the model represents.
-    fn get_model(&self) -> Value {
+    pub fn get_model(&self) -> Value {
         (self.sum_of_values / self.length as f64) as Value
     }
 

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -74,7 +74,7 @@ impl PMCMean {
         }
     }
 
-    /// Return the number of values the model currently represented.
+    /// Return the number of values the model currently represents.
     pub fn get_length(&self) -> usize {
         self.length
     }

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -53,8 +53,8 @@ impl PMCMean {
     }
 
     /// Attempt to update the current model of type PMC-Mean to also represent
-    /// `value`. Returns `true` if the model can also represent `value`,
-    /// otherwise `false`.
+    /// `value`. Returns [`true`] if the model can also represent `value`,
+    /// otherwise [`false`].
     pub fn fit_value(&mut self, value: Value) -> bool {
         let next_min_value = Value::min(self.min_value, value);
         let next_max_value = Value::max(self.max_value, value);
@@ -74,14 +74,14 @@ impl PMCMean {
         }
     }
 
+    /// Return the number of values the model currently represented.
+    pub fn get_length(&self) -> usize {
+        self.length
+    }
+
     /// Return the number of bytes the current model uses per data point on average.
     pub fn get_bytes_per_value(&self) -> f32 {
         models::VALUE_SIZE_IN_BYTES as f32 / self.length as f32
-    }
-
-    /// Return the number of values the model currently represented.
-    pub fn get_length(&self) -> usize {
-	self.length
     }
 
     /// Return the current model. For a model of type PMC-Mean, its coefficient
@@ -90,8 +90,8 @@ impl PMCMean {
         (self.sum_of_values / self.length as f64) as Value
     }
 
-    /// Determine if `approximate_value` is within `PMCMean`'s relative error
-    /// bound of `real_value`.
+    /// Determine if `approximate_value` is within [`PMCMean's`](PMCMean)
+    /// relative error bound of `real_value`.
     fn is_value_within_error_bound(&self, real_value: Value, approximate_value: Value) -> bool {
         // Needed because result becomes NAN and approximate_value is rejected
         // if approximate_value and real_value are zero, and because NAN != NAN.

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -79,6 +79,11 @@ impl PMCMean {
         models::VALUE_SIZE_IN_BYTES as f32 / self.length as f32
     }
 
+    /// Return the number of values the model currently represented.
+    pub fn get_length(&self) -> u32 {
+	self.length
+    }
+
     /// Return the current model. For a model of type PMC-Mean, its coefficient
     /// is the average value of the time series segment the model represents.
     pub fn get_model(&self) -> Value {

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -38,7 +38,7 @@ pub struct PMCMean {
     /// The sum of the values in the segment the current model is fitted to.
     sum_of_values: f64,
     /// The number of data points the current model has been fitted to.
-    length: u32,
+    length: usize,
 }
 
 impl PMCMean {
@@ -80,7 +80,7 @@ impl PMCMean {
     }
 
     /// Return the number of values the model currently represented.
-    pub fn get_length(&self) -> u32 {
+    pub fn get_length(&self) -> usize {
 	self.length
     }
 

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -17,8 +17,8 @@
 //! efficient computation of aggregates for models of type Swing as described in
 //! the [ModelarDB paper].
 //!
-//! In the implementation of Swing, `f64` is generally used instead of
-//! `crate::types::Value` to make the calculations precise enough.
+//! In the implementation of Swing, [`f64`] is generally used instead of
+//! [`Value`] to make the calculations precise enough.
 //!
 //! [Swing and Slide paper]: https://dl.acm.org/doi/10.14778/1687627.1687645
 //! [ModelarDB paper]: https://dl.acm.org/doi/abs/10.14778/3236187.3236215
@@ -74,8 +74,8 @@ impl Swing {
     }
 
     /// Attempt to update the current model of type Swing to also represent the
-    /// data point (`timestamp`, `value`). Returns `true` if the model can also
-    /// represent the data point, otherwise `false`.
+    /// data point (`timestamp`, `value`). Returns [`true`] if the model can
+    /// also represent the data point, otherwise [`false`].
     ///
     /// Swing fits a linear function to a time series segment in three stages:
     /// - (1) When the first data point is received, it is stored in memory.
@@ -193,7 +193,7 @@ impl Swing {
     /// values of the time series segment the model represents are returned. The
     /// two values are returned instead of the slope and intercept as the values
     /// only require `size_of::<Value>` while the slope and intercept generally
-    /// must be `f64` to be precise enough.
+    /// must be [`f64`] to be precise enough.
     pub fn get_model(&self) -> (Value, Value) {
         // TODO: Use the method in the Slide and Swing paper to select the
         // linear function within the lower and upper that minimizes error
@@ -318,9 +318,10 @@ fn compute_slope_and_intercept(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::tests::ProptestValue;
     use proptest::strategy::Strategy;
     use proptest::{num, prop_assert, prop_assert_eq, prop_assume, proptest};
+
+    use crate::types::tests::ProptestValue;
 
     // Tests constants chosen to be realistic while minimizing the testing time.
     const SAMPLING_INTERVAL: Timestamp = 1000;

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -55,7 +55,7 @@ pub struct Swing {
     /// current model.
     lower_bound_intercept: f64,
     /// The number of data points the current model has been fitted to.
-    length: u32,
+    length: usize,
 }
 
 impl Swing {
@@ -180,7 +180,7 @@ impl Swing {
     }
 
     /// Return the number of values the model currently represented.
-    pub fn get_length(&self) -> u32 {
+    pub fn get_length(&self) -> usize {
 	self.length
     }
 

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -179,6 +179,11 @@ impl Swing {
         }
     }
 
+    /// Return the number of values the model currently represented.
+    pub fn get_length(&self) -> u32 {
+	self.length
+    }
+
     /// Return the number of bytes the current model uses per data point on average.
     pub fn get_bytes_per_value(&self) -> f32 {
         (2.0 * models::VALUE_SIZE_IN_BYTES as f32) / self.length as f32

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -179,9 +179,9 @@ impl Swing {
         }
     }
 
-    /// Return the number of values the model currently represented.
+    /// Return the number of values the model currently represents.
     pub fn get_length(&self) -> usize {
-	self.length
+        self.length
     }
 
     /// Return the number of bytes the current model uses per data point on average.

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -31,7 +31,7 @@ use crate::types::{
 
 /// The state the Swing model type needs while fitting a model to a time series
 /// segment.
-struct Swing {
+pub struct Swing {
     /// Maximum relative error for the value of each data point.
     error_bound: ErrorBound,
     /// Time at which the first value represented by the current model was
@@ -59,7 +59,7 @@ struct Swing {
 }
 
 impl Swing {
-    fn new(error_bound: ErrorBound) -> Self {
+    pub fn new(error_bound: ErrorBound) -> Self {
         Self {
             error_bound,
             first_timestamp: 0,
@@ -89,7 +89,7 @@ impl Swing {
     /// For more detail see Algorithm 1 in the [Swing and Slide paper].
     ///
     /// [Swing and Slide paper]: https://dl.acm.org/doi/10.14778/1687627.1687645
-    fn fit_data_point(&mut self, timestamp: Timestamp, value: Value) -> bool {
+    pub fn fit_data_point(&mut self, timestamp: Timestamp, value: Value) -> bool {
         // Simplify the calculations by removing a significant number of casts.
         let value = value as f64;
         let error_bound = self.error_bound.0 as f64;
@@ -179,12 +179,17 @@ impl Swing {
         }
     }
 
+    /// Return the number of bytes the current model uses per data point on average.
+    pub fn get_bytes_per_value(&self) -> f32 {
+        (2.0 * models::VALUE_SIZE_IN_BYTES as f32) / self.length as f32
+    }
+
     /// Return the current model. For a model of type Swing, the first and last
     /// values of the time series segment the model represents are returned. The
     /// two values are returned instead of the slope and intercept as the values
     /// only require `size_of::<Value>` while the slope and intercept generally
     /// must be `f64` to be precise enough.
-    fn get_model(&self) -> (Value, Value) {
+    pub fn get_model(&self) -> (Value, Value) {
         // TODO: Use the method in the Slide and Swing paper to select the
         // linear function within the lower and upper that minimizes error
         let first_value =


### PR DESCRIPTION
This PR adds support for compressing univariate time series with regular timestamps (i.e., the data points are collected at a constant sampling interval). Support for compressing irregular time series and merging of similar models is planned but will be added through separate PRs to keep them at a manageable size. The compression is split across the new `compression` module and the `models` module. The `compression` module drives the compression by splitting the time series into dynamically sized segments, while the `models` module encodes the values and  selects the most efficient model for a dynamically sized segment.