### PR TITLE
Temporarily fix compatibility for SchemaResult

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -27,13 +27,12 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 use arrow::error::ArrowError;
-use arrow::ipc::convert::schema_from_bytes;
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty;
 
 use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::utils::flight_data_to_arrow_batch;
-use arrow_flight::{Criteria, FlightDescriptor};
+use arrow_flight::{Criteria, FlightDescriptor, IpcMessage};
 
 use rustyline::Editor;
 
@@ -189,14 +188,15 @@ fn execute_command(
             let fd = FlightDescriptor::new_path(vec![table_name.to_string()]);
             let request = Request::new(fd);
             rt.block_on(async {
-                // Both the 32-bit continuation indicator and the 32-bit
-                // little-endian length will be prepended to SchemaResult.schema
-                // for compatibility with other Apache Arrow Flight
-                // implementations until issue
+                // SchemaResults contains the bytes from IpcMessages for
+                // compatibility with the return type of
+                // FlightService.get_schema() and to ensure the SchemaResults
+                // match what is expected by the other Arrow Flight
+                // implementations until
                 // https://github.com/apache/arrow-rs/issues/2445 is fixed.
-                let mut schema_result = fsc.get_schema(request).await?.into_inner();
-                schema_result.schema.drain(0..8);
-                let schema = schema_from_bytes(&schema_result.schema)?;
+                let schema_result = fsc.get_schema(request).await?.into_inner();
+                let ipc_message = IpcMessage(schema_result.schema);
+                let schema = Schema::try_from(ipc_message)?;
                 for field in schema.fields() {
                     println!("{}: {}", field.name(), field.data_type());
                 }


### PR DESCRIPTION
This PR adds a temporary workaround for [issue \#2445 in arrow-rs](https://github.com/apache/arrow-rs/issues/2445) by extending [`FlightService.get_schema()`](https://github.com/ModelarData/ModelarDB-RS/blob/bug/serialize-schema/server/src/remote.rs#L178) to always prepend both the [32-bit continuation indicator and the 32-bit little-endian length](https://arrow.apache.org/docs/format/Columnar.html#encapsulated-message-format) to `SchemaResult.schema` so it can be deserialized by the other Apache Arrow Flight implementations. To preserve compatibility with the Rust client (`mdb`), [`execute_command()`](https://github.com/ModelarData/ModelarDB-RS/blob/bug/serialize-schema/client/src/main.rs#L192) have been extended to strip the first eight bytes of `SchemaResult.schema`. I have manually tested the changes with Go (using the code in [Telegraf-Output-Apache-Arrow-Flight](https://github.com/ModelarData/Telegraf-Output-Apache-Arrow-Flight/tree/file-transfer)), Java, Python, and the Rust client (`mdb`) using multiple different schemas. Finally, while slightly outside the scope of the PR, I have moved `DoExchangeStream` before `DoActionStream` so the order of the types should match the order of the methods that use them in `FlightService`.