### PR TITLE
Remove cmake as an extra external dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,6 +1999,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80756c9f5dacaa9ff49afddb77ea18e80013228128ced3c2162f13306a225dd7"
 dependencies = [
+ "cc",
  "cmake",
 ]
 

--- a/README.md
+++ b/README.md
@@ -37,30 +37,25 @@ if a limitation of ModelarDB prevents it from being used in a particular domain.
 The following commands are for Ubuntu Server. However, equivalent commands should work for other Linux distributions.
 
 1. Install [build-essential](https://packages.ubuntu.com/jammy/build-essential): `sudo apt install build-essential`
-2. Install [CMake](https://cmake.org/): `sudo apt install cmake`
 
 ### macOS
 1. Install the Xcode Command Line Developer Tools: `xcode-select --install`
-2. Install [CMake](https://cmake.org/) and follow the _"How to Install For Command Line Use"_ menu item.
 
 ### Windows
 1. Install a supported version of [Visual Studio](https://visualstudio.microsoft.com/vs/older-downloads/) with Visual C++:
    * Visual Studio 2017 ([Supported](https://github.com/microsoft/snmalloc/blob/main/docs/BUILDING.md#building-on-windows))
    * Visual Studio 2019 ([Supported](https://github.com/microsoft/snmalloc/issues/525#issuecomment-1128901104))
    * Note that Visual Studio 2022 is **not** supported.
-2. Install [CMake](https://cmake.org/) and select one of the following options during installation:
-   * _Add CMake to the system PATH for all users_
-   * _Add CMake to the system PATH for current user_
 
 ### All
-3. Install the latest stable [Rust Toolchain](https://rustup.rs/).
-4. Build, test, and run the system using Cargo:
+2. Install the latest stable [Rust Toolchain](https://rustup.rs/).
+3. Build, test, and run the system using Cargo:
    * Debug Build: `cargo build`
    * Release Build: `cargo build --release`
    * Run Tests: `cargo test`
    * Run Server: `cargo run --bin modelardbd path_to_data_folder`
    * Run Client: `cargo run --bin modelardb [server_address] [query_file]`
-5. Move `modelardbd` and `modelardb` from the `target` directory to any directory.
+4. Move `modelardbd` and `modelardb` from the `target` directory to any directory.
 
 ## Development
 All code must be formatted according to the [Rust Style Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0.3.23"
 arrow-flight = "20.0.0"
 tonic = "0.8.0"
 
-snmalloc-rs = "0.3.3"
+snmalloc-rs = { version = "0.3.3", features = ["build_cc"] }
 
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 


### PR DESCRIPTION
This PR replaces [CMake](https://cmake.org/) with the [cc crate](https://github.com/rust-lang/cc-rs) for building the C++ part of [snmalloc-rs](https://github.com/SchrodingerZhu/snmalloc-rs). This was made possible by the removal of the [paho-mqtt crate](https://github.com/eclipse/paho.mqtt.rust) since it required CMake.