### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "arrow"
-version = "18.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f89d2bc04fa746ee395d20c4cbfa508e4cce5c00bae816f0fae434fcfb9853"
+checksum = "c72a69495f06c8abb65b76a87be192a26fa724380d1f292d4e558a32afed9989"
 dependencies = [
  "ahash",
  "bitflags",
@@ -90,8 +90,8 @@ dependencies = [
  "lexical-core",
  "multiversion",
  "num",
- "rand",
  "regex",
+ "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "18.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30421ea30c815daae635003d8a40875922a627d55bc098a581ab215f7b7f5d35"
+checksum = "167aace6e264593bd25099bd8c089db6eb4dfc6fff7979523de062531d0f4336"
 dependencies = [
  "arrow",
  "base64",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54617e523e447c9a139fdf3682eeca8f909934bd28cdd0032ebd0ff9783775e1"
+checksum = "430b3983c7164cb113f297f45b68a69893c212cb4b80a8aeb6a8069eb93f745e"
 dependencies = [
  "ahash",
  "arrow",
@@ -508,22 +508,23 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794ca54d3b144038c36b7a31d64c9545abb2edbdda6da055e481fb8a13e4e33b"
+checksum = "594210b4819cc786d1a3dc7b17ff4f9b0c6ee522bcd0a4a52f80a41fd38d53c4"
 dependencies = [
  "arrow",
  "object_store",
  "ordered-float 3.0.0",
  "parquet",
+ "serde_json",
  "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0087a4e55a861c7040314f217672259304fd26b5f174a065867df6b4ac659896"
+checksum = "b91d4a86776ce8f7fe5df34955481d6fe77876dd278bf13098d6a1bdd3c24fb8"
 dependencies = [
  "ahash",
  "arrow",
@@ -533,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b822b1a9f4f9c953b142190229085e2856fa9ee52844aa86b40d55edd6e7cc38"
+checksum = "360f86f7dc943ca8e0da39982febac0a0fc0329d7ee58ea046438c9fed6dfec8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -549,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2328a0e901a89c46391be9445e6e55b6dd8002d4d177e578b0c4a2486ef07cda"
+checksum = "a465299f2eeb2741b33777b42f607fe56458e137d0d7b80f69be72e771a48b81"
 dependencies = [
  "ahash",
  "arrow",
@@ -574,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-row"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6b51e6398ed6dcc5e072c16722b9838f472b0c0ffe25b5df536927cda6044f"
+checksum = "959a42a1f35c8fa1b47698df6995ab5ae8477e81c9c42852476666aeac4f80b7"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -586,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9ae561d6c3dcd09d253ff28f71396b576fca05fe4d0f4fb0e75ee2fc951c72"
+checksum = "c69404e8774fe2c7d64998e94d856f32d3a908f9dc7215ce01e09895f13b4b62"
 dependencies = [
  "ahash",
  "arrow",
@@ -771,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -786,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -796,15 +797,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -813,15 +814,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -830,15 +831,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
 
 [[package]]
 name = "futures-timer"
@@ -848,9 +849,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1259,6 +1260,7 @@ dependencies = [
  "arrow-flight",
  "async-trait",
  "datafusion",
+ "datafusion-expr",
  "datafusion-physical-expr",
  "futures",
  "log",
@@ -1441,15 +1443,16 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857af043f5d9f36ed4f71815857f79b841412dda1cf0ca5a29608874f6f038e2"
+checksum = "cf3845781c5ecf37b3e3610df73fff11487591eba423a987e1b21bb4d389c326"
 dependencies = [
  "async-trait",
  "bytes",
  "chrono",
  "futures",
  "itertools",
+ "parking_lot",
  "percent-encoding",
  "snafu",
  "tokio",
@@ -1532,10 +1535,11 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "18.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f61759af307fad711e7656c705218402a8a79b776c893c20fef96e8ffd2a7d"
+checksum = "d0f0af698fcf8d1d9f2971766ebef25821ffe8c39c91837c276dcd97e075d950"
 dependencies = [
+ "ahash",
  "arrow",
  "base64",
  "brotli",
@@ -1544,11 +1548,13 @@ dependencies = [
  "chrono",
  "flate2",
  "futures",
+ "hashbrown",
  "lz4",
  "num",
  "num-bigint",
  "parquet-format",
  "rand",
+ "seq-macro",
  "snap",
  "thrift",
  "tokio",
@@ -1665,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1675,13 +1681,11 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.10.4"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
 dependencies = [
  "bytes",
- "cfg-if",
- "cmake",
  "heck",
  "itertools",
  "lazy_static",
@@ -1697,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1710,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
  "bytes",
  "prost",
@@ -1917,6 +1921,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
+
+[[package]]
 name = "serde"
 version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "indexmap",
  "itoa 1.0.2",
@@ -2035,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f531637a13132fa3d38c54d4cd8f115905e5dc3e72f6e77bd6160481f482e25d"
+checksum = "30c67d4d5de027da1da5a4ed4623f09ab5131d808364279a5f5abee5de9b8db3"
 dependencies = [
  "log",
 ]
@@ -2178,9 +2188,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2244,9 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
+checksum = "498f271adc46acce75d66f639e4d35b31b2394c295c82496727dafa16d465dd2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2276,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9263bf4c9bfaae7317c1c2faf7f18491d2fe476f70c414b73bf5d445b00ffa1"
+checksum = "2fbcd2800e34e743b9ae795867d5f77b535d3a3be69fd731e39145719752df8c"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2340,9 +2350,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "log",
@@ -2364,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
  "valuable",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-arrow = "18.0.0"
-arrow-flight = "18.0.0"
-tonic = "0.7.2"
-tokio = "1.20.0"
+arrow = "20.0.0"
+arrow-flight = "20.0.0"
+tonic = "0.8.0"
+tokio = "1.20.1"
 rustyline = "10.0.0"
 dirs = "4.0.0"
 
 # Enable default features for serde_json as it cannot compile without std
-serde_json = { version = "1.0.64", features = ["preserve_order"] }
+serde_json = { version = "1.0.83", features = ["preserve_order"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,28 +6,29 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-datafusion = "10.0.0"
-datafusion-physical-expr = "10.0.0"
-object_store = "0.3.0"
+datafusion = "11.0.0"
+datafusion-expr = "11.0.0"
+datafusion-physical-expr = "11.0.0"
+object_store = "0.4.0"
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same value
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }
-tracing = { version = "0.1.35", features = ["max_level_debug", "release_max_level_info"] }
+tracing = { version = "0.1.36", features = ["max_level_debug", "release_max_level_info"] }
 tracing-subscriber = "0.3.15"
 tracing-futures = "0.2.5"
 
-tokio = { version = "1.20.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.20.1", features = ["rt-multi-thread"] }
 
-async-trait = "0.1.56"
-futures = "0.3.21"
+async-trait = "0.1.57"
+futures = "0.3.23"
 
-arrow-flight = "18.0.0"
-tonic = "0.7.2"
+arrow-flight = "20.0.0"
+tonic = "0.8.0"
 
 snmalloc-rs = "0.3.3"
 
-paho-mqtt = { version = "0.11", default-features = false, features = ["bundled"] }
+paho-mqtt = { version = "0.11.1", default-features = false, features = ["bundled"] }
 
 [dev-dependencies]
 proptest = "1.0.0"
-tempfile = "3"
+tempfile = "3.3.0"

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -164,8 +164,8 @@ impl Catalog {
             let table_folder = read_dir(&path);
             table_folder.is_ok()
                 && table_folder.unwrap().all(|result| {
-                    result.is_ok() &&
-                        StorageEngine::is_path_an_apache_parquet_file(&result.unwrap().path())
+                    result.is_ok()
+                        && StorageEngine::is_path_an_apache_parquet_file(&result.unwrap().path())
                 })
         } else {
             false
@@ -194,8 +194,8 @@ impl Catalog {
                 && StorageEngine::is_path_an_apache_parquet_file(time_series)
                 && segment_folder.is_ok()
                 && segment_folder.unwrap().all(|result| {
-                    result.is_ok() &&
-                        StorageEngine::is_path_an_apache_parquet_file(&result.unwrap().path())
+                    result.is_ok()
+                        && StorageEngine::is_path_an_apache_parquet_file(&result.unwrap().path())
                 })
         } else {
             false
@@ -345,8 +345,8 @@ impl ModelTableMetadata {
         // lookup. Time series ids starting at 1 is used for compatibility with
         // the JVM-based version of ModelarDB.
         let mut shifted_column = Int32Builder::new(column.len() + 1);
-        shifted_column.append_value(-1)?;
-        shifted_column.append_slice(column)?;
+        shifted_column.append_value(-1);
+        shifted_column.append_slice(column);
         Ok(shifted_column.finish())
     }
 
@@ -384,12 +384,12 @@ impl ModelTableMetadata {
         // The level's name is at index 0 as ids from 1 is used for lookup.
         let mut shifted_column =
             StringBuilder::with_capacity(column.len(), column.get_buffer_memory_size());
-        shifted_column.append_value(name)?;
+        shifted_column.append_value(name);
         for maybe_member_as_bytes in column {
             let member_as_bytes = maybe_member_as_bytes
                 .ok_or_else(|| ParquetError::ArrowError(error_message.to_owned()))?;
             let member_as_str = str::from_utf8(member_as_bytes)?;
-            shifted_column.append_value(member_as_str)?;
+            shifted_column.append_value(member_as_str);
         }
         Ok(Arc::new(shifted_column.finish()))
     }

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -258,16 +258,14 @@ impl CompressedSegmentBatchBuilder {
         max_value: Value,
         error: f32,
     ) {
-        // unwrap() is used as append_value() never returns Error for
-        // PrimitiveBuilder.
-        self.model_type_ids.append_value(model_type_id).unwrap();
-        self.timestamps.append_value(timestamps).unwrap();
-        self.start_times.append_value(start_time).unwrap();
-        self.end_times.append_value(end_time).unwrap();
-        self.values.append_value(values).unwrap();
-        self.min_values.append_value(min_value).unwrap();
-        self.max_values.append_value(max_value).unwrap();
-        self.error.append_value(error).unwrap();
+        self.model_type_ids.append_value(model_type_id);
+        self.timestamps.append_value(timestamps);
+        self.start_times.append_value(start_time);
+        self.end_times.append_value(end_time);
+        self.values.append_value(values);
+        self.min_values.append_value(min_value);
+        self.max_values.append_value(max_value);
+        self.error.append_value(error);
     }
 
     /// Return [`RecordBatch`] of compressed segments and consume the builder.
@@ -421,9 +419,9 @@ mod tests {
         values: &[Value],
     ) -> (TimestampArray, ValueArray) {
         let mut timestamps_builder = TimestampBuilder::new(timestamps.len());
-        timestamps_builder.append_slice(timestamps).unwrap();
+        timestamps_builder.append_slice(timestamps);
         let mut values_builder = ValueBuilder::new(values.len());
-        values_builder.append_slice(values).unwrap();
+        values_builder.append_slice(values);
         (timestamps_builder.finish(), values_builder.finish())
     }
 

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -184,8 +184,8 @@ pub fn grid(
     values: &mut ValueBuilder,
 ) {
     for timestamp in (start_time..=end_time).step_by(sampling_interval as usize) {
-        time_series_ids.append_value(time_series_id).unwrap();
-        timestamps.append_value(timestamp).unwrap();
+        time_series_ids.append_value(time_series_id);
+        timestamps.append_value(timestamp);
     }
     decompress_values(start_time, end_time, sampling_interval, model, values);
 }
@@ -225,7 +225,7 @@ fn decompress_values(
     let mut last_value = bits.read_bits(models::VALUE_SIZE_IN_BITS);
 
     // The first value is stored uncompressed using size_of::<Value> bits.
-    values.append_value(Value::from_bits(last_value)).unwrap();
+    values.append_value(Value::from_bits(last_value));
 
     // Then values are stored using XOR and a variable length binary encoding.
     let length_without_first_value = models::length(start_time, end_time, sampling_interval) - 1;
@@ -244,7 +244,7 @@ fn decompress_values(
             value ^= last_value;
             last_value = value;
         }
-        values.append_value(Value::from_bits(last_value)).unwrap();
+        values.append_value(Value::from_bits(last_value));
     }
 }
 

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -146,9 +146,9 @@ pub fn grid(
     let value = decode_model(model);
     let sampling_interval = sampling_interval as usize;
     for timestamp in (start_time..=end_time).step_by(sampling_interval) {
-        time_series_ids.append_value(time_series_id).unwrap();
-        timestamps.append_value(timestamp).unwrap();
-        values.append_value(value).unwrap();
+        time_series_ids.append_value(time_series_id);
+        timestamps.append_value(timestamp);
+        values.append_value(value);
     }
 }
 

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -264,10 +264,10 @@ pub fn grid(
     let (slope, intercept) = decode_model(model);
     let sampling_interval = sampling_interval as usize;
     for timestamp in (start_time..=end_time).step_by(sampling_interval) {
-        time_series_ids.append_value(time_series_id).unwrap();
-        timestamps.append_value(timestamp).unwrap();
+        time_series_ids.append_value(time_series_id);
+        timestamps.append_value(timestamp);
         let value = (slope * timestamp as f64 + intercept) as Value;
-        values.append_value(value).unwrap();
+        values.append_value(value);
     }
 }
 

--- a/server/src/optimizer/mod.rs
+++ b/server/src/optimizer/mod.rs
@@ -35,7 +35,7 @@ impl OptimizerRule for LogOptimizerRule {
     fn optimize(
         &self,
         logical_plan: &LogicalPlan,
-        _execution_props: &OptimizerConfig,
+        _execution_props: &mut OptimizerConfig,
     ) -> Result<LogicalPlan> {
         debug!("Logical plan:\n{:#?}\n", &logical_plan);
         Ok(logical_plan.clone())

--- a/server/src/optimizer/model_simple_aggregates.rs
+++ b/server/src/optimizer/model_simple_aggregates.rs
@@ -39,6 +39,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::{Accumulator, AggregateExpr, PhysicalExpr};
 use datafusion::prelude::SessionConfig;
 use datafusion::scalar::ScalarValue;
+use datafusion_expr::AggregateState;
 
 // Helper Functions.
 fn new_aggregate(
@@ -303,9 +304,9 @@ impl PhysicalExpr for ModelCountPhysicalExpr {
             &self.model_table_metadata.sampling_intervals,
         ) as u64;
 
-        //If a ScalarValue is returned an array is filled with the value it contains
+        // Returning an AggregateState::Scalar fills an array with the value.
         let mut result = UInt64Array::builder(1);
-        result.append_value(count).unwrap();
+        result.append_value(count);
         Ok(ColumnarValue::Array(Arc::new(result.finish())))
     }
 }
@@ -331,8 +332,8 @@ impl Accumulator for ModelCountAccumulator {
         unreachable!()
     }
 
-    fn state(&self) -> Result<Vec<ScalarValue>> {
-        Ok(vec![ScalarValue::UInt64(Some(self.count))])
+    fn state(&self) -> Result<Vec<AggregateState>> {
+        Ok(vec![AggregateState::Scalar(ScalarValue::UInt64(Some(self.count)))])
     }
 
     fn evaluate(&self) -> Result<ScalarValue> {
@@ -395,9 +396,9 @@ impl PhysicalExpr for ModelMinPhysicalExpr {
             );
         }
 
-        //If a ScalarValue is returned an array is filled with the value it contains
+        // Returning an AggregateState::Scalar fills an array with the value.
         let mut result = Float32Array::builder(1);
-        result.append_value(min).unwrap();
+        result.append_value(min);
         Ok(ColumnarValue::Array(Arc::new(result.finish())))
     }
 }
@@ -426,8 +427,8 @@ impl Accumulator for ModelMinAccumulator {
         unreachable!()
     }
 
-    fn state(&self) -> Result<Vec<ScalarValue>> {
-        Ok(vec![ScalarValue::Float32(Some(self.min))])
+    fn state(&self) -> Result<Vec<AggregateState>> {
+        Ok(vec![AggregateState::Scalar(ScalarValue::Float32(Some(self.min)))])
     }
 
     fn evaluate(&self) -> Result<ScalarValue> {
@@ -490,9 +491,9 @@ impl PhysicalExpr for ModelMaxPhysicalExpr {
             );
         }
 
-        //If a ScalarValue is returned an array is filled with the value it contains
+        // Returning an AggregateState::Scalar fills an array with the value.
         let mut result = Float32Array::builder(1);
-        result.append_value(max).unwrap();
+        result.append_value(max);
         Ok(ColumnarValue::Array(Arc::new(result.finish())))
     }
 }
@@ -521,8 +522,8 @@ impl Accumulator for ModelMaxAccumulator {
         unreachable!()
     }
 
-    fn state(&self) -> Result<Vec<ScalarValue>> {
-        Ok(vec![ScalarValue::Float32(Some(self.max))])
+    fn state(&self) -> Result<Vec<AggregateState>> {
+        Ok(vec![AggregateState::Scalar(ScalarValue::Float32(Some(self.max)))])
     }
 
     fn evaluate(&self) -> Result<ScalarValue> {
@@ -582,9 +583,9 @@ impl PhysicalExpr for ModelSumPhysicalExpr {
             );
         }
 
-        //If a ScalarValue is returned an array is filled with the value it contains
+        // Returning an AggregateState::Scalar fills an array with the value.
         let mut result = Float32Array::builder(1);
-        result.append_value(sum as f32).unwrap();
+        result.append_value(sum as f32);
         Ok(ColumnarValue::Array(Arc::new(result.finish())))
     }
 }
@@ -610,8 +611,8 @@ impl Accumulator for ModelSumAccumulator {
         unreachable!()
     }
 
-    fn state(&self) -> Result<Vec<ScalarValue>> {
-        Ok(vec![ScalarValue::Float32(Some(self.sum))])
+    fn state(&self) -> Result<Vec<AggregateState>> {
+        Ok(vec![AggregateState::Scalar(ScalarValue::Float32(Some(self.sum)))])
     }
 
     fn evaluate(&self) -> Result<ScalarValue> {
@@ -673,10 +674,10 @@ impl PhysicalExpr for ModelAvgPhysicalExpr {
             count += (((end_time - start_time) / sampling_interval as i64) + 1) as u64;
         }
 
-        //If a ScalarValue is returned an array is filled with the value it contains
+        // Returning an AggregateState::Scalar fills an array with the value.
         let mut result = Float32Array::builder(2);
-        result.append_value(sum as f32).unwrap();
-        result.append_value(count as f32).unwrap();
+        result.append_value(sum as f32);
+        result.append_value(count as f32);
         Ok(ColumnarValue::Array(Arc::new(result.finish())))
     }
 }
@@ -701,11 +702,11 @@ impl Accumulator for ModelAvgAccumulator {
         unreachable!()
     }
 
-    fn state(&self) -> Result<Vec<ScalarValue>> {
+    fn state(&self) -> Result<Vec<AggregateState>> {
         //Must match datafusion::physical_plan::expressions::AvgAccumulator
         Ok(vec![
-            ScalarValue::UInt64(Some(self.count)),
-            ScalarValue::Float32(Some(self.sum)),
+            AggregateState::Scalar(ScalarValue::UInt64(Some(self.count))),
+            AggregateState::Scalar(ScalarValue::Float32(Some(self.sum))),
         ])
     }
 

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -222,6 +222,7 @@ impl TableProvider for ModelTable {
                 object_meta: object_meta.unwrap(),
                 partition_values: vec![],
                 range: None,
+                extensions: None,
             })
             .collect::<Vec<PartitionedFile>>()
             .await;
@@ -246,7 +247,7 @@ impl TableProvider for ModelTable {
         };
 
         let predicate = self.rewrite_and_combine_filters(filters);
-        let parquet_exec = Arc::new(ParquetExec::new(file_scan_config, predicate.clone()));
+        let parquet_exec = Arc::new(ParquetExec::new(file_scan_config, predicate.clone(), None));
         let input = self
             .add_filter_exec(&predicate, &parquet_exec)
             .unwrap_or(parquet_exec);
@@ -516,8 +517,7 @@ impl GridStream {
         let mut members = StringBuilder::new(level.iter().map(|s| s.unwrap().len()).sum());
         for tid in tids {
             members
-                .append_value(level.value(tid.unwrap() as usize))
-                .unwrap();
+                .append_value(level.value(tid.unwrap() as usize));
         }
         Arc::new(members.finish())
     }


### PR DESCRIPTION
This pull request primarily updates Apache Arrow DataFusion to [version 11.0.0](https://crates.io/crates/datafusion/11.0.0) and fixes all known breaking changes. New versions of Apache Arrow DataFusion usually have breaking changes, so updating to each new release ensures that the number of changes required does not accumulate. The changes in this PR are mainly the removal of `.unwrap()` and `?` as the append methods in [`PrimitiveBuilder`](https://docs.rs/arrow/latest/arrow/array/struct.PrimitiveBuilder.html) now return `()` instead of `Result<()>`, and changing the return type of [`Accumulator.state()`](https://docs.rs/datafusion/latest/datafusion/physical_plan/trait.Accumulator.html#tymethod.state) as it now returns [`AggregateState`](https://docs.rs/datafusion-expr/11.0.0/datafusion_expr/enum.AggregateState.html) instead of [`ScalarValue`](https://docs.rs/datafusion-common/11.0.0/datafusion_common/scalar/enum.ScalarValue.html). As the code in `server/src/optimizer/mod.rs`, `server/src/optimizer/model_simple_aggregates.rs`, and `server/src/tables.rs` have not been refactored and properly documented yet, it has purposely not been reformatted with `rustfmt` in this PR to make it easier to review.