### PR TITLE
Fix bugs caused by irregular time series

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -164,7 +164,9 @@ fn execute_and_print_action_command_or_query(
 ) -> Result<()> {
     if action_command_or_query.starts_with('\\') {
         execute_command(rt, fsc, action_command_or_query)?;
-    } else if action_command_or_query.starts_with("SELECT") {
+    } else if action_command_or_query.starts_with("SELECT")
+        || action_command_or_query.starts_with("EXPLAIN")
+    {
         let df = execute_query(rt, fsc, action_command_or_query)?;
         pretty::print_batches(&df)?;
     } else {

--- a/server/src/models/bits.rs
+++ b/server/src/models/bits.rs
@@ -120,7 +120,8 @@ impl BitVecBuilder {
             } else {
                 // Write the remaining number_of_bits bits from bits to self.current_byte.
                 let shift = self.remaining_bits - number_of_bits;
-                self.current_byte |= (bits << shift) as u8;
+                let mask = (u8::MAX >> (8 - self.remaining_bits)) as u32;
+                self.current_byte |= ((bits << shift) & mask) as u8;
                 number_of_bits
             };
             number_of_bits -= bits_written;

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -176,7 +176,7 @@ impl SelectedModel {
         uncompressed_values: &ValueArray,
     ) -> Self {
         let end_index = start_index + gorilla.get_length() - 1;
-        let uncompressed_values = &uncompressed_values.values()[start_index..end_index];
+        let uncompressed_values = &uncompressed_values.values()[start_index..=end_index];
         let min_value = uncompressed_values
             .iter()
             .fold(Value::NAN, |current_min, value| {

--- a/server/src/models/timestamps.rs
+++ b/server/src/models/timestamps.rs
@@ -313,13 +313,23 @@ mod tests {
     #[test]
     fn compress_and_decompress_timestamps_for_a_regular_time_series() {
         compress_and_decompress_timestamps_for_a_time_series(&[
-            100, 200, 300, 400, 500, 600, 700, 800,
+            1579701905500,
+            1579701905600,
+            1579701905700,
+            1579701905800,
+            1579701905900,
         ]);
     }
 
     #[test]
     fn compress_and_decompress_timestamps_for_an_irregular_time_series() {
-        compress_and_decompress_timestamps_for_a_time_series(&[100, 150, 300, 350, 700, 750, 1500]);
+        compress_and_decompress_timestamps_for_a_time_series(&[
+            1579694400057,
+            1579694400197,
+            1579694400353,
+            1579694400493,
+            1579694400650,
+        ]);
     }
 
     fn compress_and_decompress_timestamps_for_a_time_series(uncompressed_timestamps: &[Timestamp]) {


### PR DESCRIPTION
This PR fixes a collection of minor issues that were discovered while experimenting with ingesting and querying irregular time series with one issue fixed per commit. The addition of `count` to `ModelSumAccumulator` is required to match [`SumAccumulator`](https://github.com/apache/arrow-datafusion/blob/master/datafusion/physical-expr/src/aggregate/sum.rs#L138)  but it is unclear what the purpose of `count` in `SumAccumulator` is and its value seems to have no effect on the result. The files have purposely only been changed to the degree necessary to fix the bugs. 