### PR TITLE
Support compressing irregular time series

### DIFF
--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -14,8 +14,8 @@
  */
 
 //! Compress `UncompressedSegments` provided by [`StorageEngine`] using the
-//! model types in [`crate::models`] to produce compressed segments which are
-//! returned to [`StorageEngine`].
+//! model types in [`models`](crate::models) to produce compressed segments
+//! which are returned to [`StorageEngine`].
 
 use std::sync::Arc;
 
@@ -37,7 +37,7 @@ pub const GORILLA_MAXIMUM_LENGTH: usize = 50;
 
 /// Compress the regular `uncompressed_timestamps` using a start time, end time,
 /// and a sampling interval, and `uncompressed_values` within `error_bound`
-/// using the model types in [`crate::models`]. Returns
+/// using the model types in [`models`](crate::models). Returns
 /// [`CompressionError`](ModelarDBError::CompressionError) if
 /// `uncompressed_timestamps` and `uncompressed_values` have different lengths,
 /// otherwise the resulting compressed segments are returned as a
@@ -80,9 +80,9 @@ pub fn try_compress(
 }
 
 /// A compressed segment being built from an uncompressed segment using the
-/// model types in [`crate::models`]. Each of the model types is used to fit
-/// models to the data points, and then the model that uses the fewest number of
-/// bytes per value is selected.
+/// model types in [`models`](crate::models). Each of the model types is used to
+/// fit models to the data points, and then the model that uses the fewest
+/// number of bytes per value is selected.
 struct CompressedSegmentBuilder<'a> {
     /// The regular timestamps of the uncompressed segment the compressed
     /// segment is being built from.

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -32,7 +32,7 @@ use crate::types::{Timestamp, TimestampArray, TimestampBuilder, Value, ValueArra
 /// Maximum number of data points that models of type Gorilla can represent per
 /// compressed segment. As models of type Gorilla use lossless compression they
 /// will never exceed the user-defined error bounds.
-const GORILLA_MAXIMUM_LENGTH: usize = 50;
+pub const GORILLA_MAXIMUM_LENGTH: usize = 50;
 
 /// Compress the regular `uncompressed_timestamps` using a start time, end time,
 /// and a sampling interval, and `uncompressed_values` within `error_bound`

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -14,8 +14,8 @@
  */
 
 //! Compress `UncompressedSegments` provided by [`StorageEngine`] using the
-//! model types in [`models`] to produce compressed segments which are returned
-//! to [`StorageEngine`].
+//! model types in [`crate::models`] to produce compressed segments which are
+//! returned to [`StorageEngine`].
 
 use std::sync::Arc;
 
@@ -23,8 +23,9 @@ use datafusion::arrow::array::{BinaryBuilder, Float32Builder, UInt8Builder};
 use datafusion::arrow::record_batch::RecordBatch;
 
 use crate::errors::ModelarDBError;
-use crate::models;
-use crate::models::{gorilla::Gorilla, pmcmean::PMCMean, swing::Swing, ErrorBound, SelectedModel};
+use crate::models::{
+    gorilla::Gorilla, pmcmean::PMCMean, swing::Swing, timestamps, ErrorBound, SelectedModel,
+};
 use crate::storage::StorageEngine;
 use crate::types::{Timestamp, TimestampArray, TimestampBuilder, Value, ValueArray, ValueBuilder};
 
@@ -36,7 +37,7 @@ pub const GORILLA_MAXIMUM_LENGTH: usize = 50;
 
 /// Compress the regular `uncompressed_timestamps` using a start time, end time,
 /// and a sampling interval, and `uncompressed_values` within `error_bound`
-/// using the model types in [`models`]. Returns
+/// using the model types in [`crate::models`]. Returns
 /// [`CompressionError`](ModelarDBError::CompressionError) if
 /// `uncompressed_timestamps` and `uncompressed_values` have different lengths,
 /// otherwise the resulting compressed segments are returned as a
@@ -79,9 +80,9 @@ pub fn try_compress(
 }
 
 /// A compressed segment being built from an uncompressed segment using the
-/// model types in [`models`]. Each of the model types is used to fit models to
-/// the data points, and then the model that uses the fewest number of bytes per
-/// value is selected.
+/// model types in [`crate::models`]. Each of the model types is used to fit
+/// models to the data points, and then the model that uses the fewest number of
+/// bytes per value is selected.
 struct CompressedSegmentBuilder<'a> {
     /// The regular timestamps of the uncompressed segment the compressed
     /// segment is being built from.
@@ -192,12 +193,12 @@ impl<'a> CompressedSegmentBuilder<'a> {
         // Add timestamps and error.
         let start_time = self.uncompressed_timestamps.value(self.start_index);
         let end_time = self.uncompressed_timestamps.value(end_index);
-        let timestamps = &[]; // TODO: compress irregular timestamps.
+        let timestamps = timestamps::compress_residual_timestamps(&self.uncompressed_timestamps);
         let error = f32::NAN; // TODO: compute and store the actual error.
 
         compressed_record_batch_builder.append_compressed_segment(
             model_type_id,
-            timestamps,
+            &timestamps,
             start_time,
             end_time,
             &values,
@@ -289,8 +290,12 @@ impl CompressedSegmentBatchBuilder {
 
 #[cfg(test)]
 mod tests {
+    // TODO: add tests for irregular time series when refactoring the query engine.
     use super::*;
+
     use datafusion::arrow::array::UInt8Array;
+
+    use crate::models;
 
     // Tests for try_compress().
     #[test]

--- a/server/src/models/bits.rs
+++ b/server/src/models/bits.rs
@@ -38,7 +38,12 @@ impl<'a> BitReader<'a> {
 
     /// Return `true` if the reader have been exhausted, otherwise `false`.
     pub fn is_empty(&self) -> bool {
-        ((self.next_bit / 8) as usize) < self.bytes.len()
+        ((self.next_bit / 8) as usize) == self.bytes.len()
+    }
+
+    /// Return the remaining bits in the [`BitReader`].
+    pub fn remaining_bits(&self) -> usize {
+        8 * self.bytes.len() - (self.next_bit as usize) // TODO: next_bit usize?
     }
 
     /// Read the next bit from the [`BitReader`].
@@ -170,6 +175,19 @@ mod tests {
     #[test]
     fn test_reading_the_test_bits() {
         assert!(bytes_and_bits_are_equal(TEST_BYTES, TEST_BITS));
+    }
+
+    #[test]
+    pub fn test_remaining_bits() {
+        let mut bits = BitReader::try_new(&[0, 255]).unwrap();
+        assert_eq!(bits.remaining_bits(), 16);
+        bits.read_bits(4);
+        assert_eq!(bits.remaining_bits(), 12);
+        bits.read_bits(8);
+        assert_eq!(bits.remaining_bits(), 4);
+        bits.read_bits(4);
+        assert_eq!(bits.remaining_bits(), 0);
+        assert!(bits.is_empty());
     }
 
     // Tests for BitVecBuilder.

--- a/server/src/models/bits.rs
+++ b/server/src/models/bits.rs
@@ -1,0 +1,260 @@
+/* Copyright 2022 The ModelarDB Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Implementation of types for reading and writing bits from and to a sequence
+//! of bytes.
+
+/// Read one or multiple bits from a `[u8]`. [`BitReader`] is implemented based
+/// on [code published by Ilkka Rauta] dual-licensed under MIT and Apache2.
+///
+/// [code published by Ilkka Rauta]: https://github.com/irauta/bitreader
+pub struct BitReader<'a> {
+    /// Next bit to read from `bytes`.
+    next_bit: u64,
+    /// Bits packed into one or more [`u8s`](u8).
+    bytes: &'a [u8],
+}
+
+impl<'a> BitReader<'a> {
+    pub fn try_new(bytes: &'a [u8]) -> Result<Self, String> {
+        if bytes.is_empty() {
+            Err("The byte array cannot be empty".to_owned())
+        } else {
+            Ok(Self { next_bit: 0, bytes })
+        }
+    }
+
+    /// Return `true` if the reader have been exhausted, otherwise `false`.
+    pub fn is_empty(&self) -> bool {
+        ((self.next_bit / 8) as usize) < self.bytes.len()
+    }
+
+    /// Read the next bit from the [`BitReader`].
+    pub fn read_bit(&mut self) -> bool {
+        self.read_bits(1) == 1
+    }
+
+    /// Read the next `number_of_bits` bits from the [`BitReader`].
+    pub fn read_bits(&mut self, number_of_bits: u8) -> u32 {
+        let mut value: u64 = 0;
+        let start_bit = self.next_bit;
+        let end_bit = self.next_bit + number_of_bits as u64;
+        for bit in start_bit..end_bit {
+            let current_byte = (bit / 8) as usize;
+            let byte = self.bytes[current_byte];
+            let shift = 7 - (bit % 8);
+            let bit: u64 = (byte >> shift) as u64 & 1;
+            value = (value << 1) | bit;
+        }
+        self.next_bit = end_bit;
+        value as u32
+    }
+}
+
+/// Append one or multiple bits to a [`Vec<u8>`].
+pub struct BitVecBuilder {
+    /// [`u8`] currently used for storing the bits.
+    current_byte: u8,
+    /// Bits remaining in `current_byte`.
+    remaining_bits: u8,
+    /// Bits packed into one or more [`u8s`](u8).
+    bytes: Vec<u8>,
+}
+
+impl BitVecBuilder {
+    pub fn new() -> Self {
+        Self {
+            current_byte: 0,
+            remaining_bits: 8,
+            bytes: vec![],
+        }
+    }
+
+    /// Append a zero bit to the [`BitVecBuilder`].
+    pub fn append_a_zero_bit(&mut self) {
+        self.append_bits(0, 1)
+    }
+
+    /// Append a one bit to the [`BitVecBuilder`].
+    pub fn append_a_one_bit(&mut self) {
+        self.append_bits(1, 1)
+    }
+
+    /// Append `number_of_bits` from `bits` to the [`BitVecBuilder`].
+    pub fn append_bits(&mut self, bits: u32, number_of_bits: u8) {
+        let mut number_of_bits = number_of_bits;
+
+        while number_of_bits > 0 {
+            let bits_to_write = if number_of_bits > self.remaining_bits {
+                let shift = number_of_bits - self.remaining_bits;
+                self.current_byte |= ((bits >> shift) & ((1 << self.remaining_bits) - 1)) as u8;
+                self.remaining_bits
+            } else {
+                let shift = self.remaining_bits - number_of_bits;
+                self.current_byte |= (bits << shift) as u8;
+                number_of_bits
+            };
+            number_of_bits -= bits_to_write;
+            self.remaining_bits -= bits_to_write;
+
+            if self.remaining_bits == 0 {
+                self.bytes.push(self.current_byte);
+                self.current_byte = 0;
+                self.remaining_bits = 8;
+            }
+        }
+    }
+
+    /// Return [`true`] if no bits have been appended to the [`BitVecBuilder`],
+    /// otherwise [`false`].
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    /// Return the number of bytes required to store the appended bits.
+    pub fn length(&self) -> usize {
+        self.bytes.len() + (self.remaining_bits != 8) as usize
+    }
+
+    /// Consume the [`BitVecBuilder`] and return the appended bits packed into a
+    /// [`Vec<u8>`].
+    pub fn finish(mut self) -> Vec<u8> {
+        if self.remaining_bits != 8 {
+            self.bytes.push(self.current_byte);
+        }
+        self.bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models;
+    use crate::types::tests::{ProptestTimestamp, ProptestValue};
+    use proptest::{bool, collection, prop_assert, prop_assert_eq, prop_assume, proptest};
+
+    // The largest byte, a random byte, and the smallest byte for testing.
+    const TEST_BYTES: &[u8] = &[255, 170, 0];
+    const TEST_BITS: &[bool] = &[
+        true, true, true, true, true, true, true, true, true, false, true, false, true, false,
+        true, false, false, false, false, false, false, false, false, false,
+    ];
+
+    // Tests for BitReader.
+    #[test]
+    fn test_bit_reader_cannot_be_empty() {
+        assert!(BitReader::try_new(&[]).is_err());
+    }
+
+    #[test]
+    fn test_reading_the_test_bits() {
+        assert!(bytes_and_bits_are_equal(TEST_BYTES, TEST_BITS));
+    }
+
+    // Tests for BitVecBuilder.
+    #[test]
+    fn test_empty_bit_vec_builder_is_empty() {
+        assert!(BitVecBuilder::new().finish().is_empty());
+    }
+
+    #[test]
+    fn test_empty_bit_vec_builder_length() {
+        assert_eq!(BitVecBuilder::new().length(), 0);
+    }
+
+    #[test]
+    fn test_one_one_bit_vec_builder_length() {
+        let mut bit_vec_builder = BitVecBuilder::new();
+        bit_vec_builder.append_a_one_bit();
+        assert_eq!(bit_vec_builder.length(), 1);
+    }
+
+    #[test]
+    fn test_one_zero_bit_vec_builder_length() {
+        let mut bit_vec_builder = BitVecBuilder::new();
+        bit_vec_builder.append_a_zero_bit();
+        assert_eq!(bit_vec_builder.length(), 1);
+    }
+
+    #[test]
+    fn test_eight_one_bits_vec_builder_length() {
+        let mut bit_vec_builder = BitVecBuilder::new();
+        (0..8).for_each(|_| bit_vec_builder.append_a_one_bit());
+        assert_eq!(bit_vec_builder.length(), 1);
+    }
+
+    #[test]
+    fn test_eight_zero_bits_vec_builder_length() {
+        let mut bit_vec_builder = BitVecBuilder::new();
+        (0..8).for_each(|_| bit_vec_builder.append_a_zero_bit());
+        assert_eq!(bit_vec_builder.length(), 1);
+    }
+
+    #[test]
+    fn test_nine_one_bits_vec_builder_length() {
+        let mut bit_vec_builder = BitVecBuilder::new();
+        (0..9).for_each(|_| bit_vec_builder.append_a_one_bit());
+        assert_eq!(bit_vec_builder.length(), 2);
+    }
+
+    #[test]
+    fn test_nine_zero_bits_vec_builder_length() {
+        let mut bit_vec_builder = BitVecBuilder::new();
+        (0..9).for_each(|_| bit_vec_builder.append_a_zero_bit());
+        assert_eq!(bit_vec_builder.length(), 2);
+    }
+
+    // Tests combining BitReader and BitVecBuilder.
+    #[test]
+    fn test_writing_and_reading_the_test_bits() {
+        let mut bit_vector_builder = BitVecBuilder::new();
+        for bit in TEST_BITS {
+            write_bool_as_bit(&mut bit_vector_builder, *bit);
+        }
+        assert!(bytes_and_bits_are_equal(
+            &bit_vector_builder.finish(),
+            TEST_BITS
+        ));
+    }
+
+    proptest! {
+    #[test]
+    fn test_writing_and_reading_random_bits(bits in collection::vec(bool::ANY, 0..50)) {
+        prop_assume!(!bits.is_empty());
+        let mut bit_vector_builder = BitVecBuilder::new();
+        for bit in &bits {
+            write_bool_as_bit(&mut bit_vector_builder, *bit);
+        }
+        prop_assert!(bytes_and_bits_are_equal(&bit_vector_builder.finish(), &bits));
+    }
+    }
+
+    fn bytes_and_bits_are_equal(bytes: &[u8], bits: &[bool]) -> bool {
+        let mut bit_reader = BitReader::try_new(bytes).unwrap();
+        let mut contains = true;
+        for bit in bits {
+            contains &= *bit == bit_reader.read_bit();
+        }
+        contains
+    }
+
+    fn write_bool_as_bit(bit_vector_builder: &mut BitVecBuilder, bit: bool) {
+        if bit {
+            bit_vector_builder.append_a_one_bit();
+        } else {
+            bit_vector_builder.append_a_zero_bit();
+        }
+    }
+}

--- a/server/src/models/bits.rs
+++ b/server/src/models/bits.rs
@@ -22,7 +22,7 @@
 /// [code published by Ilkka Rauta]: https://github.com/irauta/bitreader
 pub struct BitReader<'a> {
     /// Next bit to read from `bytes`.
-    next_bit: u64,
+    next_bit: usize,
     /// Bits packed into one or more [`u8s`](u8).
     bytes: &'a [u8],
 }
@@ -38,12 +38,12 @@ impl<'a> BitReader<'a> {
 
     /// Return `true` if the reader have been exhausted, otherwise `false`.
     pub fn is_empty(&self) -> bool {
-        ((self.next_bit / 8) as usize) == self.bytes.len()
+        (self.next_bit / 8) == self.bytes.len()
     }
 
     /// Return the remaining bits in the [`BitReader`].
     pub fn remaining_bits(&self) -> usize {
-        8 * self.bytes.len() - (self.next_bit as usize) // TODO: next_bit usize?
+        8 * self.bytes.len() - self.next_bit
     }
 
     /// Read the next bit from the [`BitReader`].
@@ -53,14 +53,14 @@ impl<'a> BitReader<'a> {
 
     /// Read the next `number_of_bits` bits from the [`BitReader`].
     pub fn read_bits(&mut self, number_of_bits: u8) -> u32 {
-        let mut value: u64 = 0;
+        let mut value = 0;
         let start_bit = self.next_bit;
-        let end_bit = self.next_bit + number_of_bits as u64;
+        let end_bit = self.next_bit + number_of_bits as usize;
         for bit in start_bit..end_bit {
-            let current_byte = (bit / 8) as usize;
+            let current_byte = (bit / 8);
             let byte = self.bytes[current_byte];
             let shift = 7 - (bit % 8);
-            let bit: u64 = (byte >> shift) as u64 & 1;
+            let bit = (byte >> shift) as u64 & 1;
             value = (value << 1) | bit;
         }
         self.next_bit = end_bit;

--- a/server/src/models/bits.rs
+++ b/server/src/models/bits.rs
@@ -31,7 +31,7 @@ impl<'a> BitReader<'a> {
     /// Return a [`BitReader`] if `bytes` is not empty, otherwise [`String`].
     pub fn try_new(bytes: &'a [u8]) -> Result<Self, String> {
         if bytes.is_empty() {
-            Err("The byte array cannot be empty.".to_owned())
+            Err("The byte array must not be empty.".to_owned())
         } else {
             Ok(Self { next_bit: 0, bytes })
         }

--- a/server/src/models/bits.rs
+++ b/server/src/models/bits.rs
@@ -57,8 +57,7 @@ impl<'a> BitReader<'a> {
         let start_bit = self.next_bit;
         let end_bit = self.next_bit + number_of_bits as usize;
         for bit in start_bit..end_bit {
-            let current_byte = (bit / 8);
-            let byte = self.bytes[current_byte];
+            let byte = self.bytes[bit / 8];
             let shift = 7 - (bit % 8);
             let bit = (byte >> shift) as u64 & 1;
             value = (value << 1) | bit;
@@ -129,7 +128,7 @@ impl BitVecBuilder {
     }
 
     /// Return the number of bytes required to store the appended bits.
-    pub fn length(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.bytes.len() + (self.remaining_bits != 8) as usize
     }
 
@@ -198,54 +197,54 @@ mod tests {
 
     #[test]
     fn test_empty_bit_vec_builder_length() {
-        assert_eq!(BitVecBuilder::new().length(), 0);
+        assert_eq!(BitVecBuilder::new().len(), 0);
     }
 
     #[test]
     fn test_one_one_bit_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         bit_vec_builder.append_a_one_bit();
-        assert_eq!(bit_vec_builder.length(), 1);
+        assert_eq!(bit_vec_builder.len(), 1);
     }
 
     #[test]
     fn test_one_zero_bit_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         bit_vec_builder.append_a_zero_bit();
-        assert_eq!(bit_vec_builder.length(), 1);
+        assert_eq!(bit_vec_builder.len(), 1);
     }
 
     #[test]
     fn test_eight_one_bits_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         (0..8).for_each(|_| bit_vec_builder.append_a_one_bit());
-        assert_eq!(bit_vec_builder.length(), 1);
+        assert_eq!(bit_vec_builder.len(), 1);
     }
 
     #[test]
     fn test_eight_zero_bits_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         (0..8).for_each(|_| bit_vec_builder.append_a_zero_bit());
-        assert_eq!(bit_vec_builder.length(), 1);
+        assert_eq!(bit_vec_builder.len(), 1);
     }
 
     #[test]
     fn test_nine_one_bits_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         (0..9).for_each(|_| bit_vec_builder.append_a_one_bit());
-        assert_eq!(bit_vec_builder.length(), 2);
+        assert_eq!(bit_vec_builder.len(), 2);
     }
 
     #[test]
     fn test_nine_zero_bits_vec_builder_length() {
         let mut bit_vec_builder = BitVecBuilder::new();
         (0..9).for_each(|_| bit_vec_builder.append_a_zero_bit());
-        assert_eq!(bit_vec_builder.length(), 2);
+        assert_eq!(bit_vec_builder.len(), 2);
     }
 
     #[test]
     fn test_finish_with_one_bits_empty_no_effect() {
-        let mut bit_vec_builder = BitVecBuilder::new();
+        let bit_vec_builder = BitVecBuilder::new();
         let bytes = bit_vec_builder.finish_with_one_bits();
         assert_eq!(bytes.len(), 0);
     }

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -239,6 +239,8 @@ fn decompress_values(
                 trailing_zeros = models::VALUE_SIZE_IN_BITS - meaningful_bits - leading_zeros;
             }
 
+            // Decompress the value by reading its meaningful bits, restoring
+            // its trailing zeroes through shifting, and reversing the XOR.
             let meaningful_bits = models::VALUE_SIZE_IN_BITS - leading_zeros - trailing_zeros;
             let mut value = bits.read_bits(meaningful_bits);
             value <<= trailing_zeros;
@@ -305,7 +307,6 @@ mod tests {
         assert_eq!(model_type.last_leading_zero_bits, 8);
         assert_eq!(model_type.last_trailing_zero_bits, 17);
     }
-
 
     // Tests for min().
     proptest! {

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -32,8 +32,6 @@ use crate::types::{
     ValueArray, ValueBuilder,
 };
 
-// TODO: fix zeroes vs zeros.
-
 /// The state the Gorilla model type needs while compressing the values of a
 /// time series segment.
 pub struct Gorilla {
@@ -307,8 +305,8 @@ fn decompress_values(
     values: &mut ValueBuilder,
 ) {
     let mut bits = BitReader::try_new(model).unwrap();
-    let mut leading_zeroes = u8::MAX;
-    let mut trailing_zeroes: u8 = 0;
+    let mut leading_zeros = u8::MAX;
+    let mut trailing_zeros: u8 = 0;
     let mut last_value = bits.read_bits(models::VALUE_SIZE_IN_BITS);
 
     // The first value is stored uncompressed using size_of::<Value> bits.
@@ -320,14 +318,14 @@ fn decompress_values(
         if bits.read_bit() {
             if bits.read_bit() {
                 // New leading and trailing zeros.
-                leading_zeroes = bits.read_bits(5) as u8;
+                leading_zeros = bits.read_bits(5) as u8;
                 let meaningful_bits = bits.read_bits(6) as u8;
-                trailing_zeroes = models::VALUE_SIZE_IN_BITS - meaningful_bits - leading_zeroes;
+                trailing_zeros = models::VALUE_SIZE_IN_BITS - meaningful_bits - leading_zeros;
             }
 
-            let meaningful_bits = models::VALUE_SIZE_IN_BITS - leading_zeroes - trailing_zeroes;
+            let meaningful_bits = models::VALUE_SIZE_IN_BITS - leading_zeros - trailing_zeros;
             let mut value = bits.read_bits(meaningful_bits);
-            value <<= trailing_zeroes;
+            value <<= trailing_zeros;
             value ^= last_value;
             last_value = value;
         }

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -20,7 +20,7 @@
 //! encoding, aggregates are computed by iterating over all values in the
 //! segment.
 //!
-//! [Gorilla paper]: https://dl.acm.org/doi/10.14778/2824032.2824078
+//! [Gorilla paper]: https://www.vldb.org/pvldb/vol8/p1816-teller.pdf
 
 use datafusion::arrow::compute::kernels::aggregate;
 
@@ -121,7 +121,7 @@ impl Gorilla {
 
     /// Return the number of bytes currently used per data point on average.
     pub fn get_bytes_per_value(&self) -> f32 {
-        self.compressed_values.length() as f32 / self.length as f32
+        self.compressed_values.len() as f32 / self.length as f32
     }
 
     /// Return the values compressed using XOR and a variable length binary

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -21,6 +21,8 @@
 pub mod gorilla;
 pub mod pmcmean;
 pub mod swing;
+pub mod bits;
+pub mod timestamps;
 
 use std::cmp::{Ordering, PartialOrd};
 use std::mem;

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -18,7 +18,7 @@
 //! as described in the [ModelarDB paper].
 //!
 //! [Poor Man’s Compression paper]: https://ieeexplore.ieee.org/document/1260811
-//! [ModelarDB paper]: https://dl.acm.org/doi/abs/10.14778/3236187.3236215
+//! [ModelarDB paper]: http://www.vldb.org/pvldb/vol11/p1688-jensen.pdf
 
 use crate::models;
 use crate::models::ErrorBound;

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -18,7 +18,7 @@
 //! as described in the [ModelarDB paper].
 //!
 //! [Poor Man’s Compression paper]: https://ieeexplore.ieee.org/document/1260811
-//! [ModelarDB paper]: http://www.vldb.org/pvldb/vol11/p1688-jensen.pdf
+//! [ModelarDB paper]: https://www.vldb.org/pvldb/vol11/p1688-jensen.pdf
 
 use crate::models;
 use crate::models::ErrorBound;

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -21,7 +21,7 @@
 //! [`Value`] to make the calculations precise enough.
 //!
 //! [Swing and Slide paper]: https://dl.acm.org/doi/10.14778/1687627.1687645
-//! [ModelarDB paper]: https://dl.acm.org/doi/abs/10.14778/3236187.3236215
+//! [ModelarDB paper]: http://www.vldb.org/pvldb/vol11/p1688-jensen.pdf
 
 use crate::models;
 use crate::models::ErrorBound;

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -21,7 +21,7 @@
 //! [`Value`] to make the calculations precise enough.
 //!
 //! [Swing and Slide paper]: https://dl.acm.org/doi/10.14778/1687627.1687645
-//! [ModelarDB paper]: http://www.vldb.org/pvldb/vol11/p1688-jensen.pdf
+//! [ModelarDB paper]: https://www.vldb.org/pvldb/vol11/p1688-jensen.pdf
 
 use crate::models;
 use crate::models::ErrorBound;

--- a/server/src/models/timestamps.rs
+++ b/server/src/models/timestamps.rs
@@ -1,0 +1,281 @@
+/* Copyright 2022 The ModelarDB Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Implementation of lossless compression for timestamps. Optimized compression
+//! methods are used depending on the number of data points in a compressed
+//! segment and if the timestamps have been sampled at a regular sampling
+//! interval. If the segment only contains one data point its timestamps are
+//! stored as both the segment's `start_time` and `end_time`, and if the segment
+//! only contains two data point the timestamps are stored as the segment's
+//! `start_time` and `end_time`, respectively. If the segment's represents more
+//! than two data points, the first and last timestamps are stored as the
+//! segment's `start_time` and `end_time`, respectively, while the residual
+//! timestamps are compressed using one of two methods. If the data points in
+//! the segment have been collected at a regular sampling interval the residual
+//! timestamps are compressed as the segment's length with the prefix zero bits
+//! stripped, otherwise the compression method proposed for the time series
+//! management system Gorilla in the [Gorilla paper] is used.
+//!
+//! [Gorilla paper]: https://dl.acm.org/doi/10.14778/2824032.2824078
+
+use std::mem;
+
+use crate::models::bits::{BitReader, BitVecBuilder};
+use crate::types::{Timestamp, TimestampArray, TimestampBuilder};
+
+/// Compress the timestamps in `uncompressed_timestamps` from the second
+/// timestamp to the second to last timestamp. The first and last timestamp are
+/// already stored as part of the compressed segment to allow segments to be
+/// pruned. If the time series is regular the timestamps are encoded as the
+/// number of data points in the segments, and if it is irregular, the
+/// timestamp's delta-of-delta is computed and then encode using a variable
+/// length binary encoding.
+pub fn compress_residual_timestamps(uncompressed_timestamps: &TimestampArray) -> Vec<u8> {
+    // Nothing to do as the segments already store the first and last timestamp.
+    if uncompressed_timestamps.len() <= 2 {
+        return vec![];
+    }
+
+    if are_timestamps_regular(uncompressed_timestamps.values()) {
+        // Compress timestamps for a regular time series as a zero bit followed
+        // by the segment's length as an integer with all prefix zeros stripped.
+        let length = uncompressed_timestamps.len();
+        let leading_zero_bits = length.leading_zeros() as usize;
+        let number_of_bits_to_write = (mem::size_of_val(&length) * 8 - leading_zero_bits) + 1;
+        let number_of_bytes_to_write = (number_of_bits_to_write as f64 / 8.0).ceil() as usize;
+
+        let sampling_interval_bytes = length.to_be_bytes();
+        let bytes_index_first_byte = sampling_interval_bytes.len() - number_of_bytes_to_write;
+        sampling_interval_bytes[bytes_index_first_byte..].to_vec()
+    } else {
+        // Compress timestamps for an irregular time series as a one bit and
+        // then the timestamps encoded using Gorilla's compression method.
+        let mut compressed_timestamps = BitVecBuilder::new();
+        compressed_timestamps.append_a_one_bit();
+
+        // Store the second timestamp as a delta using 14 bits.
+        // TODO: remove the casts when refactoring the query engine to use unsigned.
+        let mut last_delta = uncompressed_timestamps.value(1) - uncompressed_timestamps.value(0);
+        compressed_timestamps.append_bits(last_delta as u32, 14); // 14-bit delta is max four hours.
+
+        // Encode the timestamps from the third timestamp to the second to last.
+        // A delta of delta is computed and then encoded in buckets of different
+        // sizes. Assumes that the delta of delta can fit in at most 32 bits.
+        let mut last_timestamp = uncompressed_timestamps.value(1);
+        for timestamp in &uncompressed_timestamps.values()[2..uncompressed_timestamps.len() - 1] {
+            let delta = timestamp - last_timestamp;
+            let delta_of_delta = delta - last_delta;
+
+            match delta_of_delta {
+                0 => compressed_timestamps.append_a_zero_bit(),
+                -63..=64 => {
+                    compressed_timestamps.append_bits(0b10, 2);
+                    compressed_timestamps.append_bits(delta_of_delta as u32, 7);
+                }
+                -255..=256 => {
+                    compressed_timestamps.append_bits(0b110, 3);
+                    compressed_timestamps.append_bits(delta_of_delta as u32, 9);
+                }
+                -2047..=2048 => {
+                    compressed_timestamps.append_bits(0b1110, 4);
+                    compressed_timestamps.append_bits(delta_of_delta as u32, 12);
+                }
+                _ => {
+                    compressed_timestamps.append_bits(0b1111, 4);
+                    compressed_timestamps.append_bits(delta_of_delta as u32, 32);
+                }
+            }
+            last_delta = delta;
+            last_timestamp = *timestamp;
+        }
+        compressed_timestamps.finish()
+    }
+}
+
+pub fn decompress_all_timestamps(
+    start_time: Timestamp,
+    end_time: Timestamp,
+    residual_timestamps: &[u8],
+) -> TimestampArray {
+    if residual_timestamps.is_empty() && start_time == end_time {
+        // Timestamps are assumed to be unique so the segment has one timestamp.
+        let mut timestamp_builder = TimestampBuilder::new(1);
+        timestamp_builder.append_value(start_time);
+        timestamp_builder
+    } else if residual_timestamps.is_empty() {
+        // Timestamps are assumed to be unique so the segment has two timestamp.
+        let mut timestamp_builder = TimestampBuilder::new(2);
+        timestamp_builder.append_value(start_time);
+        timestamp_builder.append_value(end_time);
+        timestamp_builder
+    } else if residual_timestamps[0] & 128 == 0 {
+        // The flag bit is zero, so only the segment's length is stored as an
+        // integer with all the prefix zeros stripped from the integer.
+        let mut bytes_to_decode = [0; 8];
+        bytes_to_decode[..residual_timestamps.len()].copy_from_slice(residual_timestamps);
+        let length = usize::from_le_bytes(bytes_to_decode);
+        let sampling_interval = (end_time - start_time) as usize / (length - 1);
+        let mut timestamp_builder = TimestampBuilder::new(length);
+        for timestamp in (start_time..=end_time).step_by(sampling_interval) {
+            timestamp_builder.append_value(timestamp);
+        }
+        timestamp_builder
+    } else {
+        // The flag bit is one, so the timestamps are compressed as
+        // delta-of-deltas stored using variable length binary encoding.
+        // TODO: remove the casts when refactoring the query engine to use unsigned.
+        let mut timestamp_builder = TimestampBuilder::new(1); // TODO: is pre-allocation possible?
+        timestamp_builder.append_value(start_time);
+
+        let mut bits = BitReader::try_new(residual_timestamps).unwrap();
+        let mut last_delta = bits.read_bits(14) as u32;
+        let mut timestamp = (start_time + last_delta as i64);
+
+        // Check if the flag is 0, 10, 110, 1110, or 1111.
+        let mut leading_one_bits = 0;
+        while bits.read_bit() && leading_one_bits < 4 {
+            leading_one_bits += 1;
+        }
+
+        // TODO: return if stream is empty, currently bits.read_bit() overflows
+        // if last bit is one but last bit cannot be always be zero as it would
+        // indicate a duplicate timestamp.
+
+        // TODO: Iterate until end of BitReader.
+        let current_delta = match leading_one_bits {
+            0 => last_delta,                                    // Flag is 0.
+            1 => read_and_decode_delta_of_delta(&mut bits, 7),  // Flag is 10.
+            2 => read_and_decode_delta_of_delta(&mut bits, 9),  // Flag is 110.
+            3 => read_and_decode_delta_of_delta(&mut bits, 12), // Flag is 1110.
+            4 => bits.read_bits(32),                            // Flag is 1111.
+            _ => panic!("Unknown encoding of timestamps"),
+        };
+
+        timestamp += current_delta as i64;
+        timestamp_builder.append_value(timestamp);
+
+        timestamp_builder.append_value(end_time);
+        timestamp_builder
+    }
+    .finish()
+}
+
+/// Return `true` if the timestamps in `uncompressed_timestamps` follow a
+/// regular sampling interval, otherwise `false`.
+fn are_timestamps_regular(uncompressed_timestamps: &[Timestamp]) -> bool {
+    if uncompressed_timestamps.len() < 2 {
+        return true;
+    }
+
+    // Unwrap is safe as uncompressed_timestamps has at least two timestamps.
+    let expected_sampling_interval = uncompressed_timestamps[1] - uncompressed_timestamps[0];
+    let mut uncompressed_timestamps = uncompressed_timestamps.iter();
+    let mut previous_timestamp = uncompressed_timestamps.next().unwrap();
+
+    while let Some(current_timestamp) = uncompressed_timestamps.next() {
+        if current_timestamp - previous_timestamp != expected_sampling_interval {
+            return false;
+        }
+        previous_timestamp = current_timestamp;
+    }
+    true
+}
+
+fn read_and_decode_delta_of_delta(bits: &mut BitReader, bits_to_read: u8) -> u32 {
+    let encoded_delta_of_delta = bits.read_bits(bits_to_read);
+    if (encoded_delta_of_delta > (1 << (bits_to_read - 1))) {
+        encoded_delta_of_delta - (1 << bits_to_read)
+    } else {
+        encoded_delta_of_delta
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests for compress_residual_timestamps() and decompress_all_timestamps().
+    #[test]
+    fn compress_timestamps_for_time_series_with_zero_one_or_two_timestamps() {
+        let mut uncompressed_timestamps_builder = TimestampBuilder::new(3);
+
+        uncompressed_timestamps_builder.append_slice(&[]);
+        assert!(compress_residual_timestamps(&uncompressed_timestamps_builder.finish()).is_empty());
+
+        uncompressed_timestamps_builder.append_slice(&[100]);
+        assert!(compress_residual_timestamps(&uncompressed_timestamps_builder.finish()).is_empty());
+
+        uncompressed_timestamps_builder.append_slice(&[100, 300]);
+        assert!(compress_residual_timestamps(&uncompressed_timestamps_builder.finish()).is_empty());
+    }
+
+    #[test]
+    fn compress_and_decompress_timestamps_for_a_regular_time_series() {
+        let uncompressed_timestamps = &[100, 200, 300, 400, 500, 600, 700, 800];
+        let mut uncompressed_timestamps_builder =
+            TimestampBuilder::new(uncompressed_timestamps.len());
+        uncompressed_timestamps_builder.append_slice(uncompressed_timestamps);
+        let uncompressed_timestamps = uncompressed_timestamps_builder.finish();
+
+        let compressed = compress_residual_timestamps(&uncompressed_timestamps);
+        assert!(!compressed.is_empty());
+        let decompressed = decompress_all_timestamps(
+            uncompressed_timestamps.value(0),
+            uncompressed_timestamps.value(uncompressed_timestamps.len() - 1),
+            compressed.as_slice(),
+        );
+        assert_eq!(uncompressed_timestamps, decompressed);
+    }
+
+    #[test]
+    fn compress_and_decompress_timestamps_for_an_irregular_time_series() {
+        let uncompressed_timestamps = &[100, 150, 300, 350, 700, 750, 1500];
+        let mut uncompressed_timestamps_builder =
+            TimestampBuilder::new(uncompressed_timestamps.len());
+        uncompressed_timestamps_builder.append_slice(uncompressed_timestamps);
+        let uncompressed_timestamps = uncompressed_timestamps_builder.finish();
+
+        let compressed = compress_residual_timestamps(&uncompressed_timestamps);
+        assert!(!compressed.is_empty());
+        let decompressed = decompress_all_timestamps(
+            uncompressed_timestamps.value(0),
+            uncompressed_timestamps.value(uncompressed_timestamps.len() - 1),
+            compressed.as_slice(),
+        );
+        assert_eq!(uncompressed_timestamps, decompressed);
+    }
+
+    // Tests for are_timestamps_regular().
+    #[test]
+    fn test_time_series_with_one_data_point_is_regular() {
+        assert!(are_timestamps_regular(&[100]));
+    }
+
+    fn test_time_series_with_two_data_points_is_regular() {
+        assert!(are_timestamps_regular(&[100, 200]));
+    }
+
+    #[test]
+    fn test_regular_time_series_is_regular() {
+        assert!(are_timestamps_regular(&[100, 200, 300, 400, 500, 600, 700]))
+    }
+
+    #[test]
+    fn test_irregular_time_series_is_irregular() {
+        assert!(!are_timestamps_regular(&[
+            100, 150, 300, 350, 700, 750, 1500
+        ]))
+    }
+}

--- a/server/src/models/timestamps.rs
+++ b/server/src/models/timestamps.rs
@@ -248,7 +248,10 @@ fn decompress_all_irregular_timestamps(
             2 => read_decode_and_compute_delta(&mut bits, 9, last_delta),  // Flag is 110.
             3 => read_decode_and_compute_delta(&mut bits, 12, last_delta), // Flag is 1110.
             4 => last_delta + bits.read_bits(32),                          // Flag is 1111.
-            _ => panic!("Unknown encoding of timestamps."),
+            _ => panic!(
+                "Unknown timestamp encoding with {} leading one bits.",
+                leading_one_bits
+            ),
         };
 
         timestamp += delta as i64;

--- a/server/src/models/timestamps.rs
+++ b/server/src/models/timestamps.rs
@@ -45,7 +45,7 @@ use crate::types::{Timestamp, TimestampArray, TimestampBuilder};
 /// number of data points in the segment with prefix zeros stripped, and if it
 /// is irregular, the timestamp's delta-of-delta is computed and then encoded
 /// using a variable length binary encoding. The first bit that is written to
-/// the returned [`Vec`] is flag that indicates if the time series was regular
+/// the returned [`Vec`] is a flag that indicates if the time series was regular
 /// (a zero bit is written) or if it was irregular (a one bit is written).
 pub fn compress_residual_timestamps(uncompressed_timestamps: &TimestampArray) -> Vec<u8> {
     // Nothing to do as the segments already store the first and last timestamp.

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -41,7 +41,7 @@ pub type Value = std::primitive::f32;
 pub type ArrowValue = datafusion::arrow::datatypes::Float32Type;
 #[cfg(test)] // Proptest is a development dependency.
 pub mod tests {
-    // proptest::num::i64 is not a type and signed integer for compatibility with tables.rs.
+    // proptest::num::i64 is not a type. A signed integer is used for compatibility with tables.rs.
     pub use proptest::num::i64 as ProptestTimestamp;
 
     // proptest::num::f32 is not a type.

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -41,6 +41,9 @@ pub type Value = std::primitive::f32;
 pub type ArrowValue = datafusion::arrow::datatypes::Float32Type;
 #[cfg(test)] // Proptest is a development dependency.
 pub mod tests {
+    // proptest::num::i64 is not a type and signed integer for compatibility with tables.rs.
+    pub use proptest::num::i64 as ProptestTimestamp;
+
     // proptest::num::f32 is not a type.
     pub use proptest::num::f32 as ProptestValue;
 }


### PR DESCRIPTION
This PR adds support for compressing irregular time series by implementing optimized methods for compressing the timestamps of segments from both regular and irregular time series. As the PR also splits `gorilla.rs` into `gorilla.rs`, `timestamps.rs` and `bits.rs` it may be easier to review the changes made to `BitReader` and `BitVecBuilder` by looking at the individual commits.