### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,15 +66,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,11 +85,15 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "arrow"
-version = "22.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5936b4185aa57cb9790d8742aab22859045ce5cc6a3023796240cd101c19335"
+checksum = "d68391300d5237f6725f0f869ae7cb65d45fcf8a6d18f6ceecd328fb803bef93"
 dependencies = [
  "ahash 0.8.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "bitflags",
  "chrono",
  "comfy-table",
@@ -113,15 +108,51 @@ dependencies = [
  "num",
  "regex",
  "regex-syntax",
- "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "arrow-flight"
-version = "22.0.0"
+name = "arrow-array"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660ed54d9d068c21281154fbf1d91905df679a81ba4a83f1742f48c40c91804f"
+checksum = "f0bb00c5862b5eea683812083c495bef01a9a5149da46ad2f4c0e4aa8800f64d"
+dependencies = [
+ "ahash 0.8.0",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e594d0fe0026a8bc2459bdc5ac9623e5fb666724a715e0acbc96ba30c5d4cc7"
+dependencies = [
+ "half",
+]
+
+[[package]]
+name = "arrow-data"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8500df05060d86fdc53e9b5cb32e51bfeaacc040fdeced3eb99ac0d59200ff45"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-flight"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5438183d2f3404f57418847a06a3925037916f80ed8aefc904276b41e7f90322"
 dependencies = [
  "arrow",
  "base64",
@@ -134,6 +165,12 @@ dependencies = [
  "tonic",
  "tonic-build",
 ]
+
+[[package]]
+name = "arrow-schema"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d1fef01f25e1452c86fa6887f078de8e0aaeeb828370feab205944cfc30e27"
 
 [[package]]
 name = "async-stream"
@@ -481,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aca80caa2b0f7fdf267799b8895ac8b6341ea879db6b1e2d361ec49b47bc676"
+checksum = "a2bdec06a3db088da76fc28cb0877b8b5438ca6b6025e04d975bace0fd85df19"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -521,23 +558,22 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7721fd550f6a28ad7235b62462aa51e9a43b08f8346d5cbe4d61f1e83f5df511"
+checksum = "506eab038bf2d39ac02c22be30b019873ca01f887148b939d309a0e9523f4515"
 dependencies = [
  "arrow",
  "object_store",
  "ordered-float 3.1.0",
  "parquet",
- "serde_json",
  "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d81255d043dc594c0ded6240e8a9be6ce8d7c22777a5093357cdb97af3d29ce"
+checksum = "b3d2810e369c735d69479e27fe8410e97a76ed07484aa9b3ad7c039efa504257"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -547,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b39f8c75163691fff72b4a71816ad5a912e7c6963ee55f29ed1910b5a6993f"
+checksum = "60f3b80326243629d02e33f37e955a7114781c6c44caf9d8b254618157de7143"
 dependencies = [
  "arrow",
  "async-trait",
@@ -563,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c4138220a109feafb63bf05418b86b17a42ece4bf047c38e4fd417572a9f7"
+checksum = "e9bf3b7ae861d351a85174fd4fddb29d249950b2f23671318971960452b4b9ab"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -588,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-row"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a178fc0fd7693d9c9f608f7b605823eb982c6731ede0cccd99e2319cacabbc"
+checksum = "3f44a2a722719c569b437b3aa2108a99dc911369e8d86c44e6293225c3387147"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -600,17 +636,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148cb56e7635faff3b16019393c49b988188c3fdadd1ca90eadb322a80aa1128"
+checksum = "e98493e04385c924d1d3d7ab8739c41f1ebf676a46863181103a0fb9c7168fa9"
 dependencies = [
- "ahash 0.8.0",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
- "hashbrown",
  "sqlparser",
- "tokio",
 ]
 
 [[package]]
@@ -930,6 +963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
 dependencies = [
  "crunchy",
+ "num-traits",
 ]
 
 [[package]]
@@ -1085,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "integer-encoding"
-version = "1.1.7"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-lifetimes"
@@ -1209,6 +1243,12 @@ name = "libc"
 version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+
+[[package]]
+name = "libm"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1397,6 +1437,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,6 +1520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1527,6 +1578,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "22.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474c423be6f10921adab3b94b42ec7fe87c1b87e1360dee150976caee444224f"
+checksum = "74fd590f0672998df84503d1bcbebc69732583d03cc3495c7dd8d3e5a1d8437f"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1567,22 +1624,12 @@ dependencies = [
  "lz4",
  "num",
  "num-bigint",
- "parquet-format",
  "rand",
  "seq-macro",
  "snap",
  "thrift",
  "tokio",
  "zstd",
-]
-
-[[package]]
-name = "parquet-format"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0c06cdcd5460967c485f9c40a821746f5955ad81990533c7fae95dbd9bc0b5"
-dependencies = [
- "thrift",
 ]
 
 [[package]]
@@ -1972,20 +2019,6 @@ name = "serde"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.145"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "serde_json"
@@ -2100,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beb13adabbdda01b63d595f38c8bfd19a361e697fd94ce0098a634077bc5b25"
+checksum = "0781f2b6bd03e5adf065c8e772b49eaea9f640d06a1b9130330fe8bd2563f4fd"
 dependencies = [
  "log",
 ]
@@ -2205,25 +2238,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
 name = "thrift"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
+checksum = "09678c4cdbb4eed72e18b7c2af1329c69825ed16fcbac62d083fc3e2b0590ff0"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "log",
  "ordered-float 1.1.1",
- "threadpool",
 ]
 
 [[package]]
@@ -2263,9 +2285,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2273,7 +2295,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2330,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd56bdb54ef93935a6a79dbd1d91f1ebd4c64150fd61654031fd6b8b775c91"
+checksum = "55b9af819e54b8f33d453655bef9b9acc171568fb49523078d0cc4e7484200ec"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2426,9 +2447,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -2439,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2450,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2481,11 +2502,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "ansi_term",
+ "nu-ansi-term",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-arrow = "22.0.0"
-arrow-flight = "22.0.0"
-tonic = "0.8.1"
-tokio = "1.21.1"
+arrow = "24.0.0"
+arrow-flight = "24.0.0"
+tonic = "0.8.2"
+tokio = "1.21.2"
 rustyline = "10.0.0"
 dirs = "4.0.0"

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -27,12 +27,13 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 use arrow::error::ArrowError;
+use arrow::ipc::convert::try_schema_from_ipc_buffer;
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty;
 
 use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::utils::flight_data_to_arrow_batch;
-use arrow_flight::{Criteria, FlightDescriptor, IpcMessage};
+use arrow_flight::{Criteria, FlightDescriptor};
 
 use rustyline::Editor;
 
@@ -188,15 +189,8 @@ fn execute_command(
             let fd = FlightDescriptor::new_path(vec![table_name.to_string()]);
             let request = Request::new(fd);
             rt.block_on(async {
-                // SchemaResults contains the bytes from IpcMessages for
-                // compatibility with the return type of
-                // FlightService.get_schema() and to ensure the SchemaResults
-                // match what is expected by the other Arrow Flight
-                // implementations until
-                // https://github.com/apache/arrow-rs/issues/2445 is fixed.
                 let schema_result = fsc.get_schema(request).await?.into_inner();
-                let ipc_message = IpcMessage(schema_result.schema);
-                let schema = Schema::try_from(ipc_message)?;
+                let schema = try_schema_from_ipc_buffer(&schema_result.schema)?;
                 for field in schema.fields() {
                     println!("{}: {}", field.name(), field.data_type());
                 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,30 +6,30 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-datafusion = "12.0.0"
-datafusion-expr = "12.0.0"
-datafusion-physical-expr = "12.0.0"
+datafusion = "13.0.0"
+datafusion-expr = "13.0.0"
+datafusion-physical-expr = "13.0.0"
 object_store = "0.5.0"
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same value
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }
-tracing = { version = "0.1.36", features = ["max_level_debug", "release_max_level_info"] }
-tracing-subscriber = "0.3.15"
+tracing = { version = "0.1.37", features = ["max_level_debug", "release_max_level_info"] }
+tracing-subscriber = "0.3.16"
 tracing-futures = "0.2.5"
 
-tokio = { version = "1.21.1", features = ["rt-multi-thread", "signal"] }
+tokio = { version = "1.21.2", features = ["rt-multi-thread", "signal"] }
 
 async-trait = "0.1.57"
 futures = "0.3.24"
 
-arrow-flight = "22.0.0"
-tonic = "0.8.1"
+arrow-flight = "24.0.0"
+tonic = "0.8.2"
 
 snmalloc-rs = "0.3.3"
 
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 
-chrono = "0.4"
+chrono = "0.4.22"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -339,19 +339,11 @@ impl FlightService for FlightServiceHandler {
         let table_name = self.get_table_name_from_flight_descriptor(&flight_descriptor)?;
         let schema = self.get_schema_of_table_in_the_default_database_schema(table_name)?;
 
-        // IpcMessages are transferred as SchemaResults for compatibility with
-        // the return type of get_schema() and to ensure the SchemaResult match
-        // what is expected by the other Arrow Flight implementations until
-        // https://github.com/apache/arrow-rs/issues/2445 is fixed.
         let options = IpcWriteOptions::default();
         let schema_as_ipc = SchemaAsIpc::new(&schema, &options);
-        let ipc_message: IpcMessage = schema_as_ipc
+        let schema_result = schema_as_ipc
             .try_into()
             .map_err(|error: ArrowError| Status::internal(error.to_string()))?;
-
-        let schema_result = SchemaResult {
-            schema: ipc_message.0,
-        };
         Ok(Response::new(schema_result))
     }
 

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -21,6 +21,7 @@ use std::io::ErrorKind::Other;
 use std::path::Path;
 use std::sync::Arc;
 
+use datafusion::arrow::compute;
 use datafusion::arrow::record_batch::RecordBatch;
 
 use crate::get_array;
@@ -70,7 +71,7 @@ impl CompressedTimeSeries {
 
         // Combine the segments into a single RecordBatch.
         let schema = StorageEngine::get_compressed_segment_schema();
-        let batch = RecordBatch::concat(&Arc::new(schema), &*self.compressed_segments).unwrap();
+        let batch = compute::concat_batches(&Arc::new(schema), &*self.compressed_segments).unwrap();
 
         // Create the folder structure if it does not already exist.
         let complete_folder_path = folder_path.join("compressed");

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -691,6 +691,7 @@ impl RecordBatchStream for GridStream {
 mod tests {
     use super::*;
 
+    use datafusion::arrow::datatypes::DataType;
     use datafusion::logical_plan::lit;
     use datafusion::prelude::Expr;
 
@@ -765,7 +766,11 @@ mod tests {
 
     #[test]
     fn test_new_filter_exec_with_predicates() {
-        let filters = vec![new_binary_expr(col("model_type_id"), Operator::Eq, lit(1))];
+        let filters = vec![new_binary_expr(
+            col("model_type_id"),
+            Operator::Eq,
+            lit(1_u8),
+        )];
         let predicates = rewrite_and_combine_filters(&filters);
         let parquet_exec = new_parquet_exec();
 
@@ -775,7 +780,11 @@ mod tests {
     fn new_parquet_exec() -> Arc<ParquetExec> {
         let file_scan_config = FileScanConfig {
             object_store_url: ObjectStoreUrl::local_filesystem(),
-            file_schema: Arc::new(Schema::empty()),
+            file_schema: Arc::new(Schema::new(vec![Field::new(
+                "model_type_id",
+                DataType::UInt8,
+                false,
+            )])),
             file_groups: vec![],
             statistics: Statistics::default(),
             projection: None,


### PR DESCRIPTION
This PR primarily updates Apache Arrow DataFusion to [v13.0.0](https://crates.io/crates/datafusion/13.0.0) and fixes all known breaking changes. New versions of Apache Arrow DataFusion usually have breaking changes, so updating to each new release ensures that the number of changes required does not accumulate. The only breaking change in this PR was [`RecordBatch.concat()`](https://docs.rs/arrow/22.0.0/arrow/record_batch/struct.RecordBatch.html#method.concat) being replaced with [`concat_batches`](https://docs.rs/arrow/latest/arrow/compute/kernels/concat/fn.concat_batches.html). In addition, new checks have been added that broke one unit test. The test has been fixed by defining a proper schema as part of the test instead of using [`Schema::empty()`](https://docs.rs/arrow/latest/arrow/datatypes/struct.Schema.html#method.empty). Finally, [Apache Arrow DataFusion v13.0.0](https://crates.io/crates/datafusion/13.0.0) depends on [Apache Arrow v24.0.0](https://crates.io/crates/arrow/24.0.0) which includes the updated definition of [`SchemaResult`](https://github.com/apache/arrow-rs/blob/24.0.0/arrow-flight/src/arrow.flight.protocol.rs#L74). Thus, the workaround added by [PR 26](https://github.com/ModelarData/ModelarDB-RS/pull/26) has been removed. Manual testing showed that the revised implementation of [`get_schema()`](https://github.com/ModelarData/ModelarDB-RS/blob/dev/update-dependencies/server/src/remote.rs#L334) works with the Python and Go implementations of Apache Arrow Flight.