### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,11 +85,11 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "arrow"
-version = "20.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a69495f06c8abb65b76a87be192a26fa724380d1f292d4e558a32afed9989"
+checksum = "c5936b4185aa57cb9790d8742aab22859045ce5cc6a3023796240cd101c19335"
 dependencies = [
- "ahash",
+ "ahash 0.8.0",
  "bitflags",
  "chrono",
  "comfy-table",
@@ -84,7 +97,6 @@ dependencies = [
  "flatbuffers",
  "half",
  "hashbrown",
- "hex",
  "indexmap",
  "lazy_static",
  "lexical-core",
@@ -93,15 +105,14 @@ dependencies = [
  "regex",
  "regex-syntax",
  "serde",
- "serde_derive",
  "serde_json",
 ]
 
 [[package]]
 name = "arrow-flight"
-version = "20.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167aace6e264593bd25099bd8c089db6eb4dfc6fff7979523de062531d0f4336"
+checksum = "660ed54d9d068c21281154fbf1d91905df679a81ba4a83f1742f48c40c91804f"
 dependencies = [
  "arrow",
  "base64",
@@ -359,6 +370,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f590d95d011aa80b063ffe3253422ed5aa462af4e9867d43ce8337562bac77c4"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
+dependencies = [
+ "getrandom",
+ "lazy_static",
+ "proc-macro-hack",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,11 +455,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430b3983c7164cb113f297f45b68a69893c212cb4b80a8aeb6a8069eb93f745e"
+checksum = "2aca80caa2b0f7fdf267799b8895ac8b6341ea879db6b1e2d361ec49b47bc676"
 dependencies = [
- "ahash",
+ "ahash 0.8.0",
  "arrow",
  "async-trait",
  "bytes",
@@ -462,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "594210b4819cc786d1a3dc7b17ff4f9b0c6ee522bcd0a4a52f80a41fd38d53c4"
+checksum = "7721fd550f6a28ad7235b62462aa51e9a43b08f8346d5cbe4d61f1e83f5df511"
 dependencies = [
  "arrow",
  "object_store",
@@ -476,11 +509,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91d4a86776ce8f7fe5df34955481d6fe77876dd278bf13098d6a1bdd3c24fb8"
+checksum = "2d81255d043dc594c0ded6240e8a9be6ce8d7c22777a5093357cdb97af3d29ce"
 dependencies = [
- "ahash",
+ "ahash 0.8.0",
  "arrow",
  "datafusion-common",
  "sqlparser",
@@ -488,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360f86f7dc943ca8e0da39982febac0a0fc0329d7ee58ea046438c9fed6dfec8"
+checksum = "71b39f8c75163691fff72b4a71816ad5a912e7c6963ee55f29ed1910b5a6993f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -504,11 +537,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a465299f2eeb2741b33777b42f607fe56458e137d0d7b80f69be72e771a48b81"
+checksum = "109c4138220a109feafb63bf05418b86b17a42ece4bf047c38e4fd417572a9f7"
 dependencies = [
- "ahash",
+ "ahash 0.8.0",
  "arrow",
  "blake2",
  "blake3",
@@ -529,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-row"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "959a42a1f35c8fa1b47698df6995ab5ae8477e81c9c42852476666aeac4f80b7"
+checksum = "87a178fc0fd7693d9c9f608f7b605823eb982c6731ede0cccd99e2319cacabbc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -541,11 +574,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69404e8774fe2c7d64998e94d856f32d3a908f9dc7215ce01e09895f13b4b62"
+checksum = "148cb56e7635faff3b16019393c49b988188c3fdadd1ca90eadb322a80aa1128"
 dependencies = [
- "ahash",
+ "ahash 0.8.0",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -732,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -747,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -757,15 +790,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -774,15 +807,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -791,21 +824,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -880,7 +913,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -906,12 +939,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1255,7 +1282,6 @@ dependencies = [
  "arrow-flight",
  "dirs",
  "rustyline",
- "serde_json",
  "tokio",
  "tonic",
 ]
@@ -1417,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3845781c5ecf37b3e3610df73fff11487591eba423a987e1b21bb4d389c326"
+checksum = "2168fee79ee3e7695905bc3a48777d807f82d956f821186fa7a2601c1295a73e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1484,15 +1510,14 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "20.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f0af698fcf8d1d9f2971766ebef25821ffe8c39c91837c276dcd97e075d950"
+checksum = "474c423be6f10921adab3b94b42ec7fe87c1b87e1360dee150976caee444224f"
 dependencies = [
- "ahash",
+ "ahash 0.8.0",
  "arrow",
  "base64",
  "brotli",
- "byteorder",
  "bytes",
  "chrono",
  "flate2",
@@ -1594,6 +1619,12 @@ dependencies = [
  "proc-macro2",
  "syn",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -1900,6 +1931,9 @@ name = "serde"
 version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1918,7 +1952,6 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
- "indexmap",
  "itoa 1.0.2",
  "ryu",
  "serde",
@@ -2014,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.20.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c67d4d5de027da1da5a4ed4623f09ab5131d808364279a5f5abee5de9b8db3"
+checksum = "0beb13adabbdda01b63d595f38c8bfd19a361e697fd94ce0098a634077bc5b25"
 dependencies = [
  "log",
 ]
@@ -2141,6 +2174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,9 +2199,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2223,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498f271adc46acce75d66f639e4d35b31b2394c295c82496727dafa16d465dd2"
+checksum = "11cd56bdb54ef93935a6a79dbd1d91f1ebd4c64150fd61654031fd6b8b775c91"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,12 +6,9 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-arrow = "20.0.0"
-arrow-flight = "20.0.0"
-tonic = "0.8.0"
-tokio = "1.20.1"
+arrow = "22.0.0"
+arrow-flight = "22.0.0"
+tonic = "0.8.1"
+tokio = "1.21.1"
 rustyline = "10.0.0"
 dirs = "4.0.0"
-
-# Enable default features for serde_json as it cannot compile without std
-serde_json = { version = "1.0.83", features = ["preserve_order"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-datafusion = "11.0.0"
-datafusion-expr = "11.0.0"
-datafusion-physical-expr = "11.0.0"
-object_store = "0.4.0"
+datafusion = "12.0.0"
+datafusion-expr = "12.0.0"
+datafusion-physical-expr = "12.0.0"
+object_store = "0.5.0"
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same value
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }
@@ -17,13 +17,13 @@ tracing = { version = "0.1.36", features = ["max_level_debug", "release_max_leve
 tracing-subscriber = "0.3.15"
 tracing-futures = "0.2.5"
 
-tokio = { version = "1.20.1", features = ["rt-multi-thread"] }
+tokio = { version = "1.21.1", features = ["rt-multi-thread"] }
 
 async-trait = "0.1.57"
-futures = "0.3.23"
+futures = "0.3.24"
 
-arrow-flight = "20.0.0"
-tonic = "0.8.0"
+arrow-flight = "22.0.0"
+tonic = "0.8.1"
 
 snmalloc-rs = "0.3.3"
 

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -539,7 +539,7 @@ impl ModelTableMetadata {
         // -1 is stored at index 0 as time series ids starting at 1 is used for
         // lookup. Time series ids starting at 1 is used for compatibility with
         // the JVM-based version of ModelarDB.
-        let mut shifted_column = Int32Builder::new(column.len() + 1);
+        let mut shifted_column = Int32Builder::with_capacity(column.len() + 1);
         shifted_column.append_value(-1);
         shifted_column.append_slice(column);
         Ok(shifted_column.finish())

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -236,14 +236,14 @@ struct CompressedSegmentBatchBuilder {
 impl CompressedSegmentBatchBuilder {
     fn new(capacity: usize) -> Self {
         Self {
-            model_type_ids: UInt8Builder::new(capacity),
-            timestamps: BinaryBuilder::new(capacity),
-            start_times: TimestampBuilder::new(capacity),
-            end_times: TimestampBuilder::new(capacity),
-            values: BinaryBuilder::new(capacity),
-            min_values: ValueBuilder::new(capacity),
-            max_values: ValueBuilder::new(capacity),
-            error: Float32Builder::new(capacity),
+            model_type_ids: UInt8Builder::with_capacity(capacity),
+            timestamps: BinaryBuilder::with_capacity(capacity, capacity),
+            start_times: TimestampBuilder::with_capacity(capacity),
+            end_times: TimestampBuilder::with_capacity(capacity),
+            values: BinaryBuilder::with_capacity(capacity, capacity),
+            min_values: ValueBuilder::with_capacity(capacity),
+            max_values: ValueBuilder::with_capacity(capacity),
+            error: Float32Builder::with_capacity(capacity),
         }
     }
 
@@ -423,9 +423,9 @@ mod tests {
         timestamps: &[Timestamp],
         values: &[Value],
     ) -> (TimestampArray, ValueArray) {
-        let mut timestamps_builder = TimestampBuilder::new(timestamps.len());
+        let mut timestamps_builder = TimestampBuilder::with_capacity(timestamps.len());
         timestamps_builder.append_slice(timestamps);
-        let mut values_builder = ValueBuilder::new(values.len());
+        let mut values_builder = ValueBuilder::with_capacity(values.len());
         values_builder.append_slice(values);
         (timestamps_builder.finish(), values_builder.finish())
     }

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -200,7 +200,7 @@ fn decompress_values_to_array(
     model: &[u8],
 ) -> ValueArray {
     let length = models::length(start_time, end_time, sampling_interval);
-    let mut value_builder = ValueBuilder::new(length as usize);
+    let mut value_builder = ValueBuilder::with_capacity(length as usize);
     decompress_values(
         start_time,
         end_time,
@@ -350,9 +350,9 @@ mod tests {
     fn test_grid(values in collection::vec(ProptestValue::ANY, 0..50)) {
         prop_assume!(!values.is_empty());
         let compressed_values = compress_values_using_gorilla(&values);
-        let mut time_series_ids_builder = TimeSeriesIdBuilder::new(10);
-        let mut timestamps_builder = TimestampBuilder::new(10);
-        let mut values_builder = ValueBuilder::new(10);
+        let mut time_series_ids_builder = TimeSeriesIdBuilder::with_capacity(10);
+        let mut timestamps_builder = TimestampBuilder::with_capacity(10);
+        let mut values_builder = ValueBuilder::with_capacity(10);
 
         grid(
             1,
@@ -388,7 +388,7 @@ mod tests {
     fn test_decode(values in collection::vec(ProptestValue::ANY, 0..50)) {
         prop_assume!(!values.is_empty());
         let compressed_values = compress_values_using_gorilla(&values);
-        let mut decompressed_values_builder = ValueBuilder::new(values.len());
+        let mut decompressed_values_builder = ValueBuilder::with_capacity(values.len());
         decompress_values(
             1,
             values.len() as i64,

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -325,9 +325,9 @@ mod tests {
     fn test_grid(value in ProptestValue::ANY) {
         let model = value.to_be_bytes();
         let sampling_interval: i64 = 60;
-        let mut time_series_ids = TimeSeriesIdBuilder::new(10);
-        let mut timestamps = TimestampBuilder::new(10);
-        let mut values = ValueBuilder::new(10);
+        let mut time_series_ids = TimeSeriesIdBuilder::with_capacity(10);
+        let mut timestamps = TimestampBuilder::with_capacity(10);
+        let mut values = ValueBuilder::with_capacity(10);
 
         grid(
             1,

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -558,9 +558,9 @@ mod tests {
         );
         let model = [slope.to_be_bytes(), intercept.to_be_bytes()].concat();
         let length = (((FINAL_TIMESTAMP - FIRST_TIMESTAMP) / SAMPLING_INTERVAL) + 1) as usize;
-        let mut time_series_ids = TimeSeriesIdBuilder::new(length);
-        let mut timestamps = TimestampBuilder::new(length);
-        let mut values = ValueBuilder::new(length);
+        let mut time_series_ids = TimeSeriesIdBuilder::with_capacity(length);
+        let mut timestamps = TimestampBuilder::with_capacity(length);
+        let mut values = ValueBuilder::with_capacity(length);
 
         grid(
             1,

--- a/server/src/models/timestamps.rs
+++ b/server/src/models/timestamps.rs
@@ -159,12 +159,12 @@ pub fn decompress_all_timestamps(
 ) -> TimestampArray {
     if residual_timestamps.is_empty() && start_time == end_time {
         // Timestamps are assumed to be unique so the segment has one timestamp.
-        let mut timestamp_builder = TimestampBuilder::new(1);
+        let mut timestamp_builder = TimestampBuilder::with_capacity(1);
         timestamp_builder.append_value(start_time);
         timestamp_builder.finish()
     } else if residual_timestamps.is_empty() {
         // Timestamps are assumed to be unique so the segment has two timestamp.
-        let mut timestamp_builder = TimestampBuilder::new(2);
+        let mut timestamp_builder = TimestampBuilder::with_capacity(2);
         timestamp_builder.append_value(start_time);
         timestamp_builder.append_value(end_time);
         timestamp_builder.finish()
@@ -191,7 +191,7 @@ fn decompress_all_regular_timestamps(
 
     let length = usize::from_le_bytes(bytes_to_decode);
     let sampling_interval = (end_time - start_time) as usize / (length - 1);
-    let mut timestamp_builder = TimestampBuilder::new(length);
+    let mut timestamp_builder = TimestampBuilder::with_capacity(length);
 
     for timestamp in (start_time..=end_time).step_by(sampling_interval) {
         timestamp_builder.append_value(timestamp);
@@ -213,7 +213,8 @@ fn decompress_all_irregular_timestamps(
     // `timestamp_builder` cannot be perfectly pre-allocated. However, as the
     // Gorilla model type is bounded by `compression::GORILLA_MAXIMUM_LENGTH`,
     // this generally becomes the predominant length of the compressed segments.
-    let mut timestamp_builder = TimestampBuilder::new(compression::GORILLA_MAXIMUM_LENGTH);
+    let mut timestamp_builder =
+        TimestampBuilder::with_capacity(compression::GORILLA_MAXIMUM_LENGTH);
 
     // Add the first timestamp stored as `start_time` in the segment.
     timestamp_builder.append_value(start_time);
@@ -288,7 +289,7 @@ mod tests {
     // Tests for compress_residual_timestamps() and decompress_all_timestamps().
     #[test]
     fn compress_timestamps_for_time_series_with_zero_one_or_two_timestamps() {
-        let mut uncompressed_timestamps_builder = TimestampBuilder::new(3);
+        let mut uncompressed_timestamps_builder = TimestampBuilder::with_capacity(3);
 
         uncompressed_timestamps_builder.append_slice(&[]);
         assert!(compress_residual_timestamps(&uncompressed_timestamps_builder.finish()).is_empty());
@@ -314,7 +315,7 @@ mod tests {
 
     fn compress_and_decompress_timestamps_for_a_time_series(uncompressed_timestamps: &[Timestamp]) {
         let mut uncompressed_timestamps_builder =
-            TimestampBuilder::new(uncompressed_timestamps.len());
+            TimestampBuilder::with_capacity(uncompressed_timestamps.len());
         uncompressed_timestamps_builder.append_slice(uncompressed_timestamps);
         let uncompressed_timestamps = uncompressed_timestamps_builder.finish();
 

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -312,7 +312,7 @@ pub mod test_util {
     use crate::storage::StorageEngine;
     use crate::types::{TimestampArray, ValueArray};
 
-    pub const COMPRESSED_SEGMENT_SIZE: usize = 2032;
+    pub const COMPRESSED_SEGMENT_SIZE: usize = 2176;
 
     /// Return a [`RecordBatch`] that only has a single column, and therefore does not match the
     /// compressed segment schema.

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -62,8 +62,8 @@ pub struct SegmentBuilder {
 impl SegmentBuilder {
     pub fn new() -> Self {
         Self {
-            timestamps: TimestampBuilder::new(BUILDER_CAPACITY),
-            values: ValueBuilder::new(BUILDER_CAPACITY),
+            timestamps: TimestampBuilder::with_capacity(BUILDER_CAPACITY),
+            values: ValueBuilder::with_capacity(BUILDER_CAPACITY),
         }
     }
 

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -514,10 +514,10 @@ impl GridStream {
             .downcast_ref::<StringArray>()
             .unwrap();
 
-        let mut members = StringBuilder::new(level.iter().map(|s| s.unwrap().len()).sum());
+        let mut members =
+            StringBuilder::with_capacity(tids.len(), level.iter().map(|s| s.unwrap().len()).sum());
         for tid in tids {
-            members
-                .append_value(level.value(tid.unwrap() as usize));
+            members.append_value(level.value(tid.unwrap() as usize));
         }
         Arc::new(members.finish())
     }


### PR DESCRIPTION
This pull request primarily updates Apache Arrow DataFusion to [v12.0.0](https://crates.io/crates/datafusion/12.0.0) and fixes all known breaking changes. New versions of Apache Arrow DataFusion usually have breaking changes, so updating to each new release ensures that the number of changes required does not accumulate. The breaking changes in this PR are mainly the split of [`PrimitiveBuilder::new(capacity: usize)` ](https://docs.rs/arrow/21.0.0/arrow/array/struct.PrimitiveBuilder.html#method.new) into [`PrimitiveBuilder::new()`](https://docs.rs/arrow/latest/arrow/array/struct.PrimitiveBuilder.html#method.new) and [`PrimitiveBuilder::with_capacity(capacity: usize)`](https://docs.rs/arrow/latest/arrow/array/struct.PrimitiveBuilder.html#method.with_capacity). Unfortunately, [Apache Arrow DataFusion v12.0.0](https://crates.io/crates/datafusion/12.0.0) depends on [Apache Arrow v22.0.0](https://crates.io/crates/arrow/22.0.0) which [does not include](https://github.com/apache/arrow-rs/blob/22.0.0/arrow-flight/src/arrow.flight.protocol.rs#L74) the updated [`SchemaResult`](https://github.com/apache/arrow-rs/blob/master/arrow-flight/src/arrow.flight.protocol.rs#L74) which is requied to remove the workaround added by [PR 26](https://github.com/ModelarData/ModelarDB-RS/pull/26). @CGodiksen please double check that changing the value of [`COMPRESSED_SEGMENT_SIZE`](https://github.com/ModelarData/ModelarDB-RS/blob/18a6a7149512fa9e3a90467735ab7a45bb9fae0a/server/src/storage/mod.rs#L315) actually fixed a test and did not hide a bug.