### PR TITLE
Support CREATE MODEL TABLE DDL commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,7 @@ dependencies = [
  "datafusion",
  "datafusion-expr",
  "datafusion-physical-expr",
+ "datafusion-sql",
  "futures",
  "log",
  "object_store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
  "proptest",
  "rusqlite",
  "snmalloc-rs",
+ "sqlparser",
  "tempfile",
  "tokio",
  "tonic",

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -162,13 +162,13 @@ fn execute_and_print_action_command_or_query(
     fsc: &mut FlightServiceClient<Channel>,
     action_command_or_query: &str,
 ) -> Result<()> {
-    if action_command_or_query.starts_with("CREATE") {
-        execute_action(rt, fsc, action_command_or_query)?;
-    } else if action_command_or_query.starts_with('\\') {
+    if action_command_or_query.starts_with('\\') {
         execute_command(rt, fsc, action_command_or_query)?;
-    } else {
+    } else if action_command_or_query.starts_with("SELECT") {
         let df = execute_query(rt, fsc, action_command_or_query)?;
         pretty::print_batches(&df)?;
+    } else {
+        execute_action(rt, fsc, action_command_or_query)?;
     }
     Ok(())
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 datafusion = "13.0.0"
 datafusion-expr = "13.0.0"
 datafusion-physical-expr = "13.0.0"
+datafusion-sql = "13.0.0"
 object_store = "0.5.0"
 sqlparser = "0.25.0"
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,6 +10,7 @@ datafusion = "13.0.0"
 datafusion-expr = "13.0.0"
 datafusion-physical-expr = "13.0.0"
 object_store = "0.5.0"
+sqlparser = "0.25.0"
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same value
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -25,7 +25,7 @@ use datafusion::arrow::array::{
 };
 use datafusion::arrow::record_batch::RecordBatch;
 
-use crate::errors::ModelarDBError;
+use crate::errors::ModelarDbError;
 use crate::models::{
     gorilla::Gorilla, pmcmean::PMCMean, swing::Swing, timestamps, ErrorBound, SelectedModel,
 };
@@ -45,7 +45,7 @@ pub const GORILLA_MAXIMUM_LENGTH: usize = 50;
 /// within `error_bound` using the model types in [`models`](crate::models).
 /// Assumes `uncompressed_timestamps` and `uncompressed_values` are sorted
 /// according to `uncompressed_timestamps`. Returns
-/// [`CompressionError`](ModelarDBError::CompressionError) if
+/// [`CompressionError`](ModelarDbError::CompressionError) if
 /// `uncompressed_timestamps` and `uncompressed_values` have different lengths,
 /// otherwise the resulting compressed segments are returned as a
 /// [`RecordBatch`] with the schema provided by
@@ -55,12 +55,12 @@ pub fn try_compress(
     uncompressed_values: &ValueArray,
     error_bound: ErrorBound,
     compressed_schema: &CompressedSchema,
-) -> Result<RecordBatch, ModelarDBError> {
+) -> Result<RecordBatch, ModelarDbError> {
     // The uncompressed data must be passed as arrays instead of a RecordBatch
     // as a TimestampArray and a ValueArray is the only supported input.
     // However, as a result it is necessary to verify they have the same length.
     if uncompressed_timestamps.len() != uncompressed_values.len() {
-        return Err(ModelarDBError::CompressionError(
+        return Err(ModelarDbError::CompressionError(
             "Uncompressed timestamps and uncompressed values have different lengths.".to_owned(),
         ));
     }

--- a/server/src/errors.rs
+++ b/server/src/errors.rs
@@ -25,7 +25,7 @@ use std::fmt::{Display, Formatter};
 
 /// Error type used throughout the system.
 #[derive(Debug)]
-pub enum ModelarDBError {
+pub enum ModelarDbError {
     /// Error returned by the model types.
     CompressionError(String),
     /// Error returned when failing to create a new instance of a struct.
@@ -34,14 +34,18 @@ pub enum ModelarDBError {
     DataRetrievalError(String),
 }
 
-impl Error for ModelarDBError {}
+impl Error for ModelarDbError {}
 
-impl Display for ModelarDBError {
+impl Display for ModelarDbError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            ModelarDBError::CompressionError(reason) => write!(f, "Compression Error: {}", reason),
-            ModelarDBError::ConfigurationError(reason) => write!(f, "Configuration Error: {}", reason),
-            ModelarDBError::DataRetrievalError(reason) => write!(f, "Data Retrieval Error: {}", reason)
+            ModelarDbError::CompressionError(reason) => write!(f, "Compression Error: {}", reason),
+            ModelarDbError::ConfigurationError(reason) => {
+                write!(f, "Configuration Error: {}", reason)
+            }
+            ModelarDbError::DataRetrievalError(reason) => {
+                write!(f, "Data Retrieval Error: {}", reason)
+            }
         }
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -22,6 +22,7 @@ mod macros;
 mod metadata;
 mod models;
 mod optimizer;
+mod parser;
 mod remote;
 mod storage;
 mod tables;
@@ -95,10 +96,14 @@ fn main() -> Result<(), String> {
         });
 
         // Register tables and model tables.
-        context.metadata_manager.register_tables(&context)
+        context
+            .metadata_manager
+            .register_tables(&context)
             .map_err(|error| format!("Unable to register tables: {}", error))?;
 
-        context.metadata_manager.register_model_tables(&context)
+        context
+            .metadata_manager
+            .register_model_tables(&context)
             .map_err(|error| format!("Unable to register model tables: {}", error))?;
 
         // Setup CTRL+C handler.

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -24,6 +24,7 @@
 //! identify each univariate time series stored in the storage engine.
 
 pub mod model_table_metadata;
+pub mod parser;
 
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -531,7 +531,7 @@ impl MetadataManager {
     fn register_model_table(row: &Row, context: &Arc<Context>) -> Result<(), Box<dyn Error>> {
         let name = row.get::<usize, String>(0)?;
 
-        // Convert the Blobs to the concrete types.
+        // Convert the BLOBs to the concrete types.
         let schema_bytes = row.get::<usize, Vec<u8>>(1)?;
         let schema = MetadataManager::convert_blob_to_schema(schema_bytes)?;
 
@@ -644,8 +644,6 @@ mod tests {
 
     use std::fs;
 
-    use arrow_flight::{IpcMessage, SchemaAsIpc};
-    use datafusion::arrow::ipc::writer::IpcWriteOptions;
     use proptest::{collection, num, prop_assert_eq, proptest};
     use tempfile;
 
@@ -1065,17 +1063,15 @@ mod tests {
     }
 
     #[test]
-    fn test_blob_to_schema_model_table() {
-        // Serialize a schema to bytes.
+    fn test_blob_to_schema_and_blob_to_schema() {
         let model_table_metadata = test_util::get_model_table_metadata();
         let schema = model_table_metadata.schema;
 
-        let options = IpcWriteOptions::default();
-        let schema_as_ipc = SchemaAsIpc::new(&schema, &options);
-        let ipc_message: IpcMessage = schema_as_ipc.try_into().unwrap();
+        // Serialize a schema to bytes.
+        let bytes = MetadataManager::convert_schema_to_blob(&schema).unwrap();
 
         // Deserialize the bytes to a schema.
-        let retrieved_schema = MetadataManager::convert_blob_to_schema(ipc_message.0).unwrap();
+        let retrieved_schema = MetadataManager::convert_blob_to_schema(bytes).unwrap();
         assert_eq!(*schema, retrieved_schema);
     }
 

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -231,7 +231,7 @@ impl MetadataManager {
             let tag_columns: String = model_table
                 .tag_column_indices
                 .iter()
-                .map(|index| model_table.schema.field(*index as usize).name().clone())
+                .map(|index| model_table.schema.field(*index).name().clone())
                 .collect::<Vec<String>>()
                 .join(",");
 
@@ -445,7 +445,7 @@ impl MetadataManager {
             .tag_column_indices
             .iter()
             .map(|index| {
-                let field = model_table_metadata.schema.field(*index as usize);
+                let field = model_table_metadata.schema.field(*index);
                 format!("{} TEXT NOT NULL", field.name())
             })
             .collect::<Vec<String>>()
@@ -488,7 +488,7 @@ impl MetadataManager {
 
         for (index, field) in model_table_metadata.schema.fields().iter().enumerate() {
             // Only add a row for the field if it is not the timestamp or a tag.
-            let is_timestamp = index == model_table_metadata.timestamp_column_index as usize;
+            let is_timestamp = index == model_table_metadata.timestamp_column_index;
             let in_tag_indices = model_table_metadata.tag_column_indices.contains(&index);
 
             if !is_timestamp && !in_tag_indices {

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -24,7 +24,6 @@
 //! identify each univariate time series stored in the storage engine.
 
 pub mod model_table_metadata;
-pub mod parser;
 
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
@@ -36,14 +35,16 @@ use std::path::{Path, PathBuf};
 use std::str;
 use std::sync::Arc;
 
-use arrow_flight::IpcMessage;
+use arrow_flight::{IpcMessage, SchemaAsIpc};
 use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
+use datafusion::arrow::{error::ArrowError, ipc::writer::IpcWriteOptions};
 use datafusion::execution::options::ParquetReadOptions;
 use rusqlite::types::Type::Blob;
 use rusqlite::{params, Connection, Result, Row};
 use tracing::{error, info, warn};
 
 use crate::metadata::model_table_metadata::ModelTableMetadata;
+use crate::models::ErrorBound;
 use crate::tables::ModelTable;
 use crate::types::{
     ArrowTimestamp, ArrowValue, CompressedSchema, TimeSeriesId, UncompressedSchema,
@@ -155,7 +156,8 @@ impl MetadataManager {
                 table_name TEXT PRIMARY KEY,
                 schema BLOB NOT NULL,
                 timestamp_column_index INTEGER NOT NULL,
-                tag_column_indices BLOB NOT NULL
+                tag_column_indices BLOB NOT NULL,
+                error_bounds BLOB NOT NULL
         ) STRICT",
             (),
         )?;
@@ -364,9 +366,9 @@ impl MetadataManager {
         Ok(keys)
     }
 
-    /// Normalize `table_name` to allow direct comparisons between table names.
-    pub fn normalize_table_name(table_name: &str) -> String {
-        table_name.to_lowercase()
+    /// Normalize `name` to allow direct comparisons between names.
+    pub fn normalize_name(name: &str) -> String {
+        name.to_lowercase()
     }
 
     /// Save the created table to the metadata database. This consists of adding
@@ -430,8 +432,10 @@ impl MetadataManager {
     pub fn save_model_table_metadata(
         &self,
         model_table_metadata: &ModelTableMetadata,
-        schema_bytes: Vec<u8>,
     ) -> Result<()> {
+        // Convert the schema to bytes so it can be saved as a BLOB in the metadata database.
+        let schema_bytes = MetadataManager::convert_schema_to_blob(&model_table_metadata.schema)?;
+
         // Create a transaction to ensure the database state is consistent across tables.
         let mut connection = Connection::open(&self.metadata_database_path)?;
         let transaction = connection.transaction()?;
@@ -460,14 +464,15 @@ impl MetadataManager {
 
         // Add a new row in the model_table_metadata table to persist the model table.
         transaction.execute(
-            "INSERT INTO model_table_metadata (table_name, schema, timestamp_column_index, tag_column_indices)
-             VALUES (?1, ?2, ?3, ?4)",
+            "INSERT INTO model_table_metadata (table_name, schema, timestamp_column_index,
+             tag_column_indices, error_bounds) VALUES (?1, ?2, ?3, ?4, ?5)",
             params![
                 model_table_metadata.name,
                 schema_bytes,
                 model_table_metadata.timestamp_column_index,
-                model_table_metadata.tag_column_indices
-            ]
+                MetadataManager::slice_usize_to_vec_u8(&model_table_metadata.tag_column_indices),
+                MetadataManager::slice_error_bounds_to_vec_u8(&model_table_metadata.error_bounds)
+            ],
         )?;
 
         // Add a row for each field column to the model_table_field_columns table.
@@ -479,9 +484,7 @@ impl MetadataManager {
         for (index, field) in model_table_metadata.schema.fields().iter().enumerate() {
             // Only add a row for the field if it is not the timestamp or a tag.
             let is_timestamp = index == model_table_metadata.timestamp_column_index as usize;
-            let in_tag_indices = model_table_metadata
-                .tag_column_indices
-                .contains(&(index as u8));
+            let in_tag_indices = model_table_metadata.tag_column_indices.contains(&index);
 
             if !is_timestamp && !in_tag_indices {
                 insert_statement.execute(params![
@@ -528,16 +531,23 @@ impl MetadataManager {
     fn register_model_table(row: &Row, context: &Arc<Context>) -> Result<(), Box<dyn Error>> {
         let name = row.get::<usize, String>(0)?;
 
-        // Convert the BLOB to an Apache Arrow Schema.
+        // Convert the Blobs to the concrete types.
         let schema_bytes = row.get::<usize, Vec<u8>>(1)?;
-        let schema = MetadataManager::blob_to_schema(schema_bytes)?;
+        let schema = MetadataManager::convert_blob_to_schema(schema_bytes)?;
+
+        let tag_column_indices_bytes = row.get::<usize, Vec<u8>>(3)?;
+        let tag_column_indices = MetadataManager::slice_u8_to_vec_usize(&tag_column_indices_bytes)?;
+
+        let error_bounds_bytes = row.get::<usize, Vec<u8>>(4)?;
+        let error_bounds = MetadataManager::slice_u8_to_vec_error_bounds(&error_bounds_bytes)?;
 
         // Create model table metadata.
         let model_table_metadata = Arc::new(ModelTableMetadata {
             name: name.clone(),
             schema: Arc::new(schema),
             timestamp_column_index: row.get(2)?,
-            tag_column_indices: row.get(3)?,
+            tag_column_indices,
+            error_bounds,
         });
 
         // Register model table.
@@ -550,14 +560,81 @@ impl MetadataManager {
         Ok(())
     }
 
+    /// Convert a [`Schema`] to [`Vec<u8>`].
+    fn convert_schema_to_blob(schema: &Schema) -> Result<Vec<u8>> {
+        let options = IpcWriteOptions::default();
+        let schema_as_ipc = SchemaAsIpc::new(schema, &options);
+        let ipc_message: IpcMessage = schema_as_ipc.try_into().map_err(|error: ArrowError| {
+            rusqlite::Error::InvalidColumnType(1, error.to_string(), Blob)
+        })?;
+        Ok(ipc_message.0)
+    }
+
     /// Return [`Schema`] if `schema_bytes` can be converted to an Apache Arrow
     /// schema, otherwise [`Error`](rusqlite::Error).
-    fn blob_to_schema(schema_bytes: Vec<u8>) -> Result<Schema> {
+    fn convert_blob_to_schema(schema_bytes: Vec<u8>) -> Result<Schema> {
         let ipc_message = IpcMessage(schema_bytes);
         Schema::try_from(ipc_message).map_err(|error| {
             let message = format!("Blob is not a valid Schema: {}", error);
             rusqlite::Error::InvalidColumnType(1, message, Blob)
         })
+    }
+
+    /// Convert a [`Vec<usize>`] to a [`Vec<u8>`].
+    fn slice_usize_to_vec_u8(usizes: &[usize]) -> Vec<u8> {
+        usizes.iter().flat_map(|v| v.to_le_bytes()).collect()
+    }
+
+    /// Convert a [`Vec<u8>`] to a [`Vec<usize>`] if the length of `bytes`
+    /// divides cleanly by [`mem::size_of::<usize>()`], otherwise
+    /// [`Error`](rusqlite::Error) is returned.
+    fn slice_u8_to_vec_usize(bytes: &[u8]) -> Result<Vec<usize>> {
+        if bytes.len() % mem::size_of::<usize>() != 0 {
+            // rusqlite defines UNKNOWN_COLUMN as usize::MAX;
+            Err(rusqlite::Error::InvalidColumnType(
+                usize::MAX,
+                "Blob is not a vector of usizes".to_owned(),
+                Blob,
+            ))
+        } else {
+            // unwrap() is safe as bytes divides by mem::size_of::<usize>().
+            Ok(bytes
+                .chunks(mem::size_of::<usize>())
+                .map(|byte_slice| usize::from_le_bytes(byte_slice.try_into().unwrap()))
+                .collect())
+        }
+    }
+
+    /// Convert a [`Vec<ErrorBound>`] to a [`Vec<u8>`].
+    fn slice_error_bounds_to_vec_u8(error_bounds: &[ErrorBound]) -> Vec<u8> {
+        error_bounds
+            .iter()
+            .flat_map(|eb| eb.to_le_bytes())
+            .collect()
+    }
+
+    /// Convert a [`Vec<u8>`] to a [`Vec<ErrorBound>`] if the length of `bytes`
+    /// divides cleanly by [`mem::size_of::<f32>()`], otherwise
+    /// [`Error`](rusqlite::Error) is returned.
+    fn slice_u8_to_vec_error_bounds(bytes: &[u8]) -> Result<Vec<ErrorBound>> {
+        if bytes.len() % mem::size_of::<f32>() != 0 {
+            // rusqlite defines UNKNOWN_COLUMN as usize::MAX;
+            Err(rusqlite::Error::InvalidColumnType(
+                usize::MAX,
+                "Blob is not a vector of error bounds".to_owned(),
+                Blob,
+            ))
+        } else {
+            Ok(bytes
+                .chunks(mem::size_of::<f32>())
+                .map(|byte_slice| {
+                    // unwrap() is safe as bytes divides by mem::size_of::<f32>().
+                    let error_bound_value = f32::from_le_bytes(byte_slice.try_into().unwrap());
+                    // unwrap() is safe as the error bound was checked on write.
+                    ErrorBound::try_new(error_bound_value).unwrap()
+                })
+                .collect())
+        }
     }
 }
 
@@ -569,6 +646,7 @@ mod tests {
 
     use arrow_flight::{IpcMessage, SchemaAsIpc};
     use datafusion::arrow::ipc::writer::IpcWriteOptions;
+    use proptest::{collection, num, prop_assert_eq, proptest};
     use tempfile;
 
     use crate::metadata::test_util;
@@ -664,7 +742,7 @@ mod tests {
 
         let model_table_metadata = test_util::get_model_table_metadata();
         metadata_manager
-            .save_model_table_metadata(&model_table_metadata, vec![])
+            .save_model_table_metadata(&model_table_metadata)
             .unwrap();
 
         let result = metadata_manager
@@ -702,7 +780,7 @@ mod tests {
 
         let model_table_metadata = test_util::get_model_table_metadata();
         metadata_manager
-            .save_model_table_metadata(&model_table_metadata, vec![])
+            .save_model_table_metadata(&model_table_metadata)
             .unwrap();
 
         metadata_manager
@@ -736,7 +814,7 @@ mod tests {
 
         let model_table_metadata = test_util::get_model_table_metadata();
         metadata_manager
-            .save_model_table_metadata(&model_table_metadata, vec![1, 2, 4, 8])
+            .save_model_table_metadata(&model_table_metadata)
             .unwrap();
 
         // Lookup keys using fields and tags for an empty table.
@@ -826,7 +904,7 @@ mod tests {
     ) {
         let model_table_metadata = test_util::get_model_table_metadata();
         metadata_manager
-            .save_model_table_metadata(&model_table_metadata, vec![1, 2, 4, 8])
+            .save_model_table_metadata(&model_table_metadata)
             .unwrap();
 
         for tag_value in tag_values {
@@ -839,18 +917,12 @@ mod tests {
 
     #[test]
     fn test_normalize_table_name_lowercase_no_effect() {
-        assert_eq!(
-            "table_name",
-            MetadataManager::normalize_table_name("table_name")
-        );
+        assert_eq!("table_name", MetadataManager::normalize_name("table_name"));
     }
 
     #[test]
     fn test_normalize_table_name_uppercase() {
-        assert_eq!(
-            "table_name",
-            MetadataManager::normalize_table_name("TABLE_NAME")
-        );
+        assert_eq!("table_name", MetadataManager::normalize_name("TABLE_NAME"));
     }
 
     #[test]
@@ -902,7 +974,7 @@ mod tests {
 
         let model_table_metadata = test_util::get_model_table_metadata();
         metadata_manager
-            .save_model_table_metadata(&model_table_metadata, vec![1, 2, 4, 8])
+            .save_model_table_metadata(&model_table_metadata)
             .unwrap();
 
         // Retrieve the model table from the metadata database.
@@ -920,16 +992,26 @@ mod tests {
         let mut select_statement = connection
             .prepare(
                 "SELECT table_name, schema, timestamp_column_index,
-                      tag_column_indices FROM model_table_metadata",
+                        tag_column_indices, error_bounds FROM model_table_metadata",
             )
             .unwrap();
         let mut rows = select_statement.query(()).unwrap();
 
         let row = rows.next().unwrap().unwrap();
         assert_eq!("model_table", row.get::<usize, String>(0).unwrap());
-        assert_eq!(vec![1, 2, 4, 8], row.get::<usize, Vec<u8>>(1).unwrap());
+        assert_eq!(
+            MetadataManager::convert_schema_to_blob(&model_table_metadata.schema).unwrap(),
+            row.get::<usize, Vec<u8>>(1).unwrap()
+        );
         assert_eq!(1, row.get::<usize, i32>(2).unwrap());
-        assert_eq!(vec![0], row.get::<usize, Vec<u8>>(3).unwrap());
+        assert_eq!(
+            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            row.get::<usize, Vec<u8>>(3).unwrap()
+        );
+        assert_eq!(
+            vec![0, 0, 0, 0, 0, 0, 0, 0],
+            row.get::<usize, Vec<u8>>(4).unwrap()
+        );
 
         assert!(rows.next().unwrap().is_none());
 
@@ -967,7 +1049,7 @@ mod tests {
         let model_table_metadata = test_util::get_model_table_metadata();
         context
             .metadata_manager
-            .save_model_table_metadata(&model_table_metadata, vec![1, 2, 4, 8])
+            .save_model_table_metadata(&model_table_metadata)
             .unwrap();
 
         // Register the model table with Apache Arrow DataFusion.
@@ -979,7 +1061,7 @@ mod tests {
 
     #[test]
     fn test_blob_to_schema_empty() {
-        assert!(MetadataManager::blob_to_schema(vec!(1, 2, 4, 8)).is_err());
+        assert!(MetadataManager::convert_blob_to_schema(vec!(1, 2, 4, 8)).is_err());
     }
 
     #[test]
@@ -993,8 +1075,28 @@ mod tests {
         let ipc_message: IpcMessage = schema_as_ipc.try_into().unwrap();
 
         // Deserialize the bytes to a schema.
-        let retrieved_schema = MetadataManager::blob_to_schema(ipc_message.0).unwrap();
+        let retrieved_schema = MetadataManager::convert_blob_to_schema(ipc_message.0).unwrap();
         assert_eq!(*schema, retrieved_schema);
+    }
+
+    proptest! {
+        #[test]
+        fn test_usize_to_u8_and_u8_to_usize(values in collection::vec(num::usize::ANY, 0..50)) {
+            let bytes = MetadataManager::slice_usize_to_vec_u8(&values);
+            let usizes = MetadataManager::slice_u8_to_vec_usize(&bytes).unwrap();
+            prop_assert_eq!(values, usizes);
+        }
+
+        #[test]
+        fn test_error_bound_to_u8_and_u8_to_error_bound(values in collection::vec(num::f32::POSITIVE, 0..50)) {
+            let error_bounds: Vec<ErrorBound> = values
+                .iter()
+                .map(|value| ErrorBound::try_new(*value).unwrap())
+                .collect();
+            let bytes = MetadataManager::slice_error_bounds_to_vec_u8(&error_bounds);
+            let usizes = MetadataManager::slice_u8_to_vec_error_bounds(&bytes).unwrap();
+            prop_assert_eq!(values, usizes);
+        }
     }
 }
 
@@ -1010,6 +1112,7 @@ pub mod test_util {
     use tempfile;
     use tokio::runtime::Runtime;
 
+    use crate::models::ErrorBound;
     use crate::storage::StorageEngine;
 
     /// Return a [`Context`] with the metadata manager created by
@@ -1062,7 +1165,13 @@ pub mod test_util {
             Field::new("field_2", ArrowValue::DATA_TYPE, false),
         ]);
 
-        ModelTableMetadata::try_new("model_table".to_owned(), schema, vec![0], 1).unwrap()
+        let error_bounds = vec![
+            ErrorBound::try_new(0.0).unwrap(),
+            ErrorBound::try_new(0.0).unwrap(),
+        ];
+
+        ModelTableMetadata::try_new("model_table".to_owned(), schema, 1, vec![0], error_bounds)
+            .unwrap()
     }
 
     /// Return the [`RecordBatch`] schema used for uncompressed segments.

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -520,7 +520,7 @@ impl MetadataManager {
         let connection = Connection::open(&self.metadata_database_path)?;
 
         let mut select_statement = connection.prepare(
-            "SELECT table_name, schema, timestamp_column_index, tag_column_indices
+            "SELECT table_name, schema, timestamp_column_index, tag_column_indices, error_bounds
             FROM model_table_metadata",
         )?;
 

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -247,10 +247,16 @@ impl MetadataManager {
             let signed_tag_hash = i64::from_ne_bytes(tag_hash.to_ne_bytes());
 
             // OR IGNORE is used to silently fail when trying to insert an already existing hash.
+            let maybe_separator = if tag_columns.is_empty() { "" } else { ", " };
             connection.execute(
                 format!(
-                    "INSERT OR IGNORE INTO {}_tags (hash,{}) VALUES ({},{})",
-                    model_table.name, tag_columns, signed_tag_hash, values
+                    "INSERT OR IGNORE INTO {}_tags (hash{}{}) VALUES ({}{}{})",
+                    model_table.name,
+                    maybe_separator,
+                    tag_columns,
+                    signed_tag_hash,
+                    maybe_separator,
+                    values
                 )
                 .as_str(),
                 (),

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -453,10 +453,11 @@ impl MetadataManager {
 
         // Create a table_name_tags SQLite table to save the 54-bit tag hashes when ingesting data.
         // The query is executed with a formatted string since CREATE TABLE cannot take parameters.
+        let maybe_separator = if tag_columns.is_empty() { "" } else { ", " };
         transaction.execute(
             format!(
-                "CREATE TABLE {}_tags (hash INTEGER PRIMARY KEY, {}) STRICT",
-                model_table_metadata.name, tag_columns
+                "CREATE TABLE {}_tags (hash INTEGER PRIMARY KEY{}{}) STRICT",
+                model_table_metadata.name, maybe_separator, tag_columns
             )
             .as_str(),
             (),

--- a/server/src/metadata/model_table_metadata.rs
+++ b/server/src/metadata/model_table_metadata.rs
@@ -64,7 +64,7 @@ impl ModelTableMetadata {
             ));
         };
 
-        if let Some(timestamp_field) = schema.fields.get(timestamp_column_index as usize) {
+        if let Some(timestamp_field) = schema.fields.get(timestamp_column_index) {
             // If the field of the timestamp column is not of type ArrowTimestamp, return an error.
             if !timestamp_field
                 .data_type()
@@ -85,7 +85,7 @@ impl ModelTableMetadata {
         }
 
         for tag_column_index in &tag_column_indices {
-            if let Some(tag_field) = schema.fields.get(*tag_column_index as usize) {
+            if let Some(tag_field) = schema.fields.get(*tag_column_index) {
                 // If the fields of the tag columns is not of type Utf8, return an error.
                 if !tag_field.data_type().equals_datatype(&DataType::Utf8) {
                     return Err(ModelarDBError::ConfigurationError(format!(

--- a/server/src/metadata/parser.rs
+++ b/server/src/metadata/parser.rs
@@ -13,62 +13,227 @@
  * limitations under the License.
  */
 
-//! Methods for parsing Data Definition Language (DDL) expressions for creating
-//! tables and model tables. The DDL expressions are tokenized and parsed using
-//! [sqlparser] as it is already used by Apache Arrow DataFusion. Afterwards,
-//! semantics checks are performed to ensure that the DDL expressions match what
-//! is expected by the system and that they create a table or model table.
+//! Methods for tokenizing and parsing SQL commands. They are tokenized and
+//! parsed using [sqlparser] as it is already used by Apache Arrow DataFusion.
 //!
 //! [sqlparser]: https://crates.io/crates/sqlparser
 
-use sqlparser::ast::{ColumnDef, DataType, Statement};
-use sqlparser::dialect::GenericDialect;
+use sqlparser::ast::{
+    ColumnDef, DataType, HiveDistributionStyle, Ident, ObjectName, Statement, TimezoneInfo,
+};
+use sqlparser::dialect::{Dialect, GenericDialect};
+use sqlparser::keywords::Keyword;
 use sqlparser::parser::{Parser, ParserError};
+use sqlparser::tokenizer::{Token, Tokenizer};
 
-/// Parse the `sql` DDL expression, performs semantic checks, and return an AST.
-/// Return the AST as a [`Vec<Statement>`] If `sql` can be parsed and the
-/// semantic checks succeed, otherwise return a [`ParserError`].
-pub fn parse_data_definition_language_expression(sql: &str) -> Result<Vec<Statement>, ParserError> {
-    if sql.is_empty() {
-        return Err(ParserError::TokenizerError(
-            "Expected CREATE TABLE but received an empty string.".to_owned(),
-        ));
-    }
-
-    let ast = Parser::parse_sql(&GenericDialect {}, sql)?;
-
-    //if is_create_model_table
-    Ok(ast)
+/// SQL dialect that extends `sqlparsers's` [`GenericDialect`] with support for
+/// parsing CREATE MODEL TABLE table_name DDL commands.
+#[derive(Debug)]
+struct ModelarDbDialect {
+    /// Dialect to use for identifying identifiers.
+    dialect: GenericDialect,
 }
 
-/// Return [`true`] if `ast` contains one [`Statement`] and it is a CREATE TABLE
-/// expression that creates a model table, otherwise [`false`].
-pub fn ast_is_create_model_table(ast: &Vec<Statement>) -> bool {
-    if ast.len() == 1 {
-        if let Statement::CreateTable { columns, .. } = ast.get(0).unwrap() {
-            return columns
-                .iter()
-                .all(|column_def| column_def_is_a_timestamp_field_or_tag(column_def));
+impl ModelarDbDialect {
+    fn new() -> Self {
+        Self {
+            dialect: GenericDialect {},
         }
     }
-    false
-}
 
-/// Return [`true`] if `column_def` is a timestamp, field, or a tag, otherwise
-/// [`false`].
-fn column_def_is_a_timestamp_field_or_tag(column_def: &ColumnDef) -> bool {
-    match &column_def.data_type {
-        DataType::Timestamp(_timezone) => true,
-        DataType::Custom(object_name) => {
-            let identifier = &object_name.0;
-            if identifier.len() == 1 {
-                let normalized_data_type_name = identifier.get(0).unwrap().value.to_lowercase();
-                normalized_data_type_name == "field" || normalized_data_type_name == "tag"
-            } else {
-                false
+    /// Return [`true`] if the token stream starts with CREATE MODEL TABLE,
+    /// otherwise [`false`] is returned. The method does not consume tokens.
+    fn next_tokens_are_create_model_table(&self, parser: &Parser) -> bool {
+        // CREATE.
+        if let Token::Word(word) = parser.peek_nth_token(0) {
+            if word.keyword == Keyword::CREATE {
+                // MODEL.
+                if let Token::Word(word) = parser.peek_nth_token(1) {
+                    if word.value.to_uppercase() == "MODEL" {
+                        // TABLE.
+                        if let Token::Word(word) = parser.peek_nth_token(2) {
+                            if word.keyword == Keyword::TABLE {
+                                return true;
+                            }
+                        }
+                    }
+                }
             }
         }
-        _ => false,
+        false
+    }
+
+    /// Parse CREATE MODEL TABLE table_name DDL commands to a
+    /// [`Statement::CreateTable`]. A [`ParserError`] is returned if the column
+    /// names and the column types cannot be parsed.
+    fn parse_create_model_table(&self, parser: &mut Parser) -> Result<Statement, ParserError> {
+        // CREATE MODEL TABLE.
+        parser.expect_keyword(Keyword::CREATE)?;
+        self.expect_word_value(parser, "MODEL")?;
+        parser.expect_keyword(Keyword::TABLE)?;
+        let table_name = self.parse_word_value(parser)?;
+
+        // (column name and column type*)
+        let columns = self.parse_columns(parser)?;
+
+        // Return Statement::CreateTable with the extracted information.
+        let name = ObjectName(vec![Ident::new(table_name)]);
+        Ok(ModelarDbDialect::new_create_table_statement(name, columns))
+    }
+
+    /// Parse (column name and type*) to a [`Vec<ColumnDef>`]. A [`ParserError`]
+    /// is returned if the column names and the column types cannot be parsed.
+    fn parse_columns(&self, parser: &mut Parser) -> Result<Vec<ColumnDef>, ParserError> {
+        let mut columns = vec![];
+        let mut parsed_all_columns = false;
+        parser.expect_token(&Token::LParen)?;
+
+        while !parsed_all_columns {
+            let column_name = self.parse_word_value(parser)?;
+            let column_type = self.parse_word_value(parser)?;
+
+            let data_type = match column_type.to_uppercase().as_str() {
+                "TIMESTAMP" => DataType::Timestamp(TimezoneInfo::None),
+                "FIELD" => {
+                    // An error bound may also be specified for field columns.
+                    let error_bound = if parser.peek_token() == Token::LParen {
+                        parser.expect_token(&Token::LParen)?;
+                        let error_bound = parser.parse_literal_uint()?;
+                        parser.expect_token(&Token::RParen)?;
+                        error_bound
+                    } else {
+                        0
+                    };
+
+                    DataType::Float(Some(error_bound))
+                }
+                "TAG" => DataType::Text,
+                column_type => {
+                    return Err(ParserError::ParserError(format!(
+                        "Expected TIMESTAMP, FIELD, or TAG, found: {}",
+                        column_type
+                    )))
+                }
+            };
+
+            columns.push(ModelarDbDialect::new_column_def(column_name, data_type));
+
+            if parser.peek_token() == Token::RParen {
+                parser.expect_token(&Token::RParen)?;
+                parsed_all_columns = true;
+            } else {
+                parser.expect_token(&Token::Comma)?;
+            }
+        }
+
+        Ok(columns)
+    }
+
+    /// Return [`()`] if the next [`Token`] is a [`Token::Word`] with the value
+    /// `expected`, otherwise a [`ParseError`] is returned.
+    fn expect_word_value(&self, parser: &mut Parser, expected: &str) -> Result<(), ParserError> {
+        if let Ok(string) = self.parse_word_value(parser) {
+            if string.to_uppercase() == expected.to_uppercase() {
+                return Ok(());
+            }
+        }
+        parser.expected(format!("{}", &expected).as_str(), parser.peek_token())
+    }
+
+    /// Return its value as a [`String`] if the next [`Token`] is a
+    /// [`Token::Word`], otherwise a [`ParseError`] is returned.
+    fn parse_word_value(&self, parser: &mut Parser) -> Result<String, ParserError> {
+        match parser.next_token() {
+            Token::Word(word) => Ok(word.value),
+            unexpected => parser.expected("literal string", unexpected),
+        }
+    }
+
+    /// Create a new [`ColumnDef`] with the provided `column_name` and
+    /// `data_type`.
+    fn new_column_def(column_name: String, data_type: DataType) -> ColumnDef {
+        ColumnDef {
+            name: Ident::new(column_name),
+            data_type,
+            collation: None,
+            options: vec![],
+        }
+    }
+
+    /// Create a new [`Statement::CreateTable`] with the provided `table_name`
+    /// and `columns`.
+    fn new_create_table_statement(table_name: ObjectName, columns: Vec<ColumnDef>) -> Statement {
+        Statement::CreateTable {
+            or_replace: false,
+            temporary: false,
+            external: false,
+            global: None,
+            if_not_exists: false,
+            name: table_name,
+            columns,
+            constraints: vec![],
+            hive_distribution: HiveDistributionStyle::NONE,
+            hive_formats: None,
+            table_properties: vec![],
+            with_options: vec![],
+            file_format: None,
+            location: None,
+            query: None,
+            without_rowid: false,
+            like: None,
+            clone: None,
+            engine: None,
+            default_charset: None,
+            collation: None,
+            on_commit: None,
+            on_cluster: None,
+        }
+    }
+}
+
+impl Dialect for ModelarDbDialect {
+    /// Return [`True`] if a character is a valid start character for an
+    /// unquoted identifier, otherwise [`False`] is returned.
+    fn is_identifier_start(&self, c: char) -> bool {
+        self.dialect.is_identifier_start(c)
+    }
+
+    /// Return [`True`] if a character is a valid unquoted identifier character,
+    /// otherwise [`False`] is returned.
+    fn is_identifier_part(&self, c: char) -> bool {
+        self.dialect.is_identifier_part(c)
+    }
+
+    /// Check if the next tokens are CREATE TABLE TABLE, if so, attempt to parse
+    /// the token stream as a CREATE MODEL TABLE DDL command. If parsing is
+    /// succeeds, a [`Statement`] is returned, and if not, a [`ParseError`] is
+    /// returned. If the next tokens are not CREATE TABLE TABLE, [`None`] is
+    /// returned so sqlparser uses its parsing methods for all other commands.
+    fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
+        if self.next_tokens_are_create_model_table(parser) {
+            Some(self.parse_create_model_table(parser))
+        } else {
+            None
+        }
+    }
+}
+
+/// Tokenize and parse the first SQL command in `sql` and return its parsed
+/// representation in the form of [`Statements`](Statement).
+pub fn tokenize_and_parse_sql(sql: &str) -> Result<Statement, ParserError> {
+    let mut statements = Parser::parse_sql(&ModelarDbDialect::new(), sql)?;
+
+    // Check that the sql contained a parseable statement.
+    if statements.is_empty() {
+        Err(ParserError::ParserError(
+            "An empty string cannot be tokenized and parsed.".to_owned(),
+        ))
+    } else if statements.len() > 1 {
+        Err(ParserError::ParserError(
+            "Multiple SQL commands are not supported.".to_owned(),
+        ))
+    } else {
+        Ok(statements.remove(0))
     }
 }
 
@@ -76,38 +241,159 @@ fn column_def_is_a_timestamp_field_or_tag(column_def: &ColumnDef) -> bool {
 mod tests {
     use super::*;
 
-    // Tests for ast_is_crate_model_table().
+    // Tests for tokenize_and_parse_sql().
     #[test]
-    fn test_ast_is_create_model_table_empty() {
-        let ast = parse_data_definition_language_expression("");
-        assert!(!ast_is_create_model_table(&ast));
+    fn test_tokenize_and_parse_empty_sql() {
+        assert!(tokenize_and_parse_sql("").is_err());
     }
 
     #[test]
-    fn test_ast_is_create_model_table_wrong_types() {
-        let ast = parse_data_definition_language_expression(
-            "CREATE TABLE table_name(timestamp TIMESTAMP, field REAL, tag VARCHAR)",
+    fn test_tokenize_and_parse_create_model_table() {
+        let sql = "CREATE MODEL TABLE table_name(timestamp TIMESTAMP, field_one FIELD, field_two FIELD(10), tag TAG)";
+        if let Statement::CreateTable { name, columns, .. } = tokenize_and_parse_sql(&sql).unwrap()
+        {
+            assert!(name == new_object_name("table_name"));
+            let expected_columns = vec![
+                new_column_def("timestamp", DataType::Timestamp(TimezoneInfo::None)),
+                new_column_def("field_one", DataType::Float(Some(0))),
+                new_column_def("field_two", DataType::Float(Some(10))),
+                new_column_def("tag", DataType::Text),
+            ];
+            assert!(columns == expected_columns);
+        } else {
+            panic!("CREATE TABLE DDL did not parse to a Statement::CreateTable");
+        }
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_without_create() {
+        assert!(tokenize_and_parse_sql(
+            "MODEL TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_without_create_model_space() {
+        assert!(tokenize_and_parse_sql(
+            "CREATEMODEL TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_without_model() {
+        // Checks if sqlparser can parse fields/tags without ModelarDbDialect.
+        assert!(tokenize_and_parse_sql(
+            "CREATE TABLE table_name(timestamp TIMESTAMP, field FIELD, field FIELD(10), tag TAG)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_without_model_table_space() {
+        assert!(tokenize_and_parse_sql(
+            "CREATE MODELTABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_without_table_name() {
+        assert!(tokenize_and_parse_sql(
+            "CREATE MODEL TABLE(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_without_table__table_name_space() {
+        assert!(tokenize_and_parse_sql(
+            "CREATE MODEL TABLEtable_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_without_start_parentheses() {
+        assert!(tokenize_and_parse_sql(
+            "CREATE MODEL TABLE table_name timestamp TIMESTAMP, field FIELD, tag TAG)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_with_option() {
+        assert!(tokenize_and_parse_sql(
+            "CREATE MODEL TABLE table_name(timestamp TIMESTAMP PRIMARY KEY, field FIELD, tag TAG)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_with_sql_types() {
+        assert!(tokenize_and_parse_sql(
+            "CREATE MODEL TABLE table_name(timestamp TIMESTAMP, field REAL, tag VARCHAR)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_without_column_name() {
+        assert!(tokenize_and_parse_sql(
+            "CREATE MODEL TABLE table_name(TIMESTAMP, field FIELD, tag TAG)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_without_column_type() {
+        assert!(tokenize_and_parse_sql(
+            "CREATE MODEL TABLE table_name(timestamp, field FIELD, tag TAG)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_without_comma() {
+        assert!(tokenize_and_parse_sql(
+            "CREATE MODEL TABLE table_name(timestamp TIMESTAMP field FIELD, tag TAG)",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_create_model_table_without_end_parentheses() {
+        assert!(tokenize_and_parse_sql(
+            "CREATE MODEL TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_tokenize_and_parse_two_create_model_table_commands() {
+        let error = tokenize_and_parse_sql(
+            "CREATE MODEL TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG);
+             CREATE MODEL TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
         );
-        assert!(!ast_is_create_model_table(&ast));
+
+        assert!(error.is_err());
+
+        let expected_error =
+            ParserError::ParserError("Multiple SQL commands are not supported.".to_owned());
+        assert!(error.unwrap_err() == expected_error);
     }
 
-    #[test]
-    fn test_ast_is_create_model_table_correct_lowercase_types() {
-        let ast = parse_data_definition_language_expression(
-            "CREATE TABLE table_name(timestamp timestamp, field field, tag tag)",
-        );
-        assert!(ast_is_create_model_table(&ast));
+    fn new_object_name(name: &str) -> ObjectName {
+        ObjectName(vec![Ident::new(name)])
     }
 
-    #[test]
-    fn test_ast_is_create_model_table_correct_uppercase_types() {
-        let ast = parse_data_definition_language_expression(
-            "CREATE TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
-        );
-        assert!(ast_is_create_model_table(&ast));
-    }
-
-    fn parse_data_definition_language_expression(sql: &str) -> Vec<Statement> {
-        Parser::parse_sql(&GenericDialect {}, sql).unwrap()
+    fn new_column_def(name: &str, data_type: DataType) -> ColumnDef {
+        ColumnDef {
+            name: Ident::new(name),
+            data_type,
+            collation: None,
+            options: vec![],
+        }
     }
 }

--- a/server/src/metadata/parser.rs
+++ b/server/src/metadata/parser.rs
@@ -1,0 +1,113 @@
+/* Copyright 2022 The ModelarDB Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Methods for parsing Data Definition Language (DDL) expressions for creating
+//! tables and model tables. The DDL expressions are tokenized and parsed using
+//! [sqlparser] as it is already used by Apache Arrow DataFusion. Afterwards,
+//! semantics checks are performed to ensure that the DDL expressions match what
+//! is expected by the system and that they create a table or model table.
+//!
+//! [sqlparser]: https://crates.io/crates/sqlparser
+
+use sqlparser::ast::{ColumnDef, DataType, Statement};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::{Parser, ParserError};
+
+/// Parse the `sql` DDL expression, performs semantic checks, and return an AST.
+/// Return the AST as a [`Vec<Statement>`] If `sql` can be parsed and the
+/// semantic checks succeed, otherwise return a [`ParserError`].
+pub fn parse_data_definition_language_expression(sql: &str) -> Result<Vec<Statement>, ParserError> {
+    if sql.is_empty() {
+        return Err(ParserError::TokenizerError(
+            "Expected CREATE TABLE but received an empty string.".to_owned(),
+        ));
+    }
+
+    let ast = Parser::parse_sql(&GenericDialect {}, sql)?;
+
+    //if is_create_model_table
+    Ok(ast)
+}
+
+/// Return [`true`] if `ast` contains one [`Statement`] and it is a CREATE TABLE
+/// expression that creates a model table, otherwise [`false`].
+pub fn ast_is_create_model_table(ast: &Vec<Statement>) -> bool {
+    if ast.len() == 1 {
+        if let Statement::CreateTable { columns, .. } = ast.get(0).unwrap() {
+            return columns
+                .iter()
+                .all(|column_def| column_def_is_a_timestamp_field_or_tag(column_def));
+        }
+    }
+    false
+}
+
+/// Return [`true`] if `column_def` is a timestamp, field, or a tag, otherwise
+/// [`false`].
+fn column_def_is_a_timestamp_field_or_tag(column_def: &ColumnDef) -> bool {
+    match &column_def.data_type {
+        DataType::Timestamp(_timezone) => true,
+        DataType::Custom(object_name) => {
+            let identifier = &object_name.0;
+            if identifier.len() == 1 {
+                let normalized_data_type_name = identifier.get(0).unwrap().value.to_lowercase();
+                normalized_data_type_name == "field" || normalized_data_type_name == "tag"
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests for ast_is_crate_model_table().
+    #[test]
+    fn test_ast_is_create_model_table_empty() {
+        let ast = parse_data_definition_language_expression("");
+        assert!(!ast_is_create_model_table(&ast));
+    }
+
+    #[test]
+    fn test_ast_is_create_model_table_wrong_types() {
+        let ast = parse_data_definition_language_expression(
+            "CREATE TABLE table_name(timestamp TIMESTAMP, field REAL, tag VARCHAR)",
+        );
+        assert!(!ast_is_create_model_table(&ast));
+    }
+
+    #[test]
+    fn test_ast_is_create_model_table_correct_lowercase_types() {
+        let ast = parse_data_definition_language_expression(
+            "CREATE TABLE table_name(timestamp timestamp, field field, tag tag)",
+        );
+        assert!(ast_is_create_model_table(&ast));
+    }
+
+    #[test]
+    fn test_ast_is_create_model_table_correct_uppercase_types() {
+        let ast = parse_data_definition_language_expression(
+            "CREATE TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        );
+        assert!(ast_is_create_model_table(&ast));
+    }
+
+    fn parse_data_definition_language_expression(sql: &str) -> Vec<Statement> {
+        Parser::parse_sql(&GenericDialect {}, sql).unwrap()
+    }
+}

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -29,7 +29,7 @@ pub mod timestamps;
 use std::cmp::{Ordering, PartialOrd};
 use std::mem;
 
-use crate::errors::ModelarDBError;
+use crate::errors::ModelarDbError;
 use crate::models::{gorilla::Gorilla, pmcmean::PMCMean, swing::Swing};
 use crate::types::{
     TimeSeriesId, TimeSeriesIdBuilder, Timestamp, TimestampBuilder, Value, ValueArray, ValueBuilder,
@@ -60,10 +60,10 @@ pub struct ErrorBound(f32);
 
 impl ErrorBound {
     /// Return [`ErrorBound`] if `error_bound` is a positive finite value,
-    /// otherwise [`CompressionError`](ModelarDBError::CompressionError).
-    pub fn try_new(error_bound: f32) -> Result<Self, ModelarDBError> {
+    /// otherwise [`CompressionError`](ModelarDbError::CompressionError).
+    pub fn try_new(error_bound: f32) -> Result<Self, ModelarDbError> {
         if error_bound < 0.0 || error_bound.is_infinite() || error_bound.is_nan() {
-            Err(ModelarDBError::CompressionError(
+            Err(ModelarDbError::CompressionError(
                 "Error bound cannot be negative, infinite, or NAN.".to_owned(),
             ))
         } else {

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -55,7 +55,7 @@ const VALUE_SIZE_IN_BITS: u8 = 8 * VALUE_SIZE_IN_BYTES as u8;
 /// For [`PMCMean`] and [`Swing`] the error bound is interpreted as a relative
 /// per value error bound in percentage, while [`Gorilla`] uses lossless
 /// compression.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct ErrorBound(f32);
 
 impl ErrorBound {
@@ -69,6 +69,12 @@ impl ErrorBound {
         } else {
             Ok(Self(error_bound))
         }
+    }
+
+    /// Return the memory representation of the error bound as a byte array in
+    /// little-endian byte order.
+    pub fn to_le_bytes(&self) -> [u8; 4] {
+        self.0.to_le_bytes()
     }
 }
 

--- a/server/src/parser.rs
+++ b/server/src/parser.rs
@@ -131,7 +131,7 @@ impl ModelarDbDialect {
                 "TAG" => DataType::Text,
                 column_type => {
                     return Err(ParserError::ParserError(format!(
-                        "Expected TIMESTAMP, FIELD, or TAG, found: {}",
+                        "Expected TIMESTAMP, FIELD, or TAG, found: {}.",
                         column_type
                     )))
                 }
@@ -154,7 +154,7 @@ impl ModelarDbDialect {
         Ok(columns)
     }
 
-    /// Return [`()`] if the next [`Token`] is a [`Token::Word`] with the value
+    /// Return [`Ok`] if the next [`Token`] is a [`Token::Word`] with the value
     /// `expected`, otherwise a [`ParseError`] is returned.
     fn expect_word_value(&self, parser: &mut Parser, expected: &str) -> Result<(), ParserError> {
         if let Ok(string) = self.parse_word_value(parser) {
@@ -275,7 +275,7 @@ pub fn tokenize_and_parse_sql(sql: &str) -> Result<Statement, ParserError> {
     }
 }
 
-/// A top-level statement (SELECT, INSERT, CREATE, Update, etc.) that have been
+/// A top-level statement (SELECT, INSERT, CREATE, UPDATE, etc.) that have been
 /// tokenized, parsed, and for which semantics checks have verified that it is
 /// compatible with ModelarDB. CREATE TABLE and CREATE MODEL TABLE is supported.
 pub enum ValidStatement {
@@ -305,7 +305,7 @@ pub fn semantic_checks_for_create_table(
     {
         // Extract the table name from the Statement::CreateTable.
         if name.0.len() > 1 {
-            let message = "Multi-part table names are not supported";
+            let message = "Multi-part table names are not supported.";
             return Err(ParserError::ParserError(message.to_owned()));
         }
 
@@ -337,7 +337,7 @@ pub fn semantic_checks_for_create_table(
             });
         }
     } else {
-        let message = "Expected CREATE TABLE or CREATE MODEL TABLE";
+        let message = "Expected CREATE TABLE or CREATE MODEL TABLE.";
         return Err(ParserError::ParserError(message.to_owned()));
     };
 }
@@ -445,7 +445,7 @@ fn check_unsupported_features_are_disabled(statement: &Statement) -> Result<(), 
         check_unsupported_feature_is_disabled(on_cluster.is_some(), "ON CLUSTER")?;
         Ok(())
     } else {
-        let message = "Expected CREATE TABLE or CREATE MODEL TABLE";
+        let message = "Expected CREATE TABLE or CREATE MODEL TABLE.";
         Err(ParserError::ParserError(message.to_owned()))
     }
 }
@@ -562,8 +562,19 @@ mod tests {
             ];
             assert!(columns == expected_columns);
         } else {
-            panic!("CREATE TABLE DDL did not parse to a Statement::CreateTable");
+            panic!("CREATE TABLE DDL did not parse to a Statement::CreateTable.");
         }
+    }
+
+    fn new_object_name(name: &str) -> ObjectName {
+        ObjectName(vec![Ident::new(name)])
+    }
+
+    fn new_column_option_def_error_bound(error_bound: usize) -> Vec<ColumnOptionDef> {
+        vec![ColumnOptionDef {
+            name: None,
+            option: ColumnOption::Comment(error_bound.to_string()),
+        }]
     }
 
     #[test]
@@ -683,16 +694,5 @@ mod tests {
         let expected_error =
             ParserError::ParserError("Multiple SQL commands are not supported.".to_owned());
         assert!(error.unwrap_err() == expected_error);
-    }
-
-    fn new_object_name(name: &str) -> ObjectName {
-        ObjectName(vec![Ident::new(name)])
-    }
-
-    fn new_column_option_def_error_bound(error_bound: usize) -> Vec<ColumnOptionDef> {
-        vec![ColumnOptionDef {
-            name: None,
-            option: ColumnOption::Comment(error_bound.to_string()),
-        }]
     }
 }

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -39,13 +39,13 @@ use datafusion::arrow::{
 use datafusion::catalog::schema::SchemaProvider;
 use datafusion::prelude::ParquetReadOptions;
 use futures::{stream, Stream, StreamExt};
-use object_store;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{debug, error, info};
 
 use crate::metadata::model_table_metadata::ModelTableMetadata;
 use crate::metadata::MetadataManager;
+use crate::parser::{self, ValidStatement};
 use crate::storage::StorageEngine;
 use crate::tables::ModelTable;
 use crate::Context;
@@ -159,6 +159,16 @@ impl FlightServiceHandler {
         }
     }
 
+    /// Return [`Status`] if a table `name` exists in the default catalog.
+    fn check_if_table_exists(&self, table_name: &str) -> Result<(), Status> {
+        let maybe_schema = self.get_schema_of_table_in_default_database_schema(table_name);
+        if maybe_schema.is_ok() {
+            let message = format!("Table with name '{}' already exists.", table_name);
+            return Err(Status::already_exists(message));
+        }
+        Ok(())
+    }
+
     /// While there is still more data to receive, ingest the data into the
     /// table.
     fn ingest_into_table(
@@ -209,10 +219,15 @@ impl FlightServiceHandler {
         Ok(())
     }
 
-    /// Create a normal table, add it to the metadata database table, and add
-    /// it to the catalog. If the table already exists or if the Apache Parquet
-    /// file cannot be created, return [`Status`] error.
-    async fn create_table(&self, table_name: String, schema: Schema) -> Result<(), Status> {
+    /// Create a normal table, register it with Apache Arrow DataFusion's
+    /// catalog, and save it to the [`MetadataManager`]. If the table exists,
+    /// the Apache Parquet file cannot be created, or if the table cannot be
+    /// saved to the [`MetadataManager`], return [`Status`] error.
+    async fn register_and_save_table(
+        &self,
+        table_name: String,
+        schema: Schema,
+    ) -> Result<(), Status> {
         // Ensure the folder for storing the table data exists.
         let metadata_manager = &self.context.metadata_manager;
         let folder_path = metadata_manager.get_data_folder_path().join(&table_name);
@@ -245,25 +260,15 @@ impl FlightServiceHandler {
         Ok(())
     }
 
-    /// Create a model table, add it to the metadata database tables, and add it to the catalog.
-    /// If the table already exists or if the metadata cannot be written to the metadata database,
-    /// return [`Status`] error.
-    fn create_model_table(
+    /// Create a model table, register it with Apache Arrow DataFusion's
+    /// catalog, and save it to the [`MetadataManager`]. If the table exists or
+    /// if the table cannot be saved to the [`MetadataManager`], return
+    /// [`Status`] error.
+    fn register_and_save_model_table(
         &self,
-        table_name: String,
-        schema: Schema,
-        tag_column_indices: Vec<u8>,
-        timestamp_column_index: u8,
+        model_table_metadata: ModelTableMetadata,
     ) -> Result<(), Status> {
-        let model_table_metadata = ModelTableMetadata::try_new(
-            table_name.clone(),
-            schema.clone(),
-            tag_column_indices,
-            timestamp_column_index,
-        )
-        .map_err(|error| Status::invalid_argument(error.to_string()))?;
-
-        // Save the model table in the Apache Arrow Datafusion catalog.
+        // Save the model table in the Apache Arrow DataFusion catalog.
         let model_table_metadata = Arc::new(model_table_metadata);
 
         self.context
@@ -274,20 +279,13 @@ impl FlightServiceHandler {
             )
             .map_err(|error| Status::invalid_argument(error.to_string()))?;
 
-        // Convert the schema to bytes so it can be saved as a BLOB in the metadata database.
-        let options = IpcWriteOptions::default();
-        let schema_as_ipc = SchemaAsIpc::new(&schema, &options);
-        let ipc_message: IpcMessage = schema_as_ipc
-            .try_into()
-            .map_err(|error: ArrowError| Status::internal(error.to_string()))?;
-
         // Persist the new model table to the metadata database.
         self.context
             .metadata_manager
-            .save_model_table_metadata(&model_table_metadata, ipc_message.0)
+            .save_model_table_metadata(&model_table_metadata)
             .map_err(|error| Status::internal(error.to_string()))?;
 
-        info!("Created model table '{}'.", table_name);
+        info!("Created model table '{}'.", model_table_metadata.name);
         Ok(())
     }
 }
@@ -429,7 +427,7 @@ impl FlightService for FlightServiceHandler {
             .flight_descriptor
             .ok_or_else(|| Status::invalid_argument("Missing FlightDescriptor."))?;
         let table_name = self.get_table_name_from_flight_descriptor(&flight_descriptor)?;
-        let normalized_table_name = MetadataManager::normalize_table_name(&table_name);
+        let normalized_table_name = MetadataManager::normalize_name(&table_name);
 
         // Handle the data based on whether it is a normal table or a model table.
         if let Some(model_table_metadata) =
@@ -457,17 +455,15 @@ impl FlightService for FlightServiceHandler {
         Err(Status::unimplemented("Not implemented."))
     }
 
-    /// Perform a specific action based on the type of the action in `request`. Currently supports
-    /// two actions: `CreateTable` and `CreateModelTable`. `CreateTable` creates a normal table
-    /// in the catalog when given a table name and schema. `CreateModelTable` creates a table
-    /// that is specialized for efficiently storing multivariate time series with tags within
-    /// a user-defined error bound. This action takes a table name, a schema, a list of indices
-    /// specifying which columns are metadata tag columns, and an index specifying which column
-    /// is the timestamp column.
-    ///
-    /// The data is given in the action body and must have the following format:
-    /// The first two bytes are the length x of the first argument. The next x bytes are the first
-    /// argument. This pattern repeats until all arguments are consumed.
+    /// Perform a specific action based on the type of the action in `request`.
+    /// Currently only the action `CommandStatementUpdate` is supported which
+    /// executes a SQL query containing a single command that does not return a
+    /// result. These commands can be `CREATE TABLE table_name(name type*)`
+    /// which creates a normal table in the catalog, and `CREATE MODEL TABLE
+    /// table_name(name_one TIMESTAMP, name_two FIELD*, name_three,
+    /// FIELD(error_bound)*, name_four TAG*)` which creates a model table in the
+    /// catalog. A model table is a specialized table for efficiently storing
+    /// multivariate time series with tags within a per field error bound.
     async fn do_action(
         &self,
         request: Request<Action>,
@@ -475,60 +471,31 @@ impl FlightService for FlightServiceHandler {
         let action = request.into_inner();
         info!("Received request to perform action '{}'.", action.r#type);
 
-        if action.r#type == "CreateTable" || action.r#type == "CreateModelTable" {
-            // Extract the table name from the action body.
-            let (table_name_bytes, offset_data) = extract_argument_bytes(&action.body);
-            let table_name = str::from_utf8(table_name_bytes)
+        if action.r#type == "CommandStatementUpdate" {
+            // Read the SQL from the action.
+            let sql = str::from_utf8(&action.body)
                 .map_err(|error| Status::invalid_argument(error.to_string()))?;
-            let normalized_table_name = MetadataManager::normalize_table_name(&table_name);
+            info!("Received request to execute '{}'.", sql);
 
-            // If the table already exists, return an error.
-            if self
-                .get_schema_of_table_in_default_database_schema(&normalized_table_name)
-                .is_ok()
-            {
-                let message = format!(
-                    "Table with name '{}' already exists.",
-                    normalized_table_name
-                );
-                return Err(Status::already_exists(message));
-            }
-
-            // Check if the table name is a valid object_store path and database table name.
-            object_store::path::Path::parse(&normalized_table_name)
+            // Parse the SQL.
+            let statement = parser::tokenize_and_parse_sql(sql)
                 .map_err(|error| Status::invalid_argument(error.to_string()))?;
 
-            if normalized_table_name.contains(char::is_whitespace) {
-                return Err(Status::invalid_argument(
-                    "Table name cannot contain whitespace.".to_owned(),
-                ));
-            }
-
-            // Extract the schema from the action body.
-            let (schema_bytes, offset_data) = extract_argument_bytes(offset_data);
-            let ipc_message = IpcMessage(Vec::from(schema_bytes));
-            let schema = Schema::try_from(ipc_message)
+            // Perform semantics checks to ensure the parsed SQL is supported.
+            let valid_statement = parser::semantic_checks_for_create_table(&statement)
                 .map_err(|error| Status::invalid_argument(error.to_string()))?;
 
-            if action.r#type == "CreateTable" {
-                self.create_table(normalized_table_name.to_owned(), schema)
-                    .await?;
-            } else {
-                // Extract the tag column indices from the action body. Note that since we assume
-                // each tag column index is one byte, we directly use the slice of bytes as the list
-                // of tag column indices.
-                let (tag_indices, offset_data) = extract_argument_bytes(offset_data);
-
-                // Extract the timestamp column index from the action body.
-                let (timestamp_index, _offset_data) = extract_argument_bytes(offset_data);
-
-                self.create_model_table(
-                    normalized_table_name.to_owned(),
-                    schema,
-                    tag_indices.to_vec(),
-                    timestamp_index[0],
-                )?;
-            }
+            // Create the table or model table if it does not already exists.
+            match valid_statement {
+                ValidStatement::CreateTable { name, schema } => {
+                    self.check_if_table_exists(&name)?;
+                    self.register_and_save_table(name, schema).await?;
+                }
+                ValidStatement::CreateModelTable(model_table_metadata) => {
+                    self.check_if_table_exists(&model_table_metadata.name)?;
+                    self.register_and_save_model_table(model_table_metadata)?;
+                }
+            };
 
             // Confirm the table was created.
             Ok(Response::new(Box::pin(stream::empty())))
@@ -542,34 +509,13 @@ impl FlightService for FlightServiceHandler {
         &self,
         _request: Request<Empty>,
     ) -> Result<Response<Self::ListActionsStream>, Status> {
-        let create_table_action = ActionType {
-            r#type: "CreateTable".to_owned(),
-            description: "Given a table name and a schema, create a table and add it to the \
-            catalog."
+        let create_command_statement_update_action = ActionType {
+            r#type: "CommandStatementUpdate".to_owned(),
+            description: "Execute a SQL query containing a single command that produce no results."
                 .to_owned(),
         };
 
-        let create_model_table_action = ActionType {
-            r#type: "CreateModelTable".to_owned(),
-            description: "Given a table name, a schema, a list of tag column indices, and the \
-            timestamp column index, create a model table and add it to the catalog."
-                .to_owned(),
-        };
-
-        let output = stream::iter(vec![Ok(create_table_action), Ok(create_model_table_action)]);
+        let output = stream::iter(vec![Ok(create_command_statement_update_action)]);
         Ok(Response::new(Box::pin(output)))
     }
-}
-
-/// Assumes `data` is a slice containing one or more arguments for an Action stored using the following
-/// format: size of argument (2 bytes) followed by argument (length bytes). Returns a tuple containing
-/// the first argument's bytes and `data` with the extracted argument's bytes removed.
-fn extract_argument_bytes(data: &[u8]) -> (&[u8], &[u8]) {
-    let size_bytes: [u8; 2] = data[..2].try_into().expect("Slice with incorrect length.");
-    let size = u16::from_be_bytes(size_bytes) as usize;
-
-    let argument_bytes = &data[2..(size + 2)];
-    let remaining_bytes = &data[(size + 2)..];
-
-    (argument_bytes, remaining_bytes)
 }

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -469,7 +469,7 @@ impl FlightService for FlightServiceHandler {
     /// Examples of CREATE TABLE and CREATE MODEL TABLE commands:
     /// * CREATE TABLE company(id INTEGER, name TEXT)
     /// * CREATE MODEL TABLE wind_turbines(timestamp TIMESTAMP,
-    ///   field_lossless FIELD, field_lossy FIELD(5),  tag_one TAG, tag_two TAG)
+    ///   field_lossless FIELD, field_lossy FIELD(5), tag_one TAG, tag_two TAG)
     async fn do_action(
         &self,
         request: Request<Action>,

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -23,7 +23,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use tracing::info;
 use tracing::{debug, debug_span};
 
-use crate::errors::ModelarDBError;
+use crate::errors::ModelarDbError;
 use crate::storage::time_series::CompressedTimeSeries;
 use crate::types::{CompressedSchema, Timestamp};
 use crate::StorageEngine;
@@ -97,11 +97,11 @@ impl CompressedDataManager {
 
     /// Return the file path to each on-disk compressed file that corresponds to `key`. If some
     /// compressed data that corresponds to `key` is still in memory, save the data to disk first.
-    /// If `key` does not correspond to any data, [`DataRetrievalError`](ModelarDBError::DataRetrievalError) is returned.
+    /// If `key` does not correspond to any data, [`DataRetrievalError`](ModelarDbError::DataRetrievalError) is returned.
     pub(super) fn save_and_get_saved_compressed_files(
         &mut self,
         key: &u64,
-    ) -> Result<Vec<PathBuf>, ModelarDBError> {
+    ) -> Result<Vec<PathBuf>, ModelarDbError> {
         // If there is any compressed data in memory, save it first.
         if self.compressed_data.contains_key(key) {
             // Remove the data from the queue of compressed time series that are ready to be saved.
@@ -115,7 +115,7 @@ impl CompressedDataManager {
         // Read the directory that contains the compressed data corresponding to the key.
         let key_path = self.data_folder_path.join(format!("{}/compressed", key));
         let dir = fs::read_dir(key_path).map_err(|error| {
-            ModelarDBError::DataRetrievalError(format!(
+            ModelarDbError::DataRetrievalError(format!(
                 "Compressed data could not be found for key '{}': {}",
                 key,
                 error.to_string()

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -39,7 +39,7 @@ use object_store::path::Path as ObjectStorePath;
 use object_store::ObjectMeta;
 
 use crate::metadata::model_table_metadata::ModelTableMetadata;
-use crate::errors::ModelarDBError;
+use crate::errors::ModelarDbError;
 use crate::metadata::MetadataManager;
 use crate::storage::compressed_data_manager::CompressedDataManager;
 use crate::storage::segment::FinishedSegment;
@@ -144,19 +144,19 @@ impl StorageEngine {
 
     /// Retrieve the compressed files that correspond to `keys` within the given range of time.
     /// If `keys` contain a key that does not exist or the end time is before the start time,
-    /// [`DataRetrievalError`](ModelarDBError::DataRetrievalError) is returned.
+    /// [`DataRetrievalError`](ModelarDbError::DataRetrievalError) is returned.
     pub fn get_compressed_files(
         &mut self,
         keys: &[u64],
         start_time: Option<Timestamp>,
         end_time: Option<Timestamp>,
-    ) -> Result<Vec<(String, ObjectMeta)>, ModelarDBError> {
+    ) -> Result<Vec<(String, ObjectMeta)>, ModelarDbError> {
         let start_time = start_time.unwrap_or(0);
         let end_time = end_time.unwrap_or(Timestamp::MAX);
         let mut compressed_files: Vec<(String, ObjectMeta)> = vec![];
 
         if start_time > end_time {
-            return Err(ModelarDBError::DataRetrievalError(format!(
+            return Err(ModelarDbError::DataRetrievalError(format!(
                 "Start time '{}' cannot be after end time '{}'.",
                 start_time, end_time
             )));

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -92,7 +92,7 @@ impl UncompressedDataManager {
         );
 
         // Prepare the timestamp column for iteration.
-        let timestamp_index = model_table.timestamp_column_index as usize;
+        let timestamp_index = model_table.timestamp_column_index;
         let timestamps: &TimestampArray = data_points
             .column(timestamp_index)
             .as_any()
@@ -103,13 +103,7 @@ impl UncompressedDataManager {
         let tag_column_arrays: Vec<&StringArray> = model_table
             .tag_column_indices
             .iter()
-            .map(|index| {
-                data_points
-                    .column(*index as usize)
-                    .as_any()
-                    .downcast_ref()
-                    .unwrap()
-            })
+            .map(|index| data_points.column(*index).as_any().downcast_ref().unwrap())
             .collect();
 
         // Prepare the field columns for iteration. The column index is saved with the corresponding array.
@@ -121,17 +115,13 @@ impl UncompressedDataManager {
                 let index = model_table.schema.index_of(field.name().as_str()).unwrap();
 
                 // Field columns are the columns that are not the timestamp column or one of the tag columns.
-                let not_timestamp_column = index != model_table.timestamp_column_index as usize;
+                let not_timestamp_column = index != model_table.timestamp_column_index;
                 let not_tag_column = !model_table.tag_column_indices.contains(&index);
 
                 if not_timestamp_column && not_tag_column {
                     Some((
                         index,
-                        data_points
-                            .column(index as usize)
-                            .as_any()
-                            .downcast_ref()
-                            .unwrap(),
+                        data_points.column(index).as_any().downcast_ref().unwrap(),
                     ))
                 } else {
                     None

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -122,7 +122,7 @@ impl UncompressedDataManager {
 
                 // Field columns are the columns that are not the timestamp column or one of the tag columns.
                 let not_timestamp_column = index != model_table.timestamp_column_index as usize;
-                let not_tag_column = !model_table.tag_column_indices.contains(&(index as u8));
+                let not_tag_column = !model_table.tag_column_indices.contains(&index);
 
                 if not_timestamp_column && not_tag_column {
                     Some((
@@ -347,7 +347,7 @@ mod tests {
 
         let (model_table_metadata, data) = get_uncompressed_data(1);
         metadata_manager
-            .save_model_table_metadata(&model_table_metadata, vec![])
+            .save_model_table_metadata(&model_table_metadata)
             .unwrap();
         data_manager
             .insert_data_points(&mut metadata_manager, &model_table_metadata, &data)
@@ -364,7 +364,7 @@ mod tests {
 
         let (model_table_metadata, data) = get_uncompressed_data(2);
         metadata_manager
-            .save_model_table_metadata(&model_table_metadata, vec![])
+            .save_model_table_metadata(&model_table_metadata)
             .unwrap();
         data_manager
             .insert_data_points(&mut metadata_manager, &model_table_metadata, &data)
@@ -400,8 +400,14 @@ mod tests {
         )
         .unwrap();
 
+        let error_bounds = vec![
+            ErrorBound::try_new(0.0).unwrap(),
+            ErrorBound::try_new(0.0).unwrap(),
+        ];
+
         let model_table_metadata =
-            ModelTableMetadata::try_new("model_table".to_owned(), schema, vec![0], 1).unwrap();
+            ModelTableMetadata::try_new("model_table".to_owned(), schema, 1, vec![0], error_bounds)
+                .unwrap();
 
         (model_table_metadata, data)
     }


### PR DESCRIPTION
This PR replaces the [`CreateTable`](https://github.com/ModelarData/ModelarDB-RS/blob/master/server/src/remote.rs#L545) and [`CreateModelTable`](https://github.com/ModelarData/ModelarDB-RS/blob/master/server/src/remote.rs#L552) Apache Arrow Flight [`Action`](https://docs.rs/arrow-flight/latest/arrow_flight/struct.Action.html)s with a single [`CommandStatementUpdate`](https://github.com/ModelarData/ModelarDB-RS/blob/dev/add-create-table-ddl/server/src/remote.rs#L512) which executes a SQL query containing a single command that produces no results. The use of a  single `Action` and the name `CommandStatementUpdate` was chosen to better match the current [Apache Arrow Flight SQL](https://arrow.apache.org/docs/format/FlightSql.html) specification, thus, hopefully making it simpler to switch to Apache Arrow Flight SQL when the specification is complete. The SQL in `CommandStatementUpdate` `Action`s are parsed to [`Statement`](https://docs.rs/sqlparser/latest/sqlparser/ast/enum.Statement.html)s using [`sqlparser`](https://docs.rs/sqlparser/latest/sqlparser/) as it is already included as a dependency of Apache Arrow DataFusion. As ModelarDB only supports a subset of the SQL `sqlparser` can tokenize and parse, a set of semantic checks are used to validate that the `Statement`s only use functionality supported by ModelarDB. If a `Statement` successfully passes the semantic checks, a [`ValidStatement`](https://github.com/ModelarData/ModelarDB-RS/blob/dev/add-create-table-ddl/server/src/parser.rs#L281) is constructed from it which only contains the data ModelarDB needs. Currently, two DDL commands are supported: `CREATE TABLE table_name(...` and `CREATE MODEL TABLE table_name(...`. Supporting additional SQL constructs simply require that suitable `ValidStatement`s and semantic checks are defined. In addition, ModelarDB's SQL dialect can be extended with new constructs like `CREATE MODEL TABLE table_name(...` by extending [`ModelarDbDialect::parse_statement()`](https://github.com/ModelarData/ModelarDB-RS/blob/dev/add-create-table-ddl/server/src/parser.rs#L250).