### PR TITLE
Rename the binaries to modelardbd and modelardb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,43 +1273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mdb"
-version = "0.1.0"
-dependencies = [
- "arrow",
- "arrow-flight",
- "dirs",
- "rustyline",
- "serde_json",
- "tokio",
- "tonic",
-]
-
-[[package]]
-name = "mdbd"
-version = "0.1.0"
-dependencies = [
- "arrow-flight",
- "async-trait",
- "datafusion",
- "datafusion-expr",
- "datafusion-physical-expr",
- "futures",
- "log",
- "object_store",
- "paho-mqtt",
- "proptest",
- "rusqlite",
- "snmalloc-rs",
- "tempfile",
- "tokio",
- "tonic",
- "tracing",
- "tracing-futures",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1303,43 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "modelardb"
+version = "0.1.0"
+dependencies = [
+ "arrow",
+ "arrow-flight",
+ "dirs",
+ "rustyline",
+ "serde_json",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "modelardbd"
+version = "0.1.0"
+dependencies = [
+ "arrow-flight",
+ "async-trait",
+ "datafusion",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "futures",
+ "log",
+ "object_store",
+ "paho-mqtt",
+ "proptest",
+ "rusqlite",
+ "snmalloc-rs",
+ "tempfile",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
    * Debug Build: `cargo build`
    * Release Build: `cargo build --release`
    * Run Tests: `cargo test`
-   * Run Server: `cargo run --bin mdbd path_to_data_folder`
-   * Run Client: `cargo run --bin mdb [server_address] [query_file]`
-5. Move `mdbd` and `mdb` from the `target` directory to any directory.
+   * Run Server: `cargo run --bin modelardbd path_to_data_folder`
+   * Run Client: `cargo run --bin modelardb [server_address] [query_file]`
+5. Move `modelardbd` and `modelardb` from the `target` directory to any directory.
 
 ## Development
 All code must be formatted according to the [Rust Style Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md)

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mdb"
+name = "modelardb"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -136,7 +136,7 @@ fn repl(rt: Runtime, mut fsc: FlightServiceClient<Channel>) -> Result<()> {
     let mut editor = Editor::<ClientHelper>::new()?;
     let table_names = retrieve_table_names(&rt, &mut fsc)?;
     editor.set_helper(Some(ClientHelper::new(table_names)));
-    let history_file_name = ".mdb_history";
+    let history_file_name = ".modelardb_history";
     if let Some(mut home) = dirs::home_dir() {
         home.push(history_file_name);
         let _ = editor.load_history(&home);

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mdbd"
+name = "modelardbd"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"

--- a/server/src/ingestion.rs
+++ b/server/src/ingestion.rs
@@ -100,7 +100,7 @@ impl Ingestor {
         let mut stream = client.get_stream(25);
 
         // Define the last will and testament message to notify other clients about disconnect.
-        let lwt = mqtt::Message::new("mdb_lwt", "ModelarDB lost connection", mqtt::QOS_1);
+        let lwt = mqtt::Message::new("modelardbd_lwt", "ModelarDB lost connection", mqtt::QOS_1);
 
         let connect_options = mqtt::ConnectOptionsBuilder::new()
             // An interval of 30 seconds is used since it is the standard in paho_mqtt examples.


### PR DESCRIPTION
This PR renames the binaries from `mdbd` and `mdb` to `modelardbd` and `modelardb`.