### PR TITLE
Removed tokio runtime from context

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -109,7 +109,7 @@ fn main() -> Result<(), String> {
         setup_ctrl_c_handler(&context, &runtime);
 
         // Start Interface.
-        remote::start_arrow_flight_server(context, &runtime,9999).map_err(|error| error.to_string())?
+        remote::start_arrow_flight_server(context, &runtime, 9999).map_err(|error| error.to_string())?
     } else {
         // The errors are consciously ignored as the program is terminating.
         let binary_path = std::env::current_exe().unwrap();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -73,7 +73,8 @@ fn main() -> Result<(), String> {
         fs::create_dir_all(data_folder_path.as_path())
             .map_err(|error| format!("Unable to create {}: {}", &data_folder, error))?;
 
-        // Create a tokio runtime for executing asynchronous tasks.
+        // Create a Tokio runtime for executing asynchronous tasks. The runtime is not part of the
+        // context to make it easier to pass the runtime to components in the context.
         let runtime = Arc::new(Runtime::new()
             .map_err(|error| format!("Unable to create a Tokio Runtime: {}", error))?);
 

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -396,7 +396,7 @@ impl MetadataManager {
     pub fn register_tables(
         &self,
         context: &Arc<Context>,
-        runtime: &Arc<Runtime>
+        runtime: &Arc<Runtime>,
     ) -> Result<(), rusqlite::Error> {
         let connection = Connection::open(&self.metadata_database_path)?;
 
@@ -420,7 +420,7 @@ impl MetadataManager {
         &self,
         row: &Row,
         context: &Arc<Context>,
-        runtime: &Arc<Runtime>
+        runtime: &Arc<Runtime>,
     ) -> Result<(), Box<dyn Error>> {
         let name = row.get::<usize, String>(0)?;
 

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -41,6 +41,7 @@ use datafusion::arrow::{error::ArrowError, ipc::writer::IpcWriteOptions};
 use datafusion::execution::options::ParquetReadOptions;
 use rusqlite::types::Type::Blob;
 use rusqlite::{params, Connection, Result, Row};
+use tokio::runtime::Runtime;
 use tracing::{error, info, warn};
 
 use crate::metadata::model_table_metadata::ModelTableMetadata;
@@ -392,7 +393,11 @@ impl MetadataManager {
     /// Read the rows in the table_metadata table and use these to register
     /// tables in Apache Arrow DataFusion. If the metadata database could not be
     /// opened or the table could not be queried, return [`rusqlite::Error`].
-    pub fn register_tables(&self, context: &Arc<Context>) -> Result<(), rusqlite::Error> {
+    pub fn register_tables(
+        &self,
+        context: &Arc<Context>,
+        runtime: &Arc<Runtime>
+    ) -> Result<(), rusqlite::Error> {
         let connection = Connection::open(&self.metadata_database_path)?;
 
         let mut select_statement = connection.prepare("SELECT table_name FROM table_metadata")?;
@@ -400,7 +405,7 @@ impl MetadataManager {
         let mut rows = select_statement.query(())?;
 
         while let Some(row) = rows.next()? {
-            if let Err(error) = self.register_table(row, &context) {
+            if let Err(error) = self.register_table(row, &context, &runtime) {
                 error!("Failed to register table due to: {}.", error);
             }
         }
@@ -411,7 +416,12 @@ impl MetadataManager {
     /// Use a row from the table_metadata table to register the table in Apache
     /// Arrow DataFusion. If the metadata database could not be opened or the
     /// table could not be queried, return [`Error`].
-    fn register_table(&self, row: &Row, context: &Arc<Context>) -> Result<(), Box<dyn Error>> {
+    fn register_table(
+        &self,
+        row: &Row,
+        context: &Arc<Context>,
+        runtime: &Arc<Runtime>
+    ) -> Result<(), Box<dyn Error>> {
         let name = row.get::<usize, String>(0)?;
 
         // Compute the path to the folder containing data for the table.
@@ -421,7 +431,7 @@ impl MetadataManager {
             .ok_or_else(|| format!("Path for table is not UTF-8: '{}'", name))?;
 
         // Register table.
-        context.runtime.block_on(context.session.register_parquet(
+        runtime.block_on(context.session.register_parquet(
             &name,
             table_folder,
             ParquetReadOptions::default(),
@@ -966,6 +976,7 @@ mod tests {
 
         // Save a table to the metadata database.
         let temp_dir = tempfile::tempdir().unwrap();
+        let runtime = Arc::new(Runtime::new().unwrap());
         let context = test_util::get_test_context(temp_dir.path());
 
         context
@@ -974,7 +985,7 @@ mod tests {
             .unwrap();
 
         // Register the table with Apache Arrow DataFusion.
-        context.metadata_manager.register_tables(&context).unwrap();
+        context.metadata_manager.register_tables(&context, &runtime).unwrap();
     }
 
     #[test]
@@ -1119,7 +1130,6 @@ pub mod test_util {
     use datafusion::execution::context::{SessionConfig, SessionContext, SessionState};
     use datafusion::execution::runtime_env::RuntimeEnv;
     use tempfile;
-    use tokio::runtime::Runtime;
 
     use crate::models::ErrorBound;
     use crate::storage::StorageEngine;
@@ -1128,7 +1138,6 @@ pub mod test_util {
     /// `get_test_metadata_manager()` and the data folder set to `path`.
     pub fn get_test_context(path: &Path) -> Arc<Context> {
         let metadata_manager = get_test_metadata_manager(path);
-        let runtime = Runtime::new().unwrap();
         let session = get_test_session_context();
         let storage_engine = RwLock::new(StorageEngine::new(
             path.to_owned(),
@@ -1138,7 +1147,6 @@ pub mod test_util {
 
         Arc::new(Context {
             metadata_manager,
-            runtime,
             session,
             storage_engine,
         })

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -56,7 +56,7 @@ use crate::Context;
 pub fn start_arrow_flight_server(
     context: Arc<Context>,
     runtime: &Arc<Runtime>,
-    port: i16
+    port: i16,
 ) -> Result<(), Box<dyn Error>> {
     let localhost_with_port = "0.0.0.0:".to_owned() + &port.to_string();
     let localhost_with_port: SocketAddr = localhost_with_port.parse()?;

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -39,6 +39,7 @@ use datafusion::arrow::{
 use datafusion::catalog::schema::SchemaProvider;
 use datafusion::prelude::ParquetReadOptions;
 use futures::{stream, Stream, StreamExt};
+use tokio::runtime::Runtime;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{debug, error, info};
@@ -52,7 +53,11 @@ use crate::Context;
 
 /// Start an Apache Arrow Flight server on 0.0.0.0:`port` that pass `context` to
 /// the methods that process the requests through `FlightServiceHandler`.
-pub fn start_arrow_flight_server(context: Arc<Context>, port: i16) -> Result<(), Box<dyn Error>> {
+pub fn start_arrow_flight_server(
+    context: Arc<Context>,
+    runtime: &Arc<Runtime>,
+    port: i16
+) -> Result<(), Box<dyn Error>> {
     let localhost_with_port = "0.0.0.0:".to_owned() + &port.to_string();
     let localhost_with_port: SocketAddr = localhost_with_port.parse()?;
     let handler = FlightServiceHandler {
@@ -61,8 +66,7 @@ pub fn start_arrow_flight_server(context: Arc<Context>, port: i16) -> Result<(),
     };
     let flight_service_server = FlightServiceServer::new(handler);
     info!("Starting Apache Arrow Flight on {}.", localhost_with_port);
-    context
-        .runtime
+    runtime
         .block_on(async {
             Server::builder()
                 .add_service(flight_service_server)


### PR DESCRIPTION
To simplify the process of passing the tokio runtime to sub-components, the runtime has been removed from the context. This means that instead of retrieving the runtime from the context, components that need to carry out async tasks need to receive a reference to the runtime that is created in main. 

Currently there is no large benefit to this change but the need for it becomes more clear when components that rely on the async object_store crate are added (fx. data transfer). 