### PR TITLE
Refactor query engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,26 +34,35 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "alloc-no-stdlib"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -67,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "arrayref"
@@ -166,9 +175,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.13"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
+checksum = "c9e3356844c4d6a6d6467b8da2cffb4a2820be256f50a3a386c9d152bab31043"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -178,7 +187,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "matchit",
  "memchr",
  "mime",
@@ -195,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
+checksum = "d9f0c0a60006f2a293d82d571f635042a72edf927539b7685bd62d361963839b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -205,6 +214,8 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -215,9 +226,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bit-set"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
  "bit-vec",
 ]
@@ -259,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
@@ -300,6 +311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,9 +324,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
@@ -328,14 +345,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "time",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -352,18 +371,18 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.45"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "comfy-table"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121d8a5b0346092c18a4b2fd6f620d7a06f0eb7ac0a45860939a0884bc579c56"
+checksum = "85914173c2f558d61613bfbbf1911f14e630895087a7ed2fafc0f5319e1536e7"
 dependencies = [
  "strum",
  "strum_macros",
@@ -399,10 +418,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.2"
+name = "core-foundation-sys"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -479,7 +504,7 @@ dependencies = [
  "log",
  "num_cpus",
  "object_store",
- "ordered-float 3.0.0",
+ "ordered-float 3.1.0",
  "parking_lot",
  "parquet",
  "paste",
@@ -502,7 +527,7 @@ checksum = "7721fd550f6a28ad7235b62462aa51e9a43b08f8346d5cbe4d61f1e83f5df511"
 dependencies = [
  "arrow",
  "object_store",
- "ordered-float 3.0.0",
+ "ordered-float 3.1.0",
  "parquet",
  "serde_json",
  "sqlparser",
@@ -553,7 +578,7 @@ dependencies = [
  "hashbrown",
  "lazy_static",
  "md-5",
- "ordered-float 3.0.0",
+ "ordered-float 3.1.0",
  "paste",
  "rand",
  "regex",
@@ -590,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -648,9 +673,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "endian-type"
@@ -703,9 +728,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -756,11 +781,10 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -855,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -882,9 +906,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -919,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452c155cb93fecdfb02a73dd57b5d8e442c2063bd7aac72f1bc5e4263a43086"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
  "hashbrown",
 ]
@@ -949,7 +973,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.2",
+ "itoa 1.0.3",
 ]
 
 [[package]]
@@ -971,9 +995,9 @@ checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -996,7 +1020,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1018,12 +1042,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.2.3"
+name = "iana-time-zone"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "3bbaead50122b06e9a973ac20bc7445074d99ad9a0a0654934876908a9cec82c"
 dependencies = [
- "matches",
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -1055,15 +1091,15 @@ checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -1076,17 +1112,26 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1161,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1184,9 +1229,9 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1203,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "lz4"
-version = "1.23.3"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edcb94251b1c375c459e5abe9fb0168c1c826c3370172684844f8f3f8d1a885"
+checksum = "7e9e2dd86df36ce760a60f6ff6ad526f7ba1f14ba0356f8254fb6905e6494df1"
 dependencies = [
  "libc",
  "lz4-sys",
@@ -1213,19 +1258,13 @@ dependencies = [
 
 [[package]]
 name = "lz4-sys"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7be8908e2ed6f31c02db8a9fa962f03e36c53fbfde437363eae3306b85d7e17"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
 dependencies = [
  "cc",
  "libc",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matchit"
@@ -1235,9 +1274,9 @@ checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "md-5"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
  "digest",
 ]
@@ -1256,9 +1295,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
 ]
@@ -1465,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "ordered-float"
@@ -1480,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bcbab4bfea7a59c2c0fe47211a1ac4e3e96bea6eb446d704f310bc5c732ae2"
+checksum = "98ffdb14730ed2ef599c65810c15b000896e21e8776b512de0db0c3d7335cc2a"
 dependencies = [
  "num-traits",
 ]
@@ -1548,15 +1587,15 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
@@ -1570,18 +1609,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1614,9 +1653,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6ffbe862780245013cb1c0a48c4e44b7d665548088f91f6b90876d0625e4c2"
+checksum = "a49e86d2c26a24059894a3afa13fd17d063419b05dfb83f06d9c3566060c3f5a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1630,9 +1669,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -1724,9 +1763,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -1764,9 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -1782,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -1848,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.7"
+version = "0.35.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51cc38aa10f6bbb377ed28197aa052aa4e2b762c22be9d3153d01822587e787"
+checksum = "af895b90e5c071badc3136fc10ff0bcfc98747eadbaf43ed8f214e07ba8f8477"
 dependencies = [
  "bitflags",
  "errno",
@@ -1862,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "rusty-fork"
@@ -1903,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "same-file"
@@ -1930,18 +1969,18 @@ checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1950,20 +1989,20 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1980,10 +2019,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.6"
+name = "signal-hook-registry"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
@@ -2039,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -2076,9 +2127,9 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2095,9 +2146,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2126,18 +2177,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2225,6 +2276,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",
@@ -2253,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2264,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2461,40 +2513,39 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 
@@ -2574,14 +2625,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "which"
-version = "4.2.5"
+name = "wasm-bindgen"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { version = "0.1.36", features = ["max_level_debug", "release_max_leve
 tracing-subscriber = "0.3.15"
 tracing-futures = "0.2.5"
 
-tokio = { version = "1.21.1", features = ["rt-multi-thread"] }
+tokio = { version = "1.21.1", features = ["rt-multi-thread", "signal"] }
 
 async-trait = "0.1.57"
 futures = "0.3.24"

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -389,7 +389,8 @@ impl ModelTableMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::datatypes::ArrowPrimitiveType;
+
+    use datafusion::arrow::datatypes::{ArrowPrimitiveType, Field};
 
     use crate::types::{ArrowTimestamp, ArrowValue};
 

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -27,7 +27,7 @@ use std::str;
 use std::sync::Arc;
 
 use arrow_flight::IpcMessage;
-use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
+use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Schema};
 use rusqlite::types::Type::Blob;
 use rusqlite::Connection;
 use tracing::{error, info, warn};

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -96,6 +96,11 @@ impl Catalog {
         })
     }
 
+    /// Normalize `table name` to allow direct comparisons between table names.
+    pub fn normalize_table_name(table_name: &str) -> String {
+        table_name.to_lowercase()
+    }
+
     /// If `dir_entry` is a table, the metadata required to query the table is
     /// added to `table_metadata`, if not the function returns without changing
     /// `table_metadata`. An [`Error`] is returned if `dir_entry` is not UTF-8.
@@ -109,13 +114,11 @@ impl Catalog {
         })?;
 
         // The extra let binding is required to create a longer lived value.
-        let file_name = dir_entry.file_name();
-        let file_name = file_name.to_str().ok_or_else(|| {
+        let file_or_folder_name = dir_entry.file_name();
+        let file_or_folder_name = file_or_folder_name.to_str().ok_or_else(|| {
             Error::new(ErrorKind::InvalidData, "File or folder name is not UTF-8.")
         })?;
-
-        // HACK: workaround for DataFusion converting table names to lowercase.
-        let normalized_file_or_folder_name = file_name.to_ascii_lowercase();
+        let normalized_file_or_folder_name = Catalog::normalize_table_name(&file_or_folder_name);
 
         // Check if the file or folder is the metadata database, so it can be
         // skipped without logging any errors, a table, or neither.

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -394,7 +394,7 @@ mod tests {
     use std::{fs, io::Write};
 
     use datafusion::arrow::datatypes::{ArrowPrimitiveType, Field};
-    use tempfile::{tempdir, TempDir};
+    use tempfile::tempdir;
 
     use crate::types::{ArrowTimestamp, ArrowValue};
 

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -596,48 +596,6 @@ mod tests {
 
     use crate::types::{ArrowTimestamp, ArrowValue};
 
-    // Tests for Catalog.
-    #[test]
-    fn test_empty_catalog_table_and_model_table_names() {
-        let catalog = Catalog {
-            data_folder_path: PathBuf::from(""),
-            table_metadata: vec![],
-            new_model_table_metadata: vec![],
-            model_table_metadata: vec![],
-        };
-        assert!(catalog.table_and_model_table_names().is_empty())
-    }
-
-    #[test]
-    fn test_catalog_table_and_model_table_names() {
-        let mut catalog = Catalog {
-            data_folder_path: PathBuf::from(""),
-            table_metadata: vec![],
-            new_model_table_metadata: vec![],
-            model_table_metadata: vec![],
-        };
-
-        catalog.table_metadata.push(TableMetadata {
-            name: "table".to_owned(),
-            path: "".to_owned(),
-        });
-
-        catalog
-            .model_table_metadata
-            .push(Arc::new(ModelTableMetadata {
-                name: "model_table".to_owned(),
-                segment_path: ObjectStorePath::parse("").unwrap(),
-                segment_file_legacy_schema: Arc::new(Schema::new(vec![])),
-                sampling_intervals: Int32Array::builder(0).finish(),
-                denormalized_dimensions: vec![],
-            }));
-
-        assert_eq!(
-            vec!("table", "model_table"),
-            catalog.table_and_model_table_names()
-        )
-    }
-
     // Tests for TableMetadata.
     #[test]
     fn test_table_metadata_zero_suffixes() {

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -98,7 +98,8 @@ impl Catalog {
     }
 
     /// If `dir_entry` is a table, the metadata required to query the table is
-    /// added to `table_metadata`. otherwise return
+    /// added to `table_metadata`, if not the function returns without changing
+    /// `table_metadata`. An `Error` is returned if `dir_entry` is not UTF-8.
     fn try_adding_table_metadata(
         dir_entry: &DirEntry,
         table_metadata: &mut Vec<TableMetadata>,

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -118,19 +118,6 @@ impl Catalog {
         })
     }
 
-    /// Return the name of all tables and model tables in the `Catalog`.
-    pub fn table_and_model_table_names(&self) -> Vec<String> {
-        let mut table_names: Vec<String> = vec![];
-        for table_metadata in &self.table_metadata {
-            table_names.push(table_metadata.name.clone());
-        }
-
-        for model_table_metadata in &self.model_table_metadata {
-            table_names.push(model_table_metadata.name.clone());
-        }
-        table_names
-    }
-
     /// Determine if `dir_entry` is a table, a model table, or neither. If
     /// `dir_entry` is a table the metadata required to query the table is added
     /// to `table_metadata`, and if `dir_entry` is a model table the metadata

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -18,23 +18,16 @@
 //! models.
 
 use std::collections::HashSet;
-use std::fs::{read_dir, DirEntry};
+use std::fs;
+use std::fs::DirEntry;
 use std::io::{Error, ErrorKind};
+use std::path::Path;
 use std::path::PathBuf;
 use std::str;
 use std::sync::Arc;
-use std::{fs::File, path::Path};
 
 use arrow_flight::IpcMessage;
-use datafusion::arrow::array::{
-    Array, ArrayRef, BinaryArray, Int32Array, Int32Builder, StringBuilder,
-};
-use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema, SchemaRef};
-use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::parquet::errors::ParquetError;
-use datafusion::parquet::file::reader::{FileReader, SerializedFileReader};
-use datafusion::parquet::record::RowAccessor;
-use object_store::path::Path as ObjectStorePath;
+use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
 use rusqlite::types::Type::Blob;
 use rusqlite::Connection;
 use tracing::{error, info, warn};
@@ -53,8 +46,6 @@ pub struct Catalog {
     /// Metadata for the tables in the data folder.
     pub table_metadata: Vec<TableMetadata>,
     /// Metadata for the model tables in the data folder.
-    pub new_model_table_metadata: Vec<NewModelTableMetadata>,
-    /// Metadata for the model tables in the data folder.
     pub model_table_metadata: Vec<Arc<ModelTableMetadata>>,
 }
 
@@ -63,34 +54,20 @@ impl Catalog {
     /// that contains the metadata necessary to query these tables. Returns
     /// `Error` if the contents of `data_folder` cannot be read.
     pub fn try_new(data_folder_path: &Path) -> Result<Self, Error> {
-        let mut table_metadata = vec![];
-        let mut model_table_metadata = vec![];
-        let model_table_legacy_segment_file_schema = Arc::new(Schema::new(vec![
-            Field::new("gid", DataType::Int32, false),
-            Field::new("start_time", DataType::Int64, false),
-            Field::new("end_time", DataType::Int64, false),
-            Field::new("mtid", DataType::Int32, false),
-            Field::new("model", DataType::Binary, false),
-            Field::new("gaps", DataType::Binary, false),
-        ]));
-
-        if Self::is_path_a_table(data_folder_path) {
-            warn!("The data folder is a table, please use the parent directory.");
-        } else if Self::is_path_a_model_table(data_folder_path) {
-            warn!("The data folder is a model table, please use the parent directory.");
+        if !Self::is_path_a_data_folder(data_folder_path) {
+            warn!("The data folder is not empty and does not contain data from ModelarDB");
         }
 
-        for maybe_dir_entry in read_dir(data_folder_path)? {
-            // The check if maybe_dir_entry is an error is not performed in
-            // try_adding_table_or_model_table_metadata() as it does not seem
-            // possible to return an error without moving it out of a reference.
+        // Add tables that only exists as Apache Parquet files to the catalog.
+        let mut table_metadata = vec![];
+        for maybe_dir_entry in fs::read_dir(data_folder_path)? {
+            // The check for if maybe_dir_entry is an error is not performed in
+            // try_adding_table_metadata() as it does not seem possible to
+            // return an error without also moving it out of a reference.
             if let Ok(ref dir_entry) = maybe_dir_entry {
-                if let Err(maybe_error) = Self::try_adding_table_or_model_table_metadata(
-                    dir_entry,
-                    &mut table_metadata,
-                    &mut model_table_metadata,
-                    &model_table_legacy_segment_file_schema,
-                ) {
+                if let Err(maybe_error) =
+                    Self::try_adding_table_metadata(dir_entry, &mut table_metadata)
+                {
                     error!(
                         "Cannot read metadata from '{}': {}",
                         dir_entry.path().to_string_lossy(),
@@ -103,9 +80,9 @@ impl Catalog {
             }
         }
 
-        // Add model tables using the data from the model_table_metadata metadata database table.
-        let new_model_table_metadata = Self::get_new_model_table_metadata(data_folder_path)
-            .unwrap_or_else(|error| {
+        // Add model tables to the catalog with data from the metadata database.
+        let model_table_metadata =
+            Self::get_model_table_metadata(data_folder_path).unwrap_or_else(|error| {
                 error!(
                     "Cannot register model tables from model_table_metadata: {}",
                     error
@@ -116,20 +93,15 @@ impl Catalog {
         Ok(Self {
             data_folder_path: data_folder_path.to_path_buf(),
             table_metadata,
-            new_model_table_metadata,
             model_table_metadata,
         })
     }
 
-    /// Determine if `dir_entry` is a table, a model table, or neither. If
-    /// `dir_entry` is a table the metadata required to query the table is added
-    /// to `table_metadata`, and if `dir_entry` is a model table the metadata
-    /// required to query the model table is added to `model_table_metadata`.
-    fn try_adding_table_or_model_table_metadata(
+    /// If `dir_entry` is a table, the metadata required to query the table is
+    /// added to `table_metadata`. otherwise return
+    fn try_adding_table_metadata(
         dir_entry: &DirEntry,
         table_metadata: &mut Vec<TableMetadata>,
-        model_table_metadata: &mut Vec<Arc<ModelTableMetadata>>,
-        model_table_legacy_segment_file_schema: &SchemaRef,
     ) -> Result<(), Error> {
         let path = dir_entry.path();
         let path_str = path.to_str().ok_or_else(|| {
@@ -145,23 +117,18 @@ impl Catalog {
         // HACK: workaround for DataFusion converting table names to lowercase.
         let normalized_file_or_folder_name = file_name.to_ascii_lowercase();
 
-        // Check if the file or folder is METADATA_SQLITE_NAME so it can be
-        // skipped without creating errors, a table, a model table, or neither.
+        // Check if the file or folder is METADATA_SQLITE_NAME, so it can be
+        // skipped without logging any errors, a table, or neither.
         if path.ends_with(METADATA_SQLITE_NAME) {
             // Skip without emitting any errors.
         } else if Self::is_path_a_table(&path) {
+            info!("Found table '{}'.", normalized_file_or_folder_name);
             table_metadata.push(TableMetadata::new(
                 normalized_file_or_folder_name,
                 path_str.to_owned(),
             ));
-            info!("Found table '{}'.", path_str);
         } else if Self::is_path_a_model_table(&path) {
-            model_table_metadata.push(ModelTableMetadata::try_new(
-                normalized_file_or_folder_name, // Only folder for model tables.
-                path_str.to_owned(),
-                &model_table_legacy_segment_file_schema,
-            )?);
-            info!("Found model table '{}'.", path_str);
+            // Skip without emitting any errors.
         } else {
             error!(
                 "File or folder '{}' is not a table or model table.",
@@ -171,62 +138,59 @@ impl Catalog {
         Ok(())
     }
 
+    /// Return `true` if `path` is a data folder, otherwise `false`.
+    fn is_path_a_data_folder(path: &Path) -> bool {
+        if let Ok(files_and_folders) = fs::read_dir(path) {
+            files_and_folders.count() == 0 || path.join(METADATA_SQLITE_NAME).exists()
+        } else {
+            false
+        }
+    }
+
     /// Return `true` if `path` is a readable table, otherwise `false`.
     fn is_path_a_table(path: &Path) -> bool {
         if path.is_file() {
             StorageEngine::is_path_an_apache_parquet_file(&path)
         } else if path.is_dir() {
-            let table_folder = read_dir(&path);
-            let mut number_of_files = 0;
-            table_folder.is_ok()
-                && table_folder.unwrap().all(|result| {
-                    number_of_files += 1;
-                    result.is_ok()
-                        && StorageEngine::is_path_an_apache_parquet_file(&result.unwrap().path())
-                }) && number_of_files > 0
+            Self::count_apache_aparquet_file_in_folder(&path) > 0
         } else {
             false
         }
     }
 
-    /// Return `true` if `path_to_folder` is a model table, otherwise `false`.
-    fn is_path_a_model_table(path_to_folder: &Path) -> bool {
-        if path_to_folder.is_dir() {
-            // Construction of the Paths is duplicated as it seems impossible to
-            // create a function that accepts a Path and returns a new Path.
-            let mut model_type = path_to_folder.to_path_buf();
-            model_type.push("model_type.parquet");
-            let model_type = model_type.as_path();
+    /// Return `true` if `path` is a readable model table, otherwise `false`.
+    fn is_path_a_model_table(path: &Path) -> bool {
+        let compressed_path = path.join("compressed");
+        compressed_path.exists() && Self::count_apache_aparquet_file_in_folder(&compressed_path) > 0
+    }
 
-            let mut time_series = path_to_folder.to_path_buf();
-            time_series.push("time_series.parquet");
-            let time_series = time_series.as_path();
+    /// Return the number of Apache Parquet files in the folder at `path`.
+    fn count_apache_aparquet_file_in_folder(path: &Path) -> usize {
+        let mut number_of_apache_parquet_files = 0;
 
-            let mut segment = path_to_folder.to_path_buf();
-            segment.push("segment");
-            let segment = segment.as_path();
-            let segment_folder = read_dir(&segment);
-
-            StorageEngine::is_path_an_apache_parquet_file(model_type)
-                && StorageEngine::is_path_an_apache_parquet_file(time_series)
-                && segment_folder.is_ok()
-                && segment_folder.unwrap().all(|result| {
-                    result.is_ok()
-                        && StorageEngine::is_path_an_apache_parquet_file(&result.unwrap().path())
-                })
-        } else {
-            false
+        if let Ok(files_or_folders) = fs::read_dir(&path) {
+            for file_or_folder in files_or_folders {
+                if let Ok(maybe_apache_parquet_file) = file_or_folder {
+                    if StorageEngine::is_path_an_apache_parquet_file(
+                        &maybe_apache_parquet_file.path(),
+                    ) {
+                        number_of_apache_parquet_files += 1;
+                    }
+                }
+            }
         }
+
+        number_of_apache_parquet_files
     }
 
     // TODO: Move to the metadata component when it exists.
-    // TODO: Rename to "get_model_table_metadata" when the old version is removed.
-    /// Convert the rows in the model_table_metadata table to a list of [`NewModelTableMetadata`]
-    /// and return it. If the metadata database could not be opened or the table could not be queried,
-    /// return [`rusqlite::Error`].
-    fn get_new_model_table_metadata(
+    // TODO: Store metadata about tables and models in METADATA_SQLITE_NAME.
+    /// Convert the rows in the model_table_metadata table to a list of
+    /// [`ModelTableMetadata`] and return it. If the metadata database could not
+    /// be opened or the table could not be queried, return [`rusqlite::Error`].
+    fn get_model_table_metadata(
         data_folder_path: &Path,
-    ) -> Result<Vec<NewModelTableMetadata>, rusqlite::Error> {
+    ) -> Result<Vec<Arc<ModelTableMetadata>>, rusqlite::Error> {
         let database_path = data_folder_path.join(METADATA_SQLITE_NAME);
         let connection = Connection::open(database_path)?;
 
@@ -250,12 +214,12 @@ impl Catalog {
                 rusqlite::Error::InvalidColumnType(1, message, Blob)
             })?;
 
-            model_table_metadata.push(NewModelTableMetadata {
+            model_table_metadata.push(Arc::new(ModelTableMetadata {
                 name: name.clone(),
                 schema,
                 timestamp_column_index: row.get(2)?,
                 tag_column_indices: row.get(3)?,
-            });
+            }));
 
             info!("Found model table '{}'.", name);
         }
@@ -289,10 +253,9 @@ impl TableMetadata {
     }
 }
 
-// TODO: Change name to "ModelTableMetadata" when the old version is removed.
 /// Metadata required to ingest data into a model table and query a model table.
-#[derive(Clone)]
-pub struct NewModelTableMetadata {
+#[derive(Debug, Clone)]
+pub struct ModelTableMetadata {
     /// Name of the model table.
     pub name: String,
     /// Schema of the data in the model table.
@@ -303,7 +266,7 @@ pub struct NewModelTableMetadata {
     pub tag_column_indices: Vec<u8>,
 }
 
-impl NewModelTableMetadata {
+impl ModelTableMetadata {
     /// Create a new model table with the given metadata. If any of the following conditions are
     /// true, [`ConfigurationError`](ModelarDBError::ConfigurationError) is returned:
     /// * The timestamp or tag column indices does not match `schema`.
@@ -321,13 +284,16 @@ impl NewModelTableMetadata {
         // If the timestamp index is in the tag indices, return an error.
         if tag_column_indices.contains(&timestamp_column_index) {
             return Err(ModelarDBError::ConfigurationError(
-                "The timestamp column cannot be a tag column.".to_owned()
+                "The timestamp column cannot be a tag column.".to_owned(),
             ));
         };
 
         if let Some(timestamp_field) = schema.fields.get(timestamp_column_index as usize) {
             // If the field of the timestamp column is not of type ArrowTimestamp, return an error.
-            if !timestamp_field.data_type().equals_datatype(&ArrowTimestamp::DATA_TYPE) {
+            if !timestamp_field
+                .data_type()
+                .equals_datatype(&ArrowTimestamp::DATA_TYPE)
+            {
                 return Err(ModelarDBError::ConfigurationError(format!(
                     "The timestamp column with index '{}' is not of type '{}'.",
                     timestamp_column_index,
@@ -361,16 +327,18 @@ impl NewModelTableMetadata {
             }
         }
 
-        let field_column_indices: Vec<usize> = (0..schema.fields().len()).filter(|index| {
-            // TODO: Change this cast when indices in the action body are changed to use two bytes.
-            let index = *index as u8;
-            index != timestamp_column_index && !tag_column_indices.contains(&index)
-        }).collect();
+        let field_column_indices: Vec<usize> = (0..schema.fields().len())
+            .filter(|index| {
+                // TODO: Change this cast when indices in the action body are changed to use two bytes.
+                let index = *index as u8;
+                index != timestamp_column_index && !tag_column_indices.contains(&index)
+            })
+            .collect();
 
         // If there are no field columns, return an error.
         if field_column_indices.is_empty() {
             return Err(ModelarDBError::ConfigurationError(
-                "There needs to be at least one field column.".to_owned()
+                "There needs to be at least one field column.".to_owned(),
             ));
         } else {
             for field_column_index in &field_column_indices {
@@ -397,7 +365,7 @@ impl NewModelTableMetadata {
             .all(|x| uniq.insert(x))
         {
             return Err(ModelarDBError::ConfigurationError(
-                "The tag column indices cannot have duplicates.".to_owned()
+                "The tag column indices cannot have duplicates.".to_owned(),
             ));
         }
 
@@ -405,7 +373,7 @@ impl NewModelTableMetadata {
         // since 10 bits are used to identify the column index of the data in the 64-bit hash key.
         if schema.fields.len() > 1024 {
             return Err(ModelarDBError::ConfigurationError(
-                "There cannot be more than 1024 columns in the model table.".to_owned()
+                "There cannot be more than 1024 columns in the model table.".to_owned(),
             ));
         }
 
@@ -418,181 +386,10 @@ impl NewModelTableMetadata {
     }
 }
 
-// TODO: update after implementing the compression component.
-/// Metadata required to query a model table.
-#[derive(Debug)]
-pub struct ModelTableMetadata {
-    /// Name of the model table.
-    pub name: String,
-    /// Location of the model table's segment folder in an `ObjectStore`.
-    pub segment_path: ObjectStorePath,
-    // TODO: remove segment_file_legacy_schema when refactoring query engine.
-    /// Schema of the Apache Parquet files used by the [JVM-based version of
-    /// ModelarDB] for storing segments.
-    ///
-    /// [JVM-based version of ModelarDB]: https://github.com/modelardata/ModelarDB
-    pub segment_file_legacy_schema: SchemaRef,
-    /// Cache that maps from time series id to sampling interval for all time
-    /// series in the table.
-    pub sampling_intervals: Int32Array,
-    // TODO: rename dimension members to tags when refactoring query engine.
-    /// Cache that maps from time series id to data warehouse dimension members
-    /// for all time series in the table. Each `Array` in
-    /// `denormalized_dimensions` is a level in a dimension.
-    pub denormalized_dimensions: Vec<ArrayRef>,
-}
-
-impl ModelTableMetadata {
-    /// Read and check the metadata for a model table produced by the [JVM-based
-    /// version of ModelarDB]. Return `ParquetError` if the metadata cannot be
-    /// read or if the model table uses unsupported model types.
-    ///
-    /// [JVM-based version of ModelarDB]: https://github.com/modelardata/ModelarDB
-    fn try_new(
-        folder_name: String,
-        folder_path: String,
-        segment_file_legacy_schema: &SchemaRef,
-    ) -> Result<Arc<Self>, ParquetError> {
-        // Pre-compute the path to the segment folder in the object store.
-        let segment_path = Self::create_object_store_path_to_segment_folder(&folder_path)?;
-
-        // Ensure only supported model types are used.
-        Self::check_model_type_metadata(&folder_path)?;
-
-        // Read time series metadata. The sampling intervals and dimension
-        // members are shifted by one as the time series ids start at one.
-        let time_series_file = folder_path.clone() + "/time_series.parquet";
-        let path = Path::new(&time_series_file);
-        if let Ok(rows) = StorageEngine::read_entire_apache_parquet_file(path) {
-            let sampling_intervals = Self::extract_and_shift_int32_array(&rows, 2)?;
-            let denormalized_dimensions = // Columns with metadata as strings.
-                Self::extract_and_shift_denormalized_dimensions(&rows, 4)?;
-
-            Ok(Arc::new(Self {
-                name: folder_name,
-                segment_path,
-                segment_file_legacy_schema: segment_file_legacy_schema.clone(),
-                sampling_intervals,
-                denormalized_dimensions,
-            }))
-        } else {
-            Err(ParquetError::General(format!(
-                "Unable to read metadata for folder '{}'.",
-                folder_name
-            )))
-        }
-    }
-
-    /// Create an `ObjectStorePath` to the segment folder in
-    /// `model_table_folder`.
-    fn create_object_store_path_to_segment_folder(
-        model_table_folder: &str,
-    ) -> Result<ObjectStorePath, ParquetError> {
-        let segment_folder = model_table_folder.to_owned() + "/segment";
-        let path = Path::new(&segment_folder);
-        ObjectStorePath::from_filesystem_path(path)
-            .map_err(|error| ParquetError::General(error.to_string()))
-    }
-
-    /// Check that the model table only use supported model types.
-    fn check_model_type_metadata(table_folder: &String) -> Result<(), ParquetError> {
-        let model_types_file = table_folder.clone() + "/model_type.parquet";
-        let path = Path::new(&model_types_file);
-        if let Ok(file) = File::open(&path) {
-            let reader = SerializedFileReader::new(file)?;
-            let rows = reader.get_row_iter(None)?;
-            for row in rows {
-                let mtid = row.get_int(0)?;
-                let name = row.get_bytes(1)?.as_utf8()?;
-                match (mtid, name) {
-                    (1, "dk.aau.modelardb.core.models.UncompressedModelType") => (),
-                    (2, "dk.aau.modelardb.core.models.PMC_MeanModelType") => (),
-                    (3, "dk.aau.modelardb.core.models.SwingFilterModelType") => (),
-                    (4, "dk.aau.modelardb.core.models.FacebookGorillaModelType") => (),
-                    _ => return Err(ParquetError::General("Unsupported model type.".to_owned())),
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Read the array at `column_index` from `rows`, cast it to `Int32Array`,
-    /// and increase the index of all values in the array with one.
-    fn extract_and_shift_int32_array(
-        rows: &RecordBatch,
-        column_index: usize,
-    ) -> Result<Int32Array, ParquetError> {
-        let column = rows
-            .column(column_index)
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .ok_or_else(|| {
-                ParquetError::ArrowError("Unable to read sampling intervals.".to_owned())
-            })?
-            .values();
-
-        // -1 is stored at index 0 as time series ids starting at 1 is used for
-        // lookup. Time series ids starting at 1 is used for compatibility with
-        // the JVM-based version of ModelarDB.
-        let mut shifted_column = Int32Builder::with_capacity(column.len() + 1);
-        shifted_column.append_value(-1);
-        shifted_column.append_slice(column);
-        Ok(shifted_column.finish())
-    }
-
-    /// Read the arrays from `first_column_index` to `rows.num_columns()` from
-    /// `rows`, cast them to `BinaryArray`, and increase the index of all values
-    /// in the arrays with one.
-    fn extract_and_shift_denormalized_dimensions(
-        rows: &RecordBatch,
-        first_column_index: usize,
-    ) -> Result<Vec<ArrayRef>, ParquetError> {
-        let mut denormalized_dimensions: Vec<ArrayRef> = vec![];
-        for level_column_index in first_column_index..rows.num_columns() {
-            let level = Self::extract_and_shift_string_array(rows, level_column_index)?;
-            denormalized_dimensions.push(level);
-        }
-        Ok(denormalized_dimensions)
-    }
-
-    /// Read the array at `column_index` from `rows`, cast it to `BinaryArray`,
-    /// and increase the index of all values in the array with one.
-    fn extract_and_shift_string_array(
-        rows: &RecordBatch,
-        column_index: usize,
-    ) -> Result<ArrayRef, ParquetError> {
-        let error_message = "Unable to read tags.";
-
-        let schema = rows.schema();
-        let name = schema.field(column_index).name();
-        let column = rows
-            .column(column_index)
-            .as_any()
-            .downcast_ref::<BinaryArray>()
-            .ok_or_else(|| ParquetError::ArrowError(error_message.to_owned()))?;
-
-        // The level's name is at index 0 as ids from 1 is used for lookup.
-        let mut shifted_column =
-            StringBuilder::with_capacity(column.len(), column.get_buffer_memory_size());
-        shifted_column.append_value(name);
-        for maybe_member_as_bytes in column {
-            let member_as_bytes = maybe_member_as_bytes
-                .ok_or_else(|| ParquetError::ArrowError(error_message.to_owned()))?;
-            let member_as_str = str::from_utf8(member_as_bytes)?;
-            shifted_column.append_value(member_as_str);
-        }
-        Ok(Arc::new(shifted_column.finish()))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::array::StringArray;
     use datafusion::arrow::datatypes::ArrowPrimitiveType;
-    use proptest::num;
-    use proptest::string;
-    use proptest::{prop_assert, prop_assert_eq, proptest};
 
     use crate::types::{ArrowTimestamp, ArrowValue};
 
@@ -619,16 +416,11 @@ mod tests {
         assert_eq!("file", table_metadata.name);
     }
 
-    // Tests for NewModelTableMetadata.
+    // Tests for ModelTableMetadata.
     #[test]
     fn test_can_create_model_table_metadata() {
         let schema = get_model_table_schema();
-        let result = NewModelTableMetadata::try_new(
-            "table_name".to_owned(),
-            schema,
-            vec![0, 1, 2],
-            3,
-        );
+        let result = ModelTableMetadata::try_new("table_name".to_owned(), schema, vec![0, 1, 2], 3);
 
         assert!(result.is_ok());
     }
@@ -636,12 +428,7 @@ mod tests {
     #[test]
     fn test_cannot_create_model_table_metadata_with_timestamp_index_in_tag_indices() {
         let schema = get_model_table_schema();
-        let result = NewModelTableMetadata::try_new(
-            "table_name".to_owned(),
-            schema,
-            vec![0, 1, 2],
-            0,
-        );
+        let result = ModelTableMetadata::try_new("table_name".to_owned(), schema, vec![0, 1, 2], 0);
 
         assert!(result.is_err());
     }
@@ -649,12 +436,8 @@ mod tests {
     #[test]
     fn test_cannot_create_model_table_metadata_with_invalid_timestamp_index() {
         let schema = get_model_table_schema();
-        let result = NewModelTableMetadata::try_new(
-            "table_name".to_owned(),
-            schema,
-            vec![0, 1, 2],
-            10,
-        );
+        let result =
+            ModelTableMetadata::try_new("table_name".to_owned(), schema, vec![0, 1, 2], 10);
 
         assert!(result.is_err());
     }
@@ -674,12 +457,8 @@ mod tests {
     #[test]
     fn test_cannot_create_model_table_metadata_with_invalid_tag_index() {
         let schema = get_model_table_schema();
-        let result = NewModelTableMetadata::try_new(
-            "table_name".to_owned(),
-            schema,
-            vec![0, 1, 10],
-            3,
-        );
+        let result =
+            ModelTableMetadata::try_new("table_name".to_owned(), schema, vec![0, 1, 10], 3);
 
         assert!(result.is_err());
     }
@@ -721,25 +500,15 @@ mod tests {
 
     /// Return metadata for a model table with one tag column and the timestamp column at index 1.
     fn create_simple_model_table_metadata(
-        schema: Schema
-    ) -> Result<NewModelTableMetadata, ModelarDBError> {
-        NewModelTableMetadata::try_new(
-            "table_name".to_owned(),
-            schema,
-            vec![0],
-            1,
-        )
+        schema: Schema,
+    ) -> Result<ModelTableMetadata, ModelarDBError> {
+        ModelTableMetadata::try_new("table_name".to_owned(), schema, vec![0], 1)
     }
 
     #[test]
     fn test_cannot_create_model_table_metadata_with_duplicate_tag_indices() {
         let schema = get_model_table_schema();
-        let result = NewModelTableMetadata::try_new(
-            "table_name".to_owned(),
-            schema,
-            vec![0, 1, 1],
-            3,
-        );
+        let result = ModelTableMetadata::try_new("table_name".to_owned(), schema, vec![0, 1, 1], 3);
 
         assert!(result.is_err());
     }
@@ -764,7 +533,7 @@ mod tests {
             .collect::<Vec<Field>>();
 
         let schema = get_model_table_schema();
-        let result = NewModelTableMetadata::try_new(
+        let result = ModelTableMetadata::try_new(
             "table_name".to_owned(),
             Schema::new(fields),
             vec![0, 1, 2],
@@ -772,94 +541,5 @@ mod tests {
         );
 
         assert!(result.is_err());
-    }
-
-    // Tests for ModelTableMetadata.
-    #[test]
-    fn test_extract_and_shift_empty_int32_array() {
-        let array = Int32Array::from(vec![] as Vec<i32>);
-        assert_eq!(0, array.len());
-
-        let record_batch = create_record_batch_with_int32_array(array);
-        let maybe_shifted_array =
-            ModelTableMetadata::extract_and_shift_int32_array(&record_batch, 0);
-        assert!(maybe_shifted_array.is_ok());
-
-        let shifted_array = maybe_shifted_array.unwrap();
-        assert_eq!(1, shifted_array.len());
-        assert_eq!(-1, shifted_array.value(0));
-    }
-
-    proptest! {
-    #[test]
-    fn test_extract_and_shift_int32_array_with_value(value in num::i32::ANY) {
-        let array = Int32Array::from(vec![value]);
-        assert_eq!(1, array.len());
-
-        let record_batch = create_record_batch_with_int32_array(array);
-        let maybe_shifted_array =
-            ModelTableMetadata::extract_and_shift_int32_array(&record_batch, 0);
-        prop_assert!(maybe_shifted_array.is_ok());
-
-        let shifted_array = maybe_shifted_array.unwrap();
-        prop_assert_eq!(2, shifted_array.len());
-        assert_eq!(-1, shifted_array.value(0));
-        prop_assert_eq!(value, shifted_array.value(1));
-    }
-    }
-
-    fn create_record_batch_with_int32_array(array: Int32Array) -> RecordBatch {
-        let schema = Schema::new(vec![Field::new("array", DataType::Int32, false)]);
-        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)]).unwrap()
-    }
-
-    #[test]
-    fn test_extract_and_shift_empty_text_array() {
-        let array = BinaryArray::from_vec(vec![]);
-        assert_eq!(0, array.len());
-
-        let record_batch = create_record_batch_with_string_array(array);
-        let maybe_shifted_array =
-            ModelTableMetadata::extract_and_shift_string_array(&record_batch, 0);
-        assert!(maybe_shifted_array.is_ok());
-
-        // The extra let binding is required to create a longer lived value.
-        let shifted_array = maybe_shifted_array.unwrap();
-        let shifted_array = shifted_array
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        assert_eq!(1, shifted_array.len());
-        assert_eq!("array", shifted_array.value(0));
-    }
-
-    proptest! {
-    #[test]
-    fn test_extract_and_shift_text_array_with_value(
-        value in string::string_regex("[a-zA-Z]+").unwrap()
-    ) {
-        let array = BinaryArray::from_vec(vec![value.as_bytes()]);
-        assert_eq!(1, array.len());
-
-        let record_batch = create_record_batch_with_string_array(array);
-        let maybe_shifted_array =
-            ModelTableMetadata::extract_and_shift_string_array(&record_batch, 0);
-        prop_assert!(maybe_shifted_array.is_ok());
-
-        // The extra let binding is required to create a longer lived value.
-        let shifted_array = maybe_shifted_array.unwrap();
-        let shifted_array = shifted_array
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        prop_assert_eq!(2, shifted_array.len());
-        assert_eq!("array", shifted_array.value(0));
-        prop_assert_eq!(value, shifted_array.value(1));
-    }
-    }
-
-    fn create_record_batch_with_string_array(array: BinaryArray) -> RecordBatch {
-        let schema = Schema::new(vec![Field::new("array", DataType::Binary, false)]);
-        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)]).unwrap()
     }
 }

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -377,7 +377,6 @@ impl CompressedSegmentBatchBuilder {
 
 #[cfg(test)]
 mod tests {
-    // TODO: add tests for irregular time series when refactoring the query engine.
     use super::*;
 
     use datafusion::arrow::array::UInt8Array;

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -139,7 +139,8 @@ pub fn merge_segments(compressed_segments: RecordBatch) -> RecordBatch {
                 ));
             }
             let timestamps = flatten_timestamp_arrays(timestamp_arrays);
-            let compressed_timestamps = timestamps::compress_residual_timestamps(&timestamps);
+            let compressed_timestamps =
+                timestamps::compress_residual_timestamps(timestamps.values());
 
             // Merge segments. The first segment's model is used for the merged
             // segment as all of the segments contain the exact same model.
@@ -275,7 +276,9 @@ impl<'a> CompressedSegmentBuilder<'a> {
         // Add timestamps and error.
         let start_time = self.uncompressed_timestamps.value(self.start_index);
         let end_time = self.uncompressed_timestamps.value(end_index);
-        let timestamps = timestamps::compress_residual_timestamps(&self.uncompressed_timestamps);
+        let timestamps = timestamps::compress_residual_timestamps(
+            &self.uncompressed_timestamps.values()[self.start_index..end_index],
+        );
         let error = f32::NAN; // TODO: compute and store the actual error.
 
         compressed_record_batch_builder.append_compressed_segment(

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -279,7 +279,7 @@ impl<'a> CompressedSegmentBuilder<'a> {
         let start_time = self.uncompressed_timestamps.value(self.start_index);
         let end_time = self.uncompressed_timestamps.value(end_index);
         let timestamps = timestamps::compress_residual_timestamps(
-            &self.uncompressed_timestamps.values()[self.start_index..end_index],
+            &self.uncompressed_timestamps.values()[self.start_index..=end_index],
         );
         let error = f32::NAN; // TODO: compute and store the actual error.
 

--- a/server/src/macros.rs
+++ b/server/src/macros.rs
@@ -46,17 +46,19 @@ macro_rules! get_array {
 ///
 /// # Panics
 ///
-/// Panics if `batch` contains less than six columns or if the columns are not
-/// Int32Array, Int64Array, Int64Array, Int32Array, BinaryArray, and BinaryArray.
-// TODO: rename downcast_arrays and update the types when refactoring query engine.
+/// Panics if `batch` does not contain seven columns or if the columns are not
+/// UInt8Array, BinaryArray, TimestampArray, TimestampArray, BinaryArray,
+/// ValueArray, ValueArray, and Float32Array.
 #[macro_export]
-macro_rules! downcast_arrays {
-    ($gids:ident, $start_times:ident, $end_times:ident, $mtids:ident, $models:ident, $gaps:ident, $batch:ident) => {
-        let $gids = crate::get_array!($batch, 0, Int32Array);
-        let $start_times = crate::get_array!($batch, 1, Int64Array);
-        let $end_times = crate::get_array!($batch, 2, Int64Array);
-        let $mtids = crate::get_array!($batch, 3, Int32Array);
-        let $models = crate::get_array!($batch, 4, BinaryArray);
-        let $gaps = crate::get_array!($batch, 5, BinaryArray);
+macro_rules! get_arrays {
+    ($batch:ident, $model_type_id:ident, $timestamps:ident, $start_time:ident, $end_time:ident, $values:ident, $min_value:ident, $max_value:ident, $error:ident) => {
+        let $model_type_id = crate::get_array!($batch, 0, UInt8Array);
+        let $timestamps = crate::get_array!($batch, 1, BinaryArray);
+        let $start_time = crate::get_array!($batch, 2, TimestampArray);
+        let $end_time = crate::get_array!($batch, 3, TimestampArray);
+        let $values = crate::get_array!($batch, 4, BinaryArray);
+        let $min_value = crate::get_array!($batch, 5, ValueArray);
+        let $max_value = crate::get_array!($batch, 6, ValueArray);
+        let $error = crate::get_array!($batch, 7, Float32Array);
     };
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> Result<(), String> {
         // Register Tables.
         register_tables_and_model_tables(&mut context);
 
-        // Setup CTRL-C handler.
+        // Setup CTRL+C handler.
         setup_ctrl_c_handler(&context);
 
         // Start Interface.
@@ -203,7 +203,7 @@ fn register_tables_and_model_tables(context: &mut Arc<Context>) {
 
 /// Check if the `result` from a table or model table initialization is an
 /// `Error`, if so log an error message containing `table_type` and `name` and
-/// return `false`, otherwise return `true`.
+/// return [`false`], otherwise return [`true`].
 fn check_if_table_or_model_table_is_initialized_otherwise_log_error<T>(
     table_type: &str,
     name: &str,
@@ -222,7 +222,9 @@ fn check_if_table_or_model_table_is_initialized_otherwise_log_error<T>(
     }
 }
 
-/// Register a handler to execute when CTRL-C is pressed.
+/// Register a handler to execute when CTRL+C is pressed. The handler takes an
+/// exclusive lock for the storage engine, flushes the data the storage engine
+/// currently buffers, and terminates the system without releasing the lock.
 fn setup_ctrl_c_handler(context: &Arc<Context>) {
     let ctrl_c_context = context.clone();
     context.runtime.spawn(async move {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -22,7 +22,7 @@ mod compression;
 mod errors;
 mod macros;
 mod models;
-//mod optimizer;
+mod optimizer;
 mod remote;
 mod storage;
 mod tables;
@@ -42,7 +42,7 @@ use tracing::error;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::catalog::Catalog;
-//use crate::optimizer::model_simple_aggregates;
+use crate::optimizer::model_simple_aggregates;
 use crate::storage::StorageEngine;
 use crate::tables::ModelTable;
 
@@ -124,7 +124,7 @@ fn create_session_context() -> SessionContext {
     let config = SessionConfig::new();
     let runtime = Arc::new(RuntimeEnv::default());
     let state = SessionState::with_config_rt(config, runtime).with_physical_optimizer_rules(vec![
-        //Arc::new(model_simple_aggregates::ModelSimpleAggregatesPhysicalOptimizerRule {}),
+        Arc::new(model_simple_aggregates::ModelSimpleAggregatesPhysicalOptimizerRule {}),
     ]);
     SessionContext::with_state(state)
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -145,7 +145,7 @@ fn create_model_table_metadata_tables(data_folder_path: &Path) -> Result<(), rus
                 schema BLOB NOT NULL,
                 timestamp_column_index INTEGER NOT NULL,
                 tag_column_indices BLOB NOT NULL
-        )",
+        ) STRICT",
         (),
     )?;
 
@@ -157,7 +157,7 @@ fn create_model_table_metadata_tables(data_folder_path: &Path) -> Result<(), rus
                 column_name TEXT NOT NULL,
                 column_index INTEGER NOT NULL,
                 PRIMARY KEY (table_name, column_name)
-        )",
+        ) STRICT",
         (),
     )?;
 

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -129,42 +129,10 @@ impl Gorilla {
     }
 }
 
-/// Compute the minimum value for a time series segment whose values are
-/// compressed using Gorilla's compression method for floating-point values.
-pub fn min(
-    start_time: Timestamp,
-    end_time: Timestamp,
-    sampling_interval: i32,
-    model: &[u8],
-) -> Value {
-    let decompressed_values =
-        decompress_values_to_array(start_time, end_time, sampling_interval, model);
-    aggregate::min(&decompressed_values).unwrap()
-}
-
-/// Compute the maximum value for a time series segment whose values are
-/// compressed using Gorilla's compression method for floating-point values.
-pub fn max(
-    start_time: Timestamp,
-    end_time: Timestamp,
-    sampling_interval: i32,
-    model: &[u8],
-) -> Value {
-    let decompressed_values =
-        decompress_values_to_array(start_time, end_time, sampling_interval, model);
-    aggregate::max(&decompressed_values).unwrap()
-}
-
 /// Compute the sum of the values for a time series segment whose values are
 /// compressed using Gorilla's compression method for floating-point values.
-pub fn sum(
-    start_time: Timestamp,
-    end_time: Timestamp,
-    sampling_interval: i32,
-    model: &[u8],
-) -> Value {
-    let decompressed_values =
-        decompress_values_to_array(start_time, end_time, sampling_interval, model);
+pub fn sum(start_time: Timestamp, end_time: Timestamp, timestamps: &[u8], model: &[u8]) -> Value {
+    let decompressed_values = decompress_values_to_array(start_time, end_time, timestamps, model);
     aggregate::sum(&decompressed_values).unwrap()
 }
 
@@ -193,11 +161,11 @@ pub fn grid(
 fn decompress_values_to_array(
     start_time: Timestamp,
     end_time: Timestamp,
-    sampling_interval: i32,
+    timestamps: &[u8],
     values: &[u8],
 ) -> ValueArray {
     // TODO: Can decompress_values_to_array() be merged with decompress_values?
-    let length = models::length(start_time, end_time, sampling_interval);
+    let length = models::length(start_time, end_time, timestamps);
     let mut value_builder = ValueBuilder::with_capacity(length);
 
     let mut bits = BitReader::try_new(values).unwrap();

--- a/server/src/models/gorilla.rs
+++ b/server/src/models/gorilla.rs
@@ -130,6 +130,9 @@ impl Gorilla {
 /// Compute the sum of the values for a time series segment whose values are
 /// compressed using Gorilla's compression method for floating-point values.
 pub fn sum(start_time: Timestamp, end_time: Timestamp, timestamps: &[u8], values: &[u8]) -> Value {
+    // This function replicates code from gorilla::grid() as it isn't necessary
+    // to store the time series ids, timestamps, and values in arrays for a sum.
+    // So any changes to the decompression must be mirrored in gorilla::grid().
     let length = models::length(start_time, end_time, timestamps);
     let mut bits = BitReader::try_new(values).unwrap();
     let mut leading_zeros = u8::MAX;
@@ -173,6 +176,7 @@ pub fn grid(
     timestamps: &[Timestamp],
     value_builder: &mut ValueBuilder,
 ) {
+    // Changes to the decompression must be mirrored in gorilla::sum().
     let mut bits = BitReader::try_new(values).unwrap();
     let mut leading_zeros = u8::MAX;
     let mut trailing_zeros: u8 = 0;

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -18,7 +18,7 @@
 //! each type. The module itself contains general functionality used by the
 //! model types.
 
-// TODO: Expand all tests in models to include both regular and irregular time series.
+// TODO: Test irregular and regular time series in models/* and compression.rs.
 
 pub mod bits;
 pub mod gorilla;

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -192,7 +192,13 @@ impl SelectedModel {
 
 /// Compute the number of data points in a time series segment.
 pub fn length(start_time: Timestamp, end_time: Timestamp, timestamps: &[u8]) -> usize {
-    if timestamps[0] & 128 == 0 {
+    if timestamps.is_empty() && start_time == end_time {
+        // Timestamps are assumed to be unique so the segment has one timestamp.
+        1
+    } else if timestamps.is_empty() {
+        // Timestamps are assumed to be unique so the segment has two timestamp.
+        2
+    } else if timestamps::are_compressed_timestamps_regular(timestamps) {
         // The flag bit is zero, so only the segment's length is stored as an
         // integer with all the prefix zeros stripped from the integer.
         let mut bytes_to_decode = [0; 8];

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -18,6 +18,8 @@
 //! each type. The module itself contains general functionality used by the
 //! model types.
 
+// TODO: Expand all tests in models to include both regular and irregular time series.
+
 pub mod bits;
 pub mod gorilla;
 pub mod pmcmean;
@@ -409,12 +411,12 @@ mod tests {
     // Tests for length().
     #[test]
     fn test_length_of_segment_with_one_data_point() {
-        assert_eq!(1, length(1658671178037, 1658671178037, 1000));
+        assert_eq!(1, length(1658671178037, 1658671178037, &[]));
     }
 
     #[test]
     fn test_length_of_segment_with_ten_data_points() {
-        assert_eq!(10, length(1658671178037, 1658671187037, 1000));
+        assert_eq!(10, length(1658671178037, 1658671187047, &[10]));
     }
 
     // Tests for equal_or_nan().

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -105,28 +105,15 @@ impl PMCMean {
     }
 }
 
-/// Compute the minimum value for a time series segment whose values are
-/// represented by a model of type PMC-Mean.
-pub fn min(model: &[u8]) -> Value {
-    decode_model(model)
-}
-
-/// Compute the maximum value for a time series segment whose values are
-/// represented by a model of type PMC-Mean.
-pub fn max(model: &[u8]) -> Value {
-    decode_model(model)
-}
-
 /// Compute the sum of the values for a time series segment whose values are
 /// represented by a model of type PMC-Mean.
 pub fn sum(
     start_time: Timestamp,
     end_time: Timestamp,
-    sampling_interval: i32,
-    model: &[u8],
+    timestamps: &[u8],
+    value: Value
 ) -> Value {
-    let length = models::length(start_time, end_time, sampling_interval);
-    length as Value * decode_model(model)
+    models::length(start_time, end_time, timestamps) as Value * value
 }
 
 /// Reconstruct the values for the `timestamps` without matching values in
@@ -143,13 +130,6 @@ pub fn grid(
         time_series_id_builder.append_value(time_series_id);
         value_builder.append_value(value);
     }
-}
-
-/// Read the coefficient for a model of type PMC-Mean from a slice of bytes. The
-/// coefficient is the average value of the time series segment whose vales are
-/// represented by the model.
-fn decode_model(model: &[u8]) -> Value {
-    Value::from_be_bytes(model.try_into().unwrap())
 }
 
 #[cfg(test)]

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -262,32 +262,11 @@ mod tests {
         return fit_all_values;
     }
 
-    // Tests for min().
-    proptest! {
-    #[test]
-    fn test_min(value in ProptestValue::ANY) {
-        let model = value.to_be_bytes();
-        let min = min(&model);
-        prop_assert!(models::equal_or_nan(min as f64, value as f64));
-    }
-    }
-
-    // Tests for max().
-    proptest! {
-    #[test]
-    fn test_max(value in ProptestValue::ANY) {
-        let model = value.to_be_bytes();
-        let max = max(&model);
-        prop_assert!(models::equal_or_nan(max as f64, value as f64));
-    }
-    }
-
     // Tests for sum().
     proptest! {
     #[test]
     fn test_sum(value in ProptestValue::ANY) {
-        let model = value.to_be_bytes();
-        let sum = sum(1657734000, 1657734540, 60, &model);
+        let sum = sum(1657734000, 1657734540, &[10], value);
         prop_assert!(models::equal_or_nan(sum as f64, (10.0 * value) as f64));
     }
     }
@@ -327,15 +306,6 @@ mod tests {
         prop_assert!(values
             .iter()
             .all(|value_option| models::equal_or_nan(value_option.unwrap() as f64, value as f64)));
-    }
-    }
-
-    // Tests for the decode_model().
-    proptest! {
-    #[test]
-    fn test_decode_model(value in ProptestValue::ANY) {
-        let decoded = decode_model(&value.to_be_bytes());
-        prop_assert!(models::equal_or_nan(decoded as f64, value as f64));
     }
     }
 }

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -275,7 +275,6 @@ mod tests {
     proptest! {
     #[test]
     fn test_grid(value in ProptestValue::ANY) {
-        let model = value.to_be_bytes();
         let sampling_interval: i64 = 60;
         let mut time_series_ids = TimeSeriesIdBuilder::with_capacity(10);
         let timestamps: Vec<Timestamp> = (60..=600).step_by(60).collect();

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -23,7 +23,7 @@
 use crate::models;
 use crate::models::ErrorBound;
 use crate::types::{
-    TimeSeriesId, TimeSeriesIdBuilder, Timestamp, TimestampBuilder, Value, ValueBuilder,
+    TimeSeriesId, TimeSeriesIdBuilder, Timestamp, Value, ValueBuilder,
 };
 
 /// The state the PMC-Mean model type needs while fitting a model to a time
@@ -139,7 +139,7 @@ pub fn grid(
     timestamps: &[Timestamp],
     value_builder: &mut ValueBuilder,
 ) {
-    for timestamp in timestamps {
+    for _timestamp in timestamps {
         time_series_id_builder.append_value(time_series_id);
         value_builder.append_value(value);
     }
@@ -319,22 +319,18 @@ mod tests {
         let model = value.to_be_bytes();
         let sampling_interval: i64 = 60;
         let mut time_series_ids = TimeSeriesIdBuilder::with_capacity(10);
-        let mut timestamps = TimestampBuilder::with_capacity(10);
+        let timestamps: Vec<Timestamp> = (60..=600).step_by(60).collect();
         let mut values = ValueBuilder::with_capacity(10);
 
         grid(
             1,
-            1657734000,
-            1657734540,
-            sampling_interval as i32,
-            &model,
+            value,
             &mut time_series_ids,
-            &mut timestamps,
+            &timestamps,
             &mut values,
         );
 
         let time_series_ids = time_series_ids.finish();
-        let timestamps = timestamps.finish();
         let values = values.finish();
 
         prop_assert!(
@@ -346,7 +342,6 @@ mod tests {
              .iter()
              .all(|time_series_id_option| time_series_id_option.unwrap() == 1));
         prop_assert!(timestamps
-            .values()
             .windows(2)
             .all(|window| window[1] - window[0] == sampling_interval));
         prop_assert!(values

--- a/server/src/models/pmcmean.rs
+++ b/server/src/models/pmcmean.rs
@@ -129,26 +129,19 @@ pub fn sum(
     length as Value * decode_model(model)
 }
 
-/// Reconstruct the data points for a time series segment whose values are
-/// represented by a model of type PMC-Mean. Each data point is split into its
-/// three components and appended to `time_series_ids`, `timestamps`, and
-/// `values`.
+/// Reconstruct the values for the `timestamps` without matching values in
+/// `value_builder` using a model of type PMC-Mean. The `time_series_ids` and
+/// `values` are appended to `time_series_id_builder` and `value_builder`.
 pub fn grid(
     time_series_id: TimeSeriesId,
-    start_time: Timestamp,
-    end_time: Timestamp,
-    sampling_interval: i32,
-    model: &[u8],
-    time_series_ids: &mut TimeSeriesIdBuilder,
-    timestamps: &mut TimestampBuilder,
-    values: &mut ValueBuilder,
+    value: Value,
+    time_series_id_builder: &mut TimeSeriesIdBuilder,
+    timestamps: &[Timestamp],
+    value_builder: &mut ValueBuilder,
 ) {
-    let value = decode_model(model);
-    let sampling_interval = sampling_interval as usize;
-    for timestamp in (start_time..=end_time).step_by(sampling_interval) {
-        time_series_ids.append_value(time_series_id);
-        timestamps.append_value(timestamp);
-        values.append_value(value);
+    for timestamp in timestamps {
+        time_series_id_builder.append_value(time_series_id);
+        value_builder.append_value(value);
     }
 }
 

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -468,18 +468,12 @@ mod tests {
     proptest! {
     #[test]
     fn test_grid(value in num::i32::ANY.prop_map(i32_to_value)) {
-        // The linear function represents a constant to have a known value.
-        let (slope, intercept) = compute_slope_and_intercept(
-            FIRST_TIMESTAMP,
-            value as f64,
-            FINAL_TIMESTAMP,
-            value as f64,
-        );
         let timestamps: Vec<Timestamp> = (FIRST_TIMESTAMP ..= FINAL_TIMESTAMP)
             .step_by(SAMPLING_INTERVAL as usize).collect();
         let mut time_series_ids = TimeSeriesIdBuilder::with_capacity(timestamps.len());
         let mut values = ValueBuilder::with_capacity(timestamps.len());
 
+        // The linear function represents a constant to have a known value.
         grid(
             1,
             FIRST_TIMESTAMP,

--- a/server/src/models/swing.rs
+++ b/server/src/models/swing.rs
@@ -247,27 +247,27 @@ pub fn sum(
     (average * length as f64) as Value
 }
 
-/// Reconstruct the data points for a time series segment whose values are
-/// represented by a model of type Swing. Each data point is split into its
-/// three components and appended to `time_series_ids`, `timestamps`, and
-/// `values`.
+/// Reconstruct the values for the `timestamps` without matching values in
+/// `value_builder` using a model of type Swing. The `time_series_ids` and
+/// `values` are appended to `time_series_id_builder` and `value_builder`.
 pub fn grid(
     time_series_id: TimeSeriesId,
     start_time: Timestamp,
     end_time: Timestamp,
-    sampling_interval: i32,
-    model: &[u8],
+    min_value: Value,
+    max_value: Value,
     time_series_ids: &mut TimeSeriesIdBuilder,
-    timestamps: &mut TimestampBuilder,
-    values: &mut ValueBuilder,
+    timestamps: &[Timestamp],
+    value_builder: &mut ValueBuilder,
 ) {
-    let (slope, intercept) = decode_model(model);
-    let sampling_interval = sampling_interval as usize;
-    for timestamp in (start_time..=end_time).step_by(sampling_interval) {
+    // TODO: how to encode if min or max is the first or last value?
+    let (slope, intercept) =
+        compute_slope_and_intercept(start_time, min_value as f64, end_time, max_value as f64);
+
+    for timestamp in timestamps {
         time_series_ids.append_value(time_series_id);
-        timestamps.append_value(timestamp);
-        let value = (slope * timestamp as f64 + intercept) as Value;
-        values.append_value(value);
+        let value = (slope * (*timestamp as f64) + intercept) as Value;
+        value_builder.append_value(value);
     }
 }
 

--- a/server/src/models/timestamps.rs
+++ b/server/src/models/timestamps.rs
@@ -1,4 +1,4 @@
-/* Copyright 2022 The ModelarDB C&ontributors
+/* Copyright 2022 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/models/timestamps.rs
+++ b/server/src/models/timestamps.rs
@@ -196,9 +196,11 @@ fn decompress_all_regular_timestamps(
     timestamp_builder: &mut TimestampBuilder,
 ) {
     let mut bytes_to_decode = [0; 8];
-    bytes_to_decode[..residual_timestamps.len()].copy_from_slice(residual_timestamps);
+    let bytes_to_decode_len = bytes_to_decode.len();
+    bytes_to_decode[bytes_to_decode_len - residual_timestamps.len()..]
+        .copy_from_slice(residual_timestamps);
 
-    let length = usize::from_le_bytes(bytes_to_decode);
+    let length = usize::from_be_bytes(bytes_to_decode);
     let sampling_interval = (end_time - start_time) as usize / (length - 1);
     for timestamp in (start_time..=end_time).step_by(sampling_interval) {
         timestamp_builder.append_value(timestamp);

--- a/server/src/models/timestamps.rs
+++ b/server/src/models/timestamps.rs
@@ -189,7 +189,7 @@ pub fn decompress_all_timestamps(
 /// sampling interval, otherwise [`false`].
 pub fn are_compressed_timestamps_regular(residual_timestamps: &[u8]) -> bool {
     // The flag bit is zero so the timestamps follow a regular interval.
-    residual_timestamps[0] & 128 == 0
+    residual_timestamps.is_empty() || residual_timestamps[0] & 128 == 0
 }
 
 /// Decompress all of a segment's timestamps, which for this segment are sampled

--- a/server/src/optimizer/model_simple_aggregates.rs
+++ b/server/src/optimizer/model_simple_aggregates.rs
@@ -62,36 +62,37 @@ pub struct ModelSimpleAggregatesPhysicalOptimizerRule {}
 impl ModelSimpleAggregatesPhysicalOptimizerRule {
     fn optimize(&self, plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
         // Matches a simple aggregate performed without filtering out segments.
-        if let Some(hae) = plan.as_any().downcast_ref::<AggregateExec>() {
-            let children = &hae.children();
+        if let Some(aggregate_exec) = plan.as_any().downcast_ref::<AggregateExec>() {
+            let children = &aggregate_exec.children();
             if children.len() == 1 {
-                let ae = hae.aggr_expr();
-                if ae.len() == 1 {
+                let aggregate_expr = aggregate_exec.aggr_expr();
+                if aggregate_expr.len() == 1 {
                     // TODO: simplify and factor out shared code using macros or functions.
-                    if ae[0].as_any().downcast_ref::<Count>().is_some() {
-                        if let Some(ge) = children[0].as_any().downcast_ref::<GridExec>() {
-                            let mae = ModelAggregateExpr::new(ModelAggregateType::Count);
-                            return Some(new_aggregate(hae, mae, ge));
+                    if aggregate_expr[0].as_any().downcast_ref::<Count>().is_some() {
+                        if let Some(grid_exec) = children[0].as_any().downcast_ref::<GridExec>() {
+                            let model_aggregate =
+                                ModelAggregateExpr::new(ModelAggregateType::Count);
+                            return Some(new_aggregate(aggregate_exec, model_aggregate, grid_exec));
                         }
-                    } else if ae[0].as_any().downcast_ref::<Min>().is_some() {
-                        if let Some(ge) = children[0].as_any().downcast_ref::<GridExec>() {
-                            let mae = ModelAggregateExpr::new(ModelAggregateType::Min);
-                            return Some(new_aggregate(hae, mae, ge));
+                    } else if aggregate_expr[0].as_any().downcast_ref::<Min>().is_some() {
+                        if let Some(grid_exec) = children[0].as_any().downcast_ref::<GridExec>() {
+                            let model_aggregate = ModelAggregateExpr::new(ModelAggregateType::Min);
+                            return Some(new_aggregate(aggregate_exec, model_aggregate, grid_exec));
                         }
-                    } else if ae[0].as_any().downcast_ref::<Max>().is_some() {
-                        if let Some(ge) = children[0].as_any().downcast_ref::<GridExec>() {
-                            let mae = ModelAggregateExpr::new(ModelAggregateType::Max);
-                            return Some(new_aggregate(hae, mae, ge));
+                    } else if aggregate_expr[0].as_any().downcast_ref::<Max>().is_some() {
+                        if let Some(grid_exec) = children[0].as_any().downcast_ref::<GridExec>() {
+                            let model_aggregate = ModelAggregateExpr::new(ModelAggregateType::Max);
+                            return Some(new_aggregate(aggregate_exec, model_aggregate, grid_exec));
                         }
-                    } else if ae[0].as_any().downcast_ref::<Sum>().is_some() {
-                        if let Some(ge) = children[0].as_any().downcast_ref::<GridExec>() {
-                            let mae = ModelAggregateExpr::new(ModelAggregateType::Sum);
-                            return Some(new_aggregate(hae, mae, ge));
+                    } else if aggregate_expr[0].as_any().downcast_ref::<Sum>().is_some() {
+                        if let Some(grid_exec) = children[0].as_any().downcast_ref::<GridExec>() {
+                            let model_aggregate = ModelAggregateExpr::new(ModelAggregateType::Sum);
+                            return Some(new_aggregate(aggregate_exec, model_aggregate, grid_exec));
                         }
-                    } else if ae[0].as_any().downcast_ref::<Avg>().is_some() {
-                        if let Some(ge) = children[0].as_any().downcast_ref::<GridExec>() {
-                            let mae = ModelAggregateExpr::new(ModelAggregateType::Avg);
-                            return Some(new_aggregate(hae, mae, ge));
+                    } else if aggregate_expr[0].as_any().downcast_ref::<Avg>().is_some() {
+                        if let Some(grid_exec) = children[0].as_any().downcast_ref::<GridExec>() {
+                            let model_aggregate = ModelAggregateExpr::new(ModelAggregateType::Avg);
+                            return Some(new_aggregate(aggregate_exec, model_aggregate, grid_exec));
                         }
                     }
                 }

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -44,7 +44,7 @@ use object_store;
 use rusqlite::{params, Connection};
 use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::catalog;
 use crate::catalog::{NewModelTableMetadata, TableMetadata};
@@ -151,7 +151,7 @@ impl FlightServiceHandler {
         model_table: &NewModelTableMetadata,
         flight_data_stream: &mut Streaming<FlightData>,
     ) -> Result<(), Status> {
-        info!("Ingesting data into model table '{}'.", model_table.name);
+        debug!("Ingesting data into model table '{}'.", model_table.name);
 
         // Retrieve the data until the request does not contain any more data.
         while let Some(flight_data) = flight_data_stream.next().await {

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -46,6 +46,7 @@ use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{error, info};
 
+use crate::catalog;
 use crate::catalog::{NewModelTableMetadata, TableMetadata};
 use crate::storage::StorageEngine;
 use crate::Context;
@@ -247,7 +248,7 @@ impl FlightServiceHandler {
             .map_err(|error: ArrowError| Status::internal(error.to_string()))?;
 
         // Persist the new model table to the metadata database.
-        let database_path = catalog.data_folder_path.join("metadata.sqlite3");
+        let database_path = catalog.data_folder_path.join(catalog::METADATA_SQLITE_NAME);
         save_model_table_to_database(database_path, &model_table_metadata, ipc_message.0)
             .map_err(|error| Status::internal(error.to_string()))?;
 

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -582,7 +582,7 @@ fn save_model_table_to_database(
     // The query is executed with a formatted string since CREATE TABLE cannot take parameters.
     transaction.execute(
         format!(
-            "CREATE TABLE {}_tags (hash BIGINT PRIMARY KEY, {})",
+            "CREATE TABLE {}_tags (hash INTEGER PRIMARY KEY, {}) STRICT",
             model_table_metadata.name, tag_columns
         )
         .as_str(),

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -20,7 +20,7 @@ use std::fs;
 use std::path:: PathBuf;
 
 use datafusion::arrow::record_batch::RecordBatch;
-use tracing::{info, info_span};
+use tracing::{debug, debug_span};
 
 use crate::errors::ModelarDBError;
 use crate::storage::time_series::CompressedTimeSeries;
@@ -57,8 +57,8 @@ impl CompressedDataManager {
 
     /// Insert `segment` into the in-memory compressed time series buffer.
     pub(super) fn insert_compressed_segment(&mut self, key: u64, segment: RecordBatch) {
-        let _span = info_span!("insert_compressed_segment", key = key.clone()).entered();
-        info!(
+        let _span = debug_span!("insert_compressed_segment", key = key.clone()).entered();
+        debug!(
             "Inserting batch with {} rows into compressed time series.",
             segment.num_rows()
         );
@@ -66,11 +66,11 @@ impl CompressedDataManager {
         // Since the compressed segment is already in memory, insert the segment into the structure
         // first and check if the reserved memory limit is exceeded after.
         let segment_size = if let Some(time_series) = self.compressed_data.get_mut(&key) {
-            info!("Found existing compressed time series.");
+            debug!("Found existing compressed time series.");
 
             time_series.append_segment(segment)
         } else {
-            info!("Could not find compressed time series. Creating compressed time series.");
+            debug!("Could not find compressed time series. Creating compressed time series.");
 
             let mut time_series = CompressedTimeSeries::new();
             let segment_size = time_series.append_segment(segment);
@@ -132,7 +132,7 @@ impl CompressedDataManager {
 
     /// Save [`CompressedTimeSeries`] to disk until the reserved memory limit is no longer exceeded.
     fn save_compressed_data_to_free_memory(&mut self) {
-        info!("Out of memory for compressed data. Saving compressed data to disk.");
+        debug!("Out of memory for compressed data. Saving compressed data to disk.");
 
         while self.compressed_remaining_memory_in_bytes < 0 {
             let key = self.compressed_queue.pop_front().unwrap();
@@ -143,7 +143,7 @@ impl CompressedDataManager {
     /// Save the compressed data corresponding to `key` to disk. The size of the saved compressed
     /// data is added back to the remaining reserved memory.
     fn save_compressed_data(&mut self, key: &u64) {
-        info!("Saving compressed time series with key '{}' to disk.", key);
+        debug!("Saving compressed time series with key '{}' to disk.", key);
 
         let mut time_series = self.compressed_data.remove(&key).unwrap();
         let folder_path = self.data_folder_path.join(key.to_string());
@@ -151,7 +151,7 @@ impl CompressedDataManager {
 
         self.compressed_remaining_memory_in_bytes += time_series.size_in_bytes as isize;
 
-        info!(
+        debug!(
             "Saved {} bytes of compressed data to disk. Remaining reserved bytes: {}.",
             time_series.size_in_bytes, self.compressed_remaining_memory_in_bytes
         );

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -29,7 +29,7 @@ use crate::types::Timestamp;
 
 /// Signed integer since compressed data is inserted first and the remaining bytes are checked after.
 /// This means that the remaining bytes can be negative briefly until compressed data is saved to disk.
-const COMPRESSED_RESERVED_MEMORY_IN_BYTES: isize = 1000000;
+const COMPRESSED_RESERVED_MEMORY_IN_BYTES: isize = 512 * 1024 * 1024; // 512 MiB
 
 /// Stores data points compressed as models in memory to batch compressed data before saving it to
 /// Apache Parquet files.

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -96,6 +96,17 @@ impl StorageEngine {
         self.uncompressed_data_manager.get_finished_segment()
     }
 
+    /// Flush all of the data the [`StorageEngine`] is managing to disk.
+    pub fn flush(&mut self) {
+        // Flush UncompressedDataManager.
+        for (key, segment) in self.uncompressed_data_manager.flush() {
+            self.compressed_data_manager.insert_compressed_segment(key, segment);
+        }
+
+        // Flush CompressedDataManager.
+        self.compressed_data_manager.flush();
+    }
+
     /// Pass `segment` to [`CompressedDataManager`].
     pub fn insert_compressed_segment(&mut self, key: u64, segment: RecordBatch) {
         self.compressed_data_manager.insert_compressed_segment(key, segment)

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -292,7 +292,7 @@ mod tests {
         assert_eq!(files.len(), 1);
 
         // The path to the returned compressed file should contain the key of the second segment.
-        let file_path = files.get(0).unwrap().location.to_string();
+        let file_path = files.get(0).unwrap().1.location.to_string();
         assert!(file_path.contains("2/compressed"));
     }
 
@@ -311,7 +311,7 @@ mod tests {
         assert_eq!(files.len(), 1);
 
         // The path to the returned compressed file should contain the key of the first segment.
-        let file_path = files.get(0).unwrap().location.to_string();
+        let file_path = files.get(0).unwrap().1.location.to_string();
         assert!(file_path.contains("1/compressed"));
     }
 
@@ -336,10 +336,10 @@ mod tests {
         assert_eq!(files.len(), 2);
 
         // The paths to the returned compressed files should contain the key of the second and third segment.
-        let file_path = files.get(0).unwrap().location.to_string();
+        let file_path = files.get(0).unwrap().1.location.to_string();
         assert!(file_path.contains("2/compressed"));
 
-        let file_path = files.get(1).unwrap().location.to_string();
+        let file_path = files.get(1).unwrap().1.location.to_string();
         assert!(file_path.contains("3/compressed"));
     }
 

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -122,7 +122,7 @@ impl StorageEngine {
         end_time: Option<Timestamp>
     ) -> Result<Vec<ObjectMeta>, ModelarDBError> {
         let start_time = start_time.unwrap_or(0);
-        let end_time = end_time.unwrap_or(i64::MAX);
+        let end_time = end_time.unwrap_or(Timestamp::MAX);
         let mut compressed_files: Vec<ObjectMeta> = vec![];
 
         if start_time > end_time {

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -39,7 +39,7 @@ use object_store::ObjectMeta;
 use object_store::path::Path as ObjectStorePath;
 use chrono::DateTime;
 
-use crate::catalog::NewModelTableMetadata;
+use crate::catalog::ModelTableMetadata;
 use crate::errors::ModelarDBError;
 use crate::storage::compressed_data_manager::CompressedDataManager;
 use crate::storage::segment::FinishedSegment;
@@ -77,7 +77,7 @@ impl StorageEngine {
     /// successfully inserted, otherwise return [`Err`].
     pub fn insert_data_points(
         &mut self,
-        model_table: &NewModelTableMetadata,
+        model_table: &ModelTableMetadata,
         data_points: &RecordBatch
     ) -> Result<(), String> {
         // TODO: When the compression component is changed, just insert the data points.

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -120,10 +120,10 @@ impl StorageEngine {
         keys: &[u64],
         start_time: Option<Timestamp>,
         end_time: Option<Timestamp>
-    ) -> Result<Vec<ObjectMeta>, ModelarDBError> {
+    ) -> Result<Vec<(String, ObjectMeta)>, ModelarDBError> {
         let start_time = start_time.unwrap_or(0);
         let end_time = end_time.unwrap_or(Timestamp::MAX);
-        let mut compressed_files: Vec<ObjectMeta> = vec![];
+        let mut compressed_files: Vec<(String, ObjectMeta)> = vec![];
 
         if start_time > end_time {
             return Err(ModelarDBError::DataRetrievalError(format!(
@@ -144,11 +144,11 @@ impl StorageEngine {
                     let metadata = fs::metadata(&file_path).unwrap();
 
                     // Create an object that contains the file path and extra metadata about the file.
-                    Some(ObjectMeta {
+                    Some((key.to_string(), ObjectMeta {
                         location: ObjectStorePath::from(file_path.to_str().unwrap()),
                         last_modified: DateTime::from(metadata.modified().unwrap()),
                         size: metadata.len() as usize
-                    })
+                    }))
                 } else {
                     None
                 }

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -55,7 +55,7 @@ const APACHE_PARQUET_FILE_SIGNATURE: &[u8] = &[80, 65, 82, 49]; // PAR1.
 
 /// Note that the capacity has to be a multiple of 64 bytes to avoid the actual capacity
 /// being larger due to internal alignment when allocating memory for the builders.
-const BUILDER_CAPACITY: usize = 64;
+const BUILDER_CAPACITY: usize = 64 * 1024; // Each element is a Timestamp and a Value.
 
 /// Manages all uncompressed and compressed data, both while being built and when finished.
 pub struct StorageEngine {

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -224,7 +224,7 @@ impl StorageEngine {
         // Create a reader that can be used to read an Apache Parquet file.
         let file = File::open(file_path).map_err(|_e| error.clone())?;
         let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
-        let mut reader = builder.build()?;
+        let mut reader = builder.with_batch_size(usize::MAX).build()?;
 
         let record_batch = reader.next().ok_or_else(|| error)??;
         Ok(record_batch)

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -230,7 +230,8 @@ impl StorageEngine {
         Ok(record_batch)
     }
 
-    /// Return `true` if `file_path` is a readable Apache Parquet file, otherwise `false`.
+    /// Return [`true`] if `file_path` is a readable Apache Parquet file,
+    /// otherwise [`false`].
     pub fn is_path_an_apache_parquet_file(file_path: &Path) -> bool {
         if let Ok(mut file) = File::open(file_path) {
             let mut first_four_bytes = vec![0u8; 4];

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -74,7 +74,8 @@ impl SegmentBuilder {
             + (BUILDER_CAPACITY * mem::size_of::<Value>())
     }
 
-    /// Return `true` if the [`SegmentBuilder`] is full, meaning additional data points cannot be appended.
+    /// Return [`true`] if the [`SegmentBuilder`] is full, meaning additional
+    /// data points cannot be appended.
     pub(super) fn is_full(&self) -> bool {
         self.get_length() == self.get_capacity()
     }

--- a/server/src/storage/segment.rs
+++ b/server/src/storage/segment.rs
@@ -27,7 +27,7 @@ use std::{fmt, fs, mem};
 use datafusion::arrow::array::{Array, ArrayBuilder};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::parquet::errors::ParquetError;
-use tracing::info;
+use tracing::debug;
 
 use crate::get_array;
 use crate::storage::{StorageEngine, BUILDER_CAPACITY};
@@ -95,7 +95,7 @@ impl SegmentBuilder {
         self.timestamps.append_value(timestamp);
         self.values.append_value(value);
 
-        info!("Inserted data point into segment with {}.", self)
+        debug!("Inserted data point into segment with {}.", self)
     }
 
     /// Return how many data points the [`SegmentBuilder`] can contain.

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -332,8 +332,7 @@ impl UncompressedDataManager {
             error_bound
         ).unwrap();
 
-        //compression::merge_segments(compressed_segments)
-        compressed_segments
+        compression::merge_segments(compressed_segments)
     }
 
     /// Move `segment_builder` to the queue of [`FinishedSegments`](FinishedSegment).

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -32,7 +32,7 @@ use crate::models::ErrorBound;
 use crate::storage::segment::{FinishedSegment, SegmentBuilder, UncompressedSegment};
 use crate::types::{Timestamp, TimestampArray, Value, ValueArray};
 
-const UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES: usize = 5000;
+const UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES: usize = 512 * 1024 * 1024; // 512 MiB
 
 /// Converts a batch of data to uncompressed data points and stores uncompressed data points
 /// temporarily in an in-memory buffer that spills to Apache Parquet files. When finished the data

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -26,7 +26,7 @@ use rusqlite::Connection;
 use tracing::{debug, debug_span};
 
 use crate::catalog;
-use crate::catalog::NewModelTableMetadata;
+use crate::catalog::ModelTableMetadata;
 use crate::{compression, get_array};
 use crate::models::ErrorBound;
 use crate::storage::segment::{FinishedSegment, SegmentBuilder, UncompressedSegment};
@@ -74,7 +74,7 @@ impl UncompressedDataManager {
     /// successfully inserted, otherwise return [`Err`].
     pub(super) fn insert_data_points(
         &mut self,
-        model_table: &NewModelTableMetadata,
+        model_table: &ModelTableMetadata,
         data_points: &RecordBatch,
     ) -> Result<Vec<(u64, RecordBatch)>, String> {
         let _span = debug_span!("insert_data_points", table = model_table.name).entered();
@@ -181,7 +181,7 @@ impl UncompressedDataManager {
     /// the table could not be accessed, return [`rusqlite::Error`].
     fn get_or_compute_tag_hash(
         &mut self,
-        model_table: &NewModelTableMetadata,
+        model_table: &ModelTableMetadata,
         tag_values: &Vec<String>,
     ) -> Result<u64, rusqlite::Error> {
         let cache_key = {
@@ -454,7 +454,7 @@ mod tests {
     /// Create a record batch with data that resembles uncompressed data with a single tag and two
     /// field columns. The returned data has `row_count` rows, with a different tag for each row.
     /// Also create model table metadata for a model table that matches the created data.
-    fn get_uncompressed_data(row_count: usize) -> (NewModelTableMetadata, RecordBatch) {
+    fn get_uncompressed_data(row_count: usize) -> (ModelTableMetadata, RecordBatch) {
         let tags: Vec<String> = (0..row_count).map(|tag| tag.to_string()).collect();
         let timestamps: Vec<Timestamp> = (0..row_count).map(|ts| ts as Timestamp).collect();
         let values: Vec<Value> = (0..row_count).map(|value| value as Value).collect();
@@ -476,7 +476,7 @@ mod tests {
             ],
         ).unwrap();
 
-        let model_table_metadata = NewModelTableMetadata::try_new(
+        let model_table_metadata = ModelTableMetadata::try_new(
             "model_table".to_owned(),
             schema,
             vec![0],
@@ -488,7 +488,7 @@ mod tests {
 
     // TODO: This is duplicated from a function in remote. Change this when the metadata component exists.
     /// Create the table in the metadata database that contains the tag hashes.
-    fn create_model_table_tags_table(model_table_metadata: &NewModelTableMetadata, path: &Path) {
+    fn create_model_table_tags_table(model_table_metadata: &ModelTableMetadata, path: &Path) {
         let database_path = path.join(catalog::METADATA_SQLITE_NAME);
         let connection = Connection::open(database_path).unwrap();
 

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -25,6 +25,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use rusqlite::Connection;
 use tracing::{info, info_span};
 
+use crate::catalog;
 use crate::catalog::NewModelTableMetadata;
 use crate::{compression, get_array};
 use crate::models::ErrorBound;
@@ -204,7 +205,7 @@ impl UncompressedDataManager {
                 .collect::<Vec<String>>()
                 .join(",");
 
-            let database_path = self.data_folder_path.join("metadata.sqlite3");
+            let database_path = self.data_folder_path.join(catalog::METADATA_SQLITE_NAME);
             let connection = Connection::open(database_path)?;
 
             // OR IGNORE is used to silently fail when trying to insert an already existing hash.
@@ -407,7 +408,7 @@ mod tests {
         assert_eq!(data_manager.tag_value_hashes.keys().len(), 1);
 
         // It should also be saved in the metadata database table.
-        let database_path = temp_dir.path().join("metadata.sqlite3");
+        let database_path = temp_dir.path().join(catalog::METADATA_SQLITE_NAME);
         let connection = Connection::open(database_path).unwrap();
 
         let mut statement = connection.prepare("SELECT * FROM model_table_tags").unwrap();
@@ -471,7 +472,7 @@ mod tests {
     // TODO: This is duplicated from a function in remote. Change this when the metadata component exists.
     /// Create the table in the metadata database that contains the tag hashes.
     fn create_model_table_tags_table(model_table_metadata: &NewModelTableMetadata, path: &Path) {
-        let database_path = path.join("metadata.sqlite3");
+        let database_path = path.join(catalog::METADATA_SQLITE_NAME);
         let connection = Connection::open(database_path).unwrap();
 
         // Add a column definition for each tag field in the schema.

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -332,7 +332,8 @@ impl UncompressedDataManager {
             error_bound
         ).unwrap();
 
-        compression::merge_segments(compressed_segments)
+        //compression::merge_segments(compressed_segments)
+        compressed_segments
     }
 
     /// Move `segment_builder` to the queue of [`FinishedSegments`](FinishedSegment).

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -21,7 +21,6 @@
 use std::any::Any;
 use std::fmt;
 use std::fmt::Formatter;
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context as StdTaskContext, Poll};

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -276,7 +276,7 @@ impl TableProvider for ModelTable {
 
     async fn scan(
         &self,
-        ctx: &SessionState,
+        _ctx: &SessionState,
         projection: &Option<Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
@@ -451,7 +451,6 @@ impl ExecutionPlan for GridExec {
         task_context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         Ok(Box::pin(GridStream::new(
-            self.model_table_metadata.clone(),
             self.projection.clone(),
             self.limit,
             self.schema_after_projection.clone(),
@@ -491,9 +490,8 @@ impl ExecutionPlan for GridExec {
 
 /* Stream */
 struct GridStream {
-    model_table_metadata: Arc<ModelTableMetadata>,
     projection: Vec<usize>,
-    limit: Option<usize>,
+    _limit: Option<usize>,
     schema_after_projection: SchemaRef,
     input: SendableRecordBatchStream,
     baseline_metrics: BaselineMetrics,
@@ -501,7 +499,6 @@ struct GridStream {
 
 impl GridStream {
     fn new(
-        model_table_metadata: Arc<ModelTableMetadata>,
         projection: Vec<usize>,
         limit: Option<usize>,
         schema_after_projection: SchemaRef,
@@ -509,9 +506,8 @@ impl GridStream {
         baseline_metrics: BaselineMetrics,
     ) -> Self {
         GridStream {
-            model_table_metadata,
             projection,
-            limit,
+            _limit: limit,
             schema_after_projection,
             input,
             baseline_metrics,
@@ -534,7 +530,7 @@ impl GridStream {
             values_array,
             min_value_array,
             max_value_array,
-            error_array
+            _error_array
         );
 
         // Each segments contains at least one data point.

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -768,7 +768,6 @@ mod tests {
         let filters = vec!(new_binary_expr(col("model_type_id"), Operator::Eq, lit(1)));
         let predicates = rewrite_and_combine_filters(&filters);
         let parquet_exec = new_parquet_exec();
-        new_filter_exec(&predicates, &parquet_exec).unwrap();
 
         assert!(new_filter_exec(&predicates, &parquet_exec).is_ok());
     }

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -765,9 +765,10 @@ mod tests {
 
     #[test]
     fn test_new_filter_exec_with_predicates() {
-        let filters = vec!(new_binary_expr(col("timestamp"), Operator::Eq, lit(37)));
+        let filters = vec!(new_binary_expr(col("model_type_id"), Operator::Eq, lit(1)));
         let predicates = rewrite_and_combine_filters(&filters);
         let parquet_exec = new_parquet_exec();
+        new_filter_exec(&predicates, &parquet_exec).unwrap();
 
         assert!(new_filter_exec(&predicates, &parquet_exec).is_ok());
     }

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -227,7 +227,7 @@ impl ModelTable {
         };
 
         // Retrieve the hashes using the query and reconstruct the keys.
-        self.lookup_keys_from_sqlite_database(&database_path, &query_hashes, &query_field_columns)
+        self.lookup_keys_from_sqlite_database(&database_path, &query_field_columns, &query_hashes)
             .map_err(|error| DataFusionError::Plan(error.to_string()))
     }
 

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -41,7 +41,6 @@ use datafusion::physical_plan::{
     metrics::MetricsSet, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
 };
-use datafusion::scalar::ScalarValue::{Int64, TimestampNanosecond};
 use datafusion_physical_expr::planner;
 use futures::stream::{Stream, StreamExt};
 use rusqlite::{Connection, Result as RusqliteResult};

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -252,8 +252,12 @@ impl ModelTable {
 
         let mut keys = vec![];
         while let Some(row) = rows.next()? {
+            // SQLite use signed integers https://www.sqlite.org/datatype3.html.
+            let signed_tag_hash = row.get::<usize, i64>(0)?;
+            let tag_hash = u64::from_ne_bytes(signed_tag_hash.to_ne_bytes());
+
             for field_column in &field_columns {
-                keys.push(row.get::<usize, u64>(0)? | field_column);
+                keys.push(tag_hash | field_column);
             }
         }
         Ok(keys)

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -21,15 +21,15 @@
 //! assumed that each set of aliases are all for the same underlying type.
 
 // Types used for a single time series id.
-pub type TimeSeriesId = std::primitive::i32; // Signed integer for compatibility with tables.rs.
-pub type ArrowTimeSeriesId = datafusion::arrow::datatypes::Int32Type;
+pub type TimeSeriesId = std::primitive::u64;
+pub type ArrowTimeSeriesId = datafusion::arrow::datatypes::UInt64Type;
 
 // Types used for a collection of time series ids.
 pub type TimeSeriesIdBuilder = datafusion::arrow::array::PrimitiveBuilder<ArrowTimeSeriesId>;
 pub type TimeSeriesIdArray = datafusion::arrow::array::PrimitiveArray<ArrowTimeSeriesId>;
 
 // Types used for a single timestamp.
-pub type Timestamp = std::primitive::i64; // Signed integer for compatibility with tables.rs.
+pub type Timestamp = std::primitive::i64; // It is signed to match TimestampMillisecondType.
 pub type ArrowTimestamp = datafusion::arrow::datatypes::TimestampMillisecondType;
 
 // Types used for a collection of timestamps.
@@ -41,7 +41,7 @@ pub type Value = std::primitive::f32;
 pub type ArrowValue = datafusion::arrow::datatypes::Float32Type;
 #[cfg(test)] // Proptest is a development dependency.
 pub mod tests {
-    // proptest::num::i64 is not a type. A signed integer is used for compatibility with tables.rs.
+    // proptest::num::i64 is not a type. It is signed to match TimestampMillisecondType.
     pub use proptest::num::i64 as ProptestTimestamp;
 
     // proptest::num::f32 is not a type.


### PR DESCRIPTION
The primary focus of this PR is to refactor the code in `table.rs` which adds support for querying model tables to Apache Arrow DataFusion. The `TODO`s that stated that a change should be made when `tables.rs` was refactored have also been fixed. However, a few of the broader `TODO`s have been rewritten and moved to a suitable location as the changes they suggested were not required for model tables to be queried and the changes they suggested would increase the size of this somewhat large PR. Multiple minor issues have also been fixed throughout the code base as they prevented model tables from being queried. Unfortunately, this PR also increases the time required to run all of the unit tests from 0.82s to 39.26s on my development VM as the buffers used by the storage engine have been made significantly larger.