### PR TITLE
Added actions to create table and create model table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +939,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452c155cb93fecdfb02a73dd57b5d8e442c2063bd7aac72f1bc5e4263a43086"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -1175,6 +1196,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f0455f2c1bc9a7caa792907026e469c1d91761fb0ea37cbb16427c77280cf35"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1299,7 @@ dependencies = [
  "object_store",
  "paho-mqtt",
  "proptest",
+ "rusqlite",
  "snmalloc-rs",
  "tempfile",
  "tokio",
@@ -1625,6 +1658,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,6 +1881,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -2494,6 +2547,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,6 @@ dependencies = [
  "paho-mqtt",
  "proptest",
  "rusqlite",
- "serde_json",
  "snmalloc-rs",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,6 @@ dependencies = [
  "paho-mqtt",
  "proptest",
  "rusqlite",
- "serde",
  "serde_json",
  "snmalloc-rs",
  "tempfile",
@@ -1986,9 +1985,6 @@ name = "serde"
 version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
-dependencies = [
- "serde_derive",
-]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,6 +1300,8 @@ dependencies = [
  "paho-mqtt",
  "proptest",
  "rusqlite",
+ "serde",
+ "serde_json",
  "snmalloc-rs",
  "tempfile",
  "tokio",
@@ -1984,6 +1986,9 @@ name = "serde"
 version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,7 +30,6 @@ snmalloc-rs = "0.3.3"
 paho-mqtt = { version = "0.11.1", default-features = false, features = ["bundled"] }
 
 rusqlite = { version = "0.28.0", features = ["bundled"] }
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,7 +30,6 @@ snmalloc-rs = "0.3.3"
 paho-mqtt = { version = "0.11.1", default-features = false, features = ["bundled"] }
 
 rusqlite = { version = "0.28.0", features = ["bundled"] }
-serde_json = "1.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,8 @@ snmalloc-rs = "0.3.3"
 paho-mqtt = { version = "0.11.1", default-features = false, features = ["bundled"] }
 
 rusqlite = { version = "0.28.0", features = ["bundled"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,6 +29,8 @@ snmalloc-rs = "0.3.3"
 
 paho-mqtt = { version = "0.11.1", default-features = false, features = ["bundled"] }
 
+rusqlite = { version = "0.28.0", features = ["bundled"] }
+
 [dev-dependencies]
 proptest = "1.0.0"
 tempfile = "3.3.0"

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -112,6 +112,22 @@ impl Catalog {
         table_names
     }
 
+    /// Add a table to the catalog of normal tables. If the table name already exists in the catalog
+    /// return [`Err`]. If the table is successfully inserted, return the inserted [`TableMetadata`].
+    pub fn insert_table(&mut self, name: String, path: String) -> Result<TableMetadata, String> {
+        let mut existing_tables = self.table_metadata.iter();
+
+        if existing_tables.any(|table| table.name == table_name) {
+            // TODO: Maybe check if the schema is different.
+            Err(format!("Table with name '{}' already exists.", table_name))
+        } else {
+            let new_table_metadata = TableMetadata { name, path };
+            self.table_metadata.push(new_table_medata);
+
+            Ok(new_table_metadata)
+        }
+    }
+
     /// Determine if `dir_entry` is a table, a model table, or neither. If
     /// `dir_entry` is a table the metadata required to query the table is added
     /// to `table_metadata`, and if `dir_entry` is a model table the metadata

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -112,22 +112,6 @@ impl Catalog {
         table_names
     }
 
-    /// Add a table to the catalog of normal tables. If the table name already exists in the catalog
-    /// return [`Err`]. If the table is successfully inserted, return [`Ok`].
-    pub fn insert_table(&mut self, name: String, path: String) -> Result<(), String> {
-        let mut existing_tables = self.table_metadata.iter();
-
-        if existing_tables.any(|table| table.name == name) {
-            // TODO: Maybe check if the schema is different.
-            Err(format!("Table with name '{}' already exists.", name))
-        } else {
-            let new_table_metadata = TableMetadata { name, path };
-            self.table_metadata.push(new_table_metadata);
-
-            Ok(())
-        }
-    }
-
     /// Determine if `dir_entry` is a table, a model table, or neither. If
     /// `dir_entry` is a table the metadata required to query the table is added
     /// to `table_metadata`, and if `dir_entry` is a model table the metadata

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -113,18 +113,18 @@ impl Catalog {
     }
 
     /// Add a table to the catalog of normal tables. If the table name already exists in the catalog
-    /// return [`Err`]. If the table is successfully inserted, return the inserted [`TableMetadata`].
-    pub fn insert_table(&mut self, name: String, path: String) -> Result<TableMetadata, String> {
+    /// return [`Err`]. If the table is successfully inserted, return [`Ok`].
+    pub fn insert_table(&mut self, name: String, path: String) -> Result<(), String> {
         let mut existing_tables = self.table_metadata.iter();
 
-        if existing_tables.any(|table| table.name == table_name) {
+        if existing_tables.any(|table| table.name == name) {
             // TODO: Maybe check if the schema is different.
-            Err(format!("Table with name '{}' already exists.", table_name))
+            Err(format!("Table with name '{}' already exists.", name))
         } else {
             let new_table_metadata = TableMetadata { name, path };
-            self.table_metadata.push(new_table_medata);
+            self.table_metadata.push(new_table_metadata);
 
-            Ok(new_table_metadata)
+            Ok(())
         }
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -131,16 +131,17 @@ fn create_model_table_metadata_tables(data_folder_path: &Path) -> Result<(), rus
     connection.execute(
         "CREATE TABLE IF NOT EXISTS model_table_metadata (
                 table_name TEXT PRIMARY KEY,
-                schema TEXT NOT NULL,
+                schema BLOB NOT NULL,
                 timestamp_column_index INTEGER NOT NULL,
                 tag_column_indices BLOB NOT NULL
         )",
         (),
     )?;
 
-    // Create the model_table_columns SQLite table if it does not exist.
+    // Create the model_table_field_columns SQLite table if it does not exist. Note that column_index
+    // will only use a maximum of 10 bits.
     connection.execute(
-        "CREATE TABLE IF NOT EXISTS model_table_columns (
+        "CREATE TABLE IF NOT EXISTS model_table_field_columns (
                 table_name TEXT NOT NULL,
                 column_name TEXT NOT NULL,
                 column_index INTEGER NOT NULL,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -29,6 +29,7 @@ mod storage;
 mod tables;
 mod types;
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use datafusion::common::DataFusionError;
@@ -68,8 +69,10 @@ fn main() -> Result<(), String> {
     let mut args = std::env::args();
     args.next(); // Skip executable.
     if let Some(data_folder) = args.next() {
+        let data_folder_path = PathBuf::from(&data_folder);
+
         // Build Context.
-        let mut catalog = Catalog::try_new(&data_folder).map_err(|error| {
+        let mut catalog = Catalog::try_new(&data_folder_path).map_err(|error| {
             format!("Unable to read data folder '{}': {}", &data_folder, &error)
         })?;
         let runtime = Runtime::new().unwrap();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -30,7 +30,7 @@ mod tables;
 mod types;
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use datafusion::common::DataFusionError;
 use datafusion::execution::context::{SessionConfig, SessionContext, SessionState};
@@ -50,7 +50,7 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 /// Provides access to the system's configuration and components.
 pub struct Context {
     /// Metadata for the tables and model tables in the data folder.
-    catalog: Catalog,
+    catalog: RwLock<Catalog>,
     /// A Tokio runtime for executing asynchronous tasks.
     runtime: Runtime,
     /// Main interface for Apache Arrow DataFusion.
@@ -83,7 +83,7 @@ fn main() -> Result<(), String> {
 
         // Start Interface.
         let context = Arc::new(Context {
-            catalog,
+            catalog: RwLock::new(catalog),
             runtime,
             session,
         });

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -36,7 +36,6 @@ use datafusion::common::DataFusionError;
 use datafusion::execution::context::{SessionConfig, SessionContext, SessionState};
 use datafusion::execution::options::ParquetReadOptions;
 use datafusion::execution::runtime_env::RuntimeEnv;
-use log::info;
 use rusqlite::Connection;
 use tokio::runtime::Runtime;
 use tracing::error;
@@ -84,11 +83,6 @@ fn main() -> Result<(), String> {
         create_model_table_metadata_tables(data_folder_path.as_path())
             .map_err(|error| error.to_string())?;
 
-        // TODO: Currently we load the tables into the ModelarDB catalog when starting. We also just
-        //       add the tables to the ModelarDB catalog when creating tables. When querying should
-        //       be supported, the tables should be loaded/added to the DataFusion catalog.
-        // TODO: Load the model tables from the metadata table to the catalog.
-
         // Register Tables.
         register_tables_and_model_tables(&runtime, &mut session, &mut catalog);
 
@@ -123,7 +117,7 @@ fn create_session_context() -> SessionContext {
     SessionContext::with_state(state)
 }
 
-
+// TODO: Move this function to the configuration/metadata component.
 /// If they do not already exist, create the tables used for model table metadata. A
 /// "model_table_metadata" table that can persist model tables is created. A "columns" table that
 /// can save the index of field columns in specific tables is also created. If the tables already
@@ -157,7 +151,9 @@ fn create_model_table_metadata_tables(data_folder_path: &Path) -> Result<(), rus
     Ok(())
 }
 
-
+// TODO: Currently we load the tables into the ModelarDB catalog when starting. We also just
+//       add the tables to the ModelarDB catalog when creating tables. When querying should
+//       be supported, the new model tables should be registered with the DataFusion catalog.
 /// Register all tables and model tables in `catalog` with Apache Arrow
 /// DataFusion through `session_context`. If initialization fails the table or
 /// model table is removed from `catalog`.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -80,8 +80,9 @@ fn main() -> Result<(), String> {
         let mut session = create_session_context();
 
         // Set up the metadata tables used for model tables.
-        create_model_table_metadata_tables(data_folder_path.as_path())
-            .map_err(|error| error.to_string())?;
+        create_model_table_metadata_tables(data_folder_path.as_path()).map_err(|error| {
+            format!("Unable to create metadata tables: {}", error)
+        })?;
 
         // Register Tables.
         register_tables_and_model_tables(&runtime, &mut session, &mut catalog);
@@ -137,7 +138,7 @@ fn create_model_table_metadata_tables(data_folder_path: &Path) -> Result<(), rus
         (),
     )?;
 
-    // Create the columns SQLite table if it does not exist.
+    // Create the model_table_columns SQLite table if it does not exist.
     connection.execute(
         "CREATE TABLE IF NOT EXISTS model_table_columns (
                 table_name TEXT NOT NULL,
@@ -151,8 +152,8 @@ fn create_model_table_metadata_tables(data_folder_path: &Path) -> Result<(), rus
     Ok(())
 }
 
-// TODO: Currently we load the tables into the ModelarDB catalog when starting. We also just
-//       add the tables to the ModelarDB catalog when creating tables. When querying should
+// TODO: Currently we load the model tables into the ModelarDB catalog when starting. We also just
+//       add the model tables to the ModelarDB catalog when creating tables. When querying should
 //       be supported, the new model tables should be registered with the DataFusion catalog.
 /// Register all tables and model tables in `catalog` with Apache Arrow
 /// DataFusion through `session_context`. If initialization fails the table or

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -296,8 +296,9 @@ impl FlightService for FlightServiceHandler {
     /// Perform a specific action based on the type of the action in `request`. Currently supports
     /// two actions: `CreateTable` and `CreateModelTable`. `CreateTable` creates a normal table
     /// in the catalog when given a table name and schema. `CreateModelTable` creates a table
-    /// that can be used for ingestion when given a table name, a schema and a list of indices,
-    /// specifying which columns are metadata tag columns.
+    /// that can be used for ingestion when given a table name, a schema, a list of indices
+    /// specifying which columns are metadata tag columns, and an index specifying which column
+    /// is the timestamp column.
     ///
     /// The data is given in the action body and must have the following format:
     /// The first two bytes are the length x of the first argument. The next x bytes are the first
@@ -321,7 +322,7 @@ impl FlightService for FlightServiceHandler {
                 .map_err(|error| Status::invalid_argument(error.to_string()))?;
 
             if action.r#type == "CreateTable" {
-                // TODO: Maybe check if the schema is different, this is expensive since all tables have to be read.
+                // TODO: Maybe check if the schema is different.
                 // If the table name already exists, return an error.
                 let mut existing_tables = self.context.catalog.table_metadata.iter();
                 if existing_tables.any(|table| table.name == table_name) {
@@ -345,9 +346,21 @@ impl FlightService for FlightServiceHandler {
 
                 info!("Tag indices: {:?}", tag_indices_bytes);
 
+                // TODO: In main, create the model_table_metadata SQLite table if it does not exist.
+                // TODO: In main, create the columns SQLite table if it does not exist.
+                // TODO: Merge.
+
+                // TODO: Create the folder to check if it is a valid object_store folder.
                 // TODO: The table should be added to the catalog (as a model table?).
-                // TODO: If the table already exists and the schemas is different, return an error.
+                // TODO: If the table already exists and the schemas are different, return an error.
                 // TODO: If the indexes for the tag columns does not match the schema, return an error.
+                // TODO: If the index for the timestamp columns does not match the schema, return an error.
+                // TODO: Create tests for all these checks.
+
+                // TODO: If it passes the checks, create a table_tags SQLite table.
+                // TODO: Create a new row in the model_table_metadata table.
+                // TODO: Add the field columns to the columns table.
+                // TODO: Create test to ensure this happens.
             }
 
             // Confirm the table was created.

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -349,8 +349,20 @@ impl FlightService for FlightServiceHandler {
         &self,
         _request: Request<Empty>,
     ) -> Result<Response<Self::ListActionsStream>, Status> {
-        // TODO: List two new actions above.
-        Err(Status::unimplemented("Not implemented."))
+        let create_table_action = ActionType {
+            r#type: "CreateTable".to_owned(),
+            description: "Given a table name and a schema, create a table and add it to the \
+            catalog.".to_owned(),
+        };
+
+        let create_ingestion_table_action = ActionType {
+            r#type: "CreateIngestionTable".to_owned(),
+            description: "Given a table name, a schema, and a list of tag column indices, \
+            create an ingestion table and add it to the catalog.".to_owned()
+        };
+
+        let output = stream::iter(vec![Ok(create_table_action), Ok(create_ingestion_table_action)]);
+        Ok(Response::new(Box::pin(output)))
     }
 }
 

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -354,7 +354,9 @@ impl FlightService for FlightServiceHandler {
             if action.r#type == "CreateTable" {
                 create_table(catalog, table_name.to_owned(), schema)?;
             } else {
-                // Extract the tag column indices from the action body.
+                // Extract the tag column indices from the action body. Note that since we assume
+                // each tag column index is one byte, we directly use the slice of bytes as the list
+                // of tag column indices.
                 let (tag_indices, offset_data) = extract_argument_bytes(offset_data);
 
                 // Extract the timestamp column index from the action body.

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -288,19 +288,35 @@ impl FlightService for FlightServiceHandler {
         Err(Status::unimplemented("Not implemented."))
     }
 
-    /// Not implemented.
+    /// Perform a specific action based on the type of the action in `request`. Currently supports
+    /// two actions: `CreateTable` and `CreateIngestionTable`. `CreateTable` creates a normal table
+    /// in the catalog when given a table name and schema. `CreateIngestionTable` creates a table
+    /// that can be used for ingestion when given a table name, a schema and a list of indexes,
+    /// specifying which columns are metadata tag columns.
     async fn do_action(
         &self,
         _request: Request<Action>,
     ) -> Result<Response<Self::DoActionStream>, Status> {
+        // TODO: Add an action to create a table. It should have a name and a schema.
+        // TODO: The table should be added to the catalog.
+        // TODO: The name should be the given name and the path should be based on the name.
+        // TODO: If the table already exists and the schema is different, return an error.
+
+        // TODO: Add an action to create a model table. It should have a name, a schema and what are tag columns.
+        // TODO: The table should be added to the catalog (as a model table?).
+        // TODO: If the table already exists and the schemas is different, return an error.
+        // TODO: If the indexes for the tag columns does not match the schema, return an error.
+
+        // TODO: If given an action that does not exist return not implemented error.
         Err(Status::unimplemented("Not implemented."))
     }
 
-    /// Not implemented.
+    /// Return all available actions, including both a name of the action and a description.
     async fn list_actions(
         &self,
         _request: Request<Empty>,
     ) -> Result<Response<Self::ListActionsStream>, Status> {
+        // TODO: List two new actions above.
         Err(Status::unimplemented("Not implemented."))
     }
 }

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -291,24 +291,31 @@ impl FlightService for FlightServiceHandler {
     /// Perform a specific action based on the type of the action in `request`. Currently supports
     /// two actions: `CreateTable` and `CreateIngestionTable`. `CreateTable` creates a normal table
     /// in the catalog when given a table name and schema. `CreateIngestionTable` creates a table
-    /// that can be used for ingestion when given a table name, a schema and a list of indexes,
+    /// that can be used for ingestion when given a table name, a schema and a list of indices,
     /// specifying which columns are metadata tag columns.
     async fn do_action(
         &self,
-        _request: Request<Action>,
+        request: Request<Action>,
     ) -> Result<Response<Self::DoActionStream>, Status> {
+        let action = request.into_inner();
+        info!("Received request to perform action: {}", action.r#type);
+
         // TODO: Add an action to create a table. It should have a name and a schema.
         // TODO: The table should be added to the catalog.
         // TODO: The name should be the given name and the path should be based on the name.
         // TODO: If the table already exists and the schema is different, return an error.
 
-        // TODO: Add an action to create a model table. It should have a name, a schema and what are tag columns.
-        // TODO: The table should be added to the catalog (as a model table?).
-        // TODO: If the table already exists and the schemas is different, return an error.
-        // TODO: If the indexes for the tag columns does not match the schema, return an error.
-
-        // TODO: If given an action that does not exist return not implemented error.
-        Err(Status::unimplemented("Not implemented."))
+        if action.r#type == "CreateTable" {
+            Err(Status::unimplemented("Action not implemented."))
+        } else if action.r#type == "CreateIngestionTable" {
+            // TODO: Add an action to create a model table. It should have a name, a schema and what are tag columns.
+            // TODO: The table should be added to the catalog (as a model table?).
+            // TODO: If the table already exists and the schemas is different, return an error.
+            // TODO: If the indexes for the tag columns does not match the schema, return an error.
+            Err(Status::unimplemented("Action not implemented."))
+        } else {
+            Err(Status::unimplemented("Action not implemented."))
+        }
     }
 
     /// Return all available actions, including both a name of the action and a description.


### PR DESCRIPTION
This PR includes a new implementation of the `do_action` endpoint that adds support for two new actions; `CreateTable` and `CreateModelTable`. The `list_actions` endpoint has also been changed to reflect the new actions. Using a table name and a schema, a normal table can be created. This just creates an empty parquet file in the data folder to save the schema and table name.

Using a table name, schema, tag column indices and a timestamp column index, a model table can be created. This creates a new instance of the `NewModelTableMetadata` struct to save the data in the in-memory catalog and applies changes to the metadata SQLite tables to persist the new model table.

It should be noted that the old model table implementation has not been removed. This PR purely adds new functionality. It should also be noted that some extra functionality has been added to `main` in order to create the SQLite tables that are used later when creating model tables, namely the `model_table_metadata` and `model_table_columns` tables. 

For now, only the checks when creating a `NewModelTableMetadata` instance are tested. Creating normal tables and model tables could also be tested, but I think this should be done when the old model table implementation has been removed. At that point, tests can be added for the entire catalog since other I/O testing is also missing. I have added a [work item](https://dev.azure.com/ModelarData/ModelarDB%20Implementation/_workitems/edit/155) to do this.