### PR TITLE
Compressing directly from storage engine

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -80,7 +80,7 @@ fn main() -> Result<(), String> {
         })?;
         let runtime = Runtime::new().unwrap();
         let mut session = create_session_context();
-        let storage_engine = StorageEngine::new(data_folder_path.clone());
+        let storage_engine = StorageEngine::new(data_folder_path.clone(), true);
 
         // Set up the metadata tables used for model tables.
         create_model_table_metadata_tables(data_folder_path.as_path()).map_err(|error| {

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -29,7 +29,7 @@ use crate::types::Timestamp;
 
 /// Signed integer since compressed data is inserted first and the remaining bytes are checked after.
 /// This means that the remaining bytes can be negative briefly until compressed data is saved to disk.
-const COMPRESSED_RESERVED_MEMORY_IN_BYTES: isize = 5000;
+const COMPRESSED_RESERVED_MEMORY_IN_BYTES: isize = 1000000;
 
 /// Stores data points compressed as models in memory to batch compressed data before saving it to
 /// Apache Parquet files.

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -189,6 +189,7 @@ mod tests {
 
     use tempfile::{tempdir, TempDir};
 
+    use crate::get_array;
     use crate::storage::test_util;
     use crate::types::TimestampArray;
 
@@ -313,8 +314,8 @@ mod tests {
         assert_eq!(files.len(), 1);
 
         // The file should have the first start time and the last end time as the file name.
-        let start_times: &TimestampArray = segment.column(2).as_any().downcast_ref().unwrap();
-        let end_times: &TimestampArray = segment.column(3).as_any().downcast_ref().unwrap();
+        let start_times = get_array!(segment, 2, TimestampArray);
+        let end_times = get_array!(segment, 3, TimestampArray);
         let expected_file_path = format!(
             "{}/compressed/{}-{}.parquet",
             KEY,

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -81,7 +81,14 @@ impl StorageEngine {
         model_table: &NewModelTableMetadata,
         data_points: &RecordBatch
     ) -> Result<(), String> {
-        self.uncompressed_data_manager.insert_data_points(model_table, data_points)
+        // TODO: When the compression component is changed, just insert the data points.
+        let compressed_segments = self.uncompressed_data_manager.insert_data_points(model_table, data_points)?;
+
+        for (key, segment) in compressed_segments {
+            self.compressed_data_manager.insert_compressed_segment(key, segment);
+        };
+
+        Ok(())
     }
 
     /// Retrieve the oldest [`FinishedSegment`] from [`UncompressedDataManager`] and return it.

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -67,9 +67,9 @@ pub struct StorageEngine {
 }
 
 impl StorageEngine {
-    pub fn new(data_folder_path: PathBuf) -> Self {
+    pub fn new(data_folder_path: PathBuf, compress_directly: bool) -> Self {
         Self {
-            uncompressed_data_manager: UncompressedDataManager::new(data_folder_path.clone()),
+            uncompressed_data_manager: UncompressedDataManager::new(data_folder_path.clone(), compress_directly),
             compressed_data_manager: CompressedDataManager::new(data_folder_path),
         }
     }
@@ -378,7 +378,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
 
         let data_folder_path = temp_dir.path().to_path_buf();
-        (temp_dir, StorageEngine::new(data_folder_path))
+        (temp_dir, StorageEngine::new(data_folder_path, false))
     }
 
     // Tests for writing and reading Apache Parquet files.

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -249,7 +249,6 @@ impl StorageEngine {
 mod tests {
     use super::*;
     use std::path::PathBuf;
-    use std::time::Duration;
 
     use tempfile::{tempdir, TempDir};
 

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -253,6 +253,7 @@ mod tests {
 
     use tempfile::{tempdir, TempDir};
 
+    use crate::get_array;
     use crate::types::TimestampArray;
 
     // Tests for get_compressed_files().
@@ -286,7 +287,7 @@ mod tests {
 
         // If we have a start time after the first segments ends, only the file from the second
         // segment should be retrieved.
-        let end_times: &TimestampArray = segment_1.column(3).as_any().downcast_ref().unwrap();
+        let end_times = get_array!(segment_1, 3, TimestampArray);
         let start_time = Some(end_times.value(end_times.len() - 1) + 100);
 
         let result = storage_engine.get_compressed_files(&[1, 2], start_time, None);
@@ -305,7 +306,7 @@ mod tests {
 
         // If we have an end time before the second segment starts, only the file from the first
         // segment should be retrieved.
-        let start_times: &TimestampArray = segment_2.column(2).as_any().downcast_ref().unwrap();
+        let start_times = get_array!(segment_2, 2, TimestampArray);
         let end_time = Some(start_times.value(1) - 100);
 
         let result = storage_engine.get_compressed_files(&[1, 2], None, end_time);
@@ -327,8 +328,8 @@ mod tests {
 
         // If we have a start time after the first segment ends and an end time before the fourth
         // segment starts, only the files from the second and third segment should be retrieved.
-        let end_times: &TimestampArray = segment_1.column(3).as_any().downcast_ref().unwrap();
-        let start_times: &TimestampArray = segment_4.column(2).as_any().downcast_ref().unwrap();
+        let end_times = get_array!(segment_1, 3, TimestampArray);
+        let start_times = get_array!(segment_4, 2, TimestampArray);
 
         let start_time = Some(end_times.value(end_times.len() - 1) + 100);
         let end_time = Some(start_times.value(1) - 100);

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -29,6 +29,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::parquet::errors::ParquetError;
 use tracing::info;
 
+use crate::get_array;
 use crate::storage::{StorageEngine, BUILDER_CAPACITY};
 use crate::types::{Timestamp, TimestampArray, TimestampBuilder, Value, ValueBuilder};
 
@@ -169,7 +170,7 @@ impl SpilledSegment {
         fs::create_dir_all(complete_folder_path.as_path());
 
         // Create a path that uses the first timestamp as the filename.
-        let timestamps: &TimestampArray = segment.column(0).as_any().downcast_ref().unwrap();
+        let timestamps = get_array!(segment, 0, TimestampArray);
         let file_name = format!("{}.parquet", timestamps.value(0));
         let file_path = complete_folder_path.join(file_name);
 

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 
 use datafusion::arrow::record_batch::RecordBatch;
 
+use crate::get_array;
 use crate::storage::StorageEngine;
 use crate::types::TimestampArray;
 
@@ -77,8 +78,8 @@ impl CompressedTimeSeries {
 
         // Create a path that uses the first start timestamp and the last end timestamp as the file
         // name to better support pruning data that is too new or too old when executing a specific query.
-        let start_times: &TimestampArray = batch.column(2).as_any().downcast_ref().unwrap();
-        let end_times: &TimestampArray = batch.column(3).as_any().downcast_ref().unwrap();
+        let start_times = get_array!(batch, 2, TimestampArray);
+        let end_times = get_array!(batch, 3, TimestampArray);
 
         let file_name = format!(
             "{}-{}.parquet",
@@ -150,8 +151,8 @@ mod tests {
         time_series.save_to_apache_parquet(temp_dir.path());
 
         // Data should be saved to a file with the first start time and last end time as the file name.
-        let start_times: &TimestampArray = segment.column(2).as_any().downcast_ref().unwrap();
-        let end_times: &TimestampArray = segment.column(3).as_any().downcast_ref().unwrap();
+        let start_times = get_array!(segment, 2, TimestampArray);
+        let end_times = get_array!(segment, 3, TimestampArray);
         let file_path = format!(
             "compressed/{}-{}.parquet",
             start_times.value(0),

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -61,7 +61,7 @@ impl UncompressedDataManager {
             finished_queue: VecDeque::new(),
             tag_value_hashes: HashMap::new(),
             uncompressed_remaining_memory_in_bytes: UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES,
-            compress_directly
+            compress_directly,
         }
     }
 
@@ -149,7 +149,7 @@ impl UncompressedDataManager {
                 // TODO: When the compression component is changed, just insert the data points.
                 // unwrap() is safe to use since the timestamps array cannot contain null values.
                 if let Some(segment) = self.insert_data_point(key, timestamp.unwrap(), value) {
-                    compressed_segments.push((key, segment))
+                    compressed_segments.push((key, segment));
                 };
             }
         }
@@ -250,9 +250,9 @@ impl UncompressedDataManager {
                 //       should be changed to queue the segment and let the compression component
                 //       retrieve the finished segment and insert it back when compressed.
                 if self.compress_directly {
-                    return Some(self.compress_full_segment(full_segment))
+                    return Some(self.compress_full_segment(full_segment));
                 } else {
-                    self.enqueue_segment(key, full_segment)
+                    self.enqueue_segment(key, full_segment);
                 }
             }
         } else {

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -61,7 +61,6 @@ impl UncompressedDataManager {
         }
     }
 
-    // TODO: Use the new macro for downcasting the arrays.
     // TODO: When the compression component is changed, this function should return Ok or Err.
     /// Parse `data_points` and insert it into the in-memory buffer. The data points are first parsed
     /// into multiple univariate time series based on `model_table`. These individual time series

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -244,7 +244,7 @@ impl UncompressedDataManager {
                 info!("Segment is full, moving it to the queue of finished segments.");
 
                 // Since this is only reachable if the segment exists in the HashMap, unwrap is safe to use.
-                let mut full_segment = self.uncompressed_data.remove(&key).unwrap();
+                let full_segment = self.uncompressed_data.remove(&key).unwrap();
 
                 // TODO: Currently we directly compress a segment when it is finished. This
                 //       should be changed to queue the segment and let the compression component
@@ -302,12 +302,12 @@ impl UncompressedDataManager {
         // unwrap() is safe to use since the error bound is not negative, infinite, or NAN.
         let error_bound = ErrorBound::try_new(0.0).unwrap();
 
-        // unwrap() is safe to use
+        // unwrap() is safe to use since get_record_batch() can only fail for spilled segments.
         let data_points = segment_builder.get_record_batch().unwrap();
         let uncompressed_timestamps = get_array!(data_points, 0, TimestampArray);
         let uncompressed_values = get_array!(data_points, 1, ValueArray);
 
-        // unwrap() is safe to use since timestamps and values have the same length.
+        // unwrap() is safe to use since uncompressed_timestamps and uncompressed_values have the same length.
         let compressed_segments = compression::try_compress(
             &uncompressed_timestamps,
             &uncompressed_values,


### PR DESCRIPTION
This PR includes a minor change to the storage engine that makes it so we instead of queuing finished segments and making them available for retrieval, now just compress the segment directly. In the future this should be changed back and functionality should be added to a compression component that can dynamically allocate threads for compression. Each of these threads should retrieve finished segments from the storage engine and insert the compressed data back into the storage engine when done.

TODOs have been added to revert the storage engine when the above mentioned ideal functionality has been added. Finally, the PR contains a new field on the uncompressed data manager used to make the manager use the old functionality in the tests. This was only added to fix existing tests and thereby avoid changing a significant number of "broken" tests. 

As a minor thing this PR also uses the new `get_array!` macro wherever possible. 