### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,15 +85,16 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "arrow"
-version = "24.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68391300d5237f6725f0f869ae7cb65d45fcf8a6d18f6ceecd328fb803bef93"
+checksum = "e24e2bcd431a4aa0ff003fdd2dc21c78cfb42f31459c89d2312c2746fe17a5ac"
 dependencies = [
  "ahash 0.8.0",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
+ "arrow-select",
  "bitflags",
  "chrono",
  "comfy-table",
@@ -113,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "24.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0bb00c5862b5eea683812083c495bef01a9a5149da46ad2f4c0e4aa8800f64d"
+checksum = "c9044300874385f19e77cbf90911e239bd23630d8f23bb0f948f9067998a13b7"
 dependencies = [
  "ahash 0.8.0",
  "arrow-buffer",
@@ -129,18 +130,19 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "24.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e594d0fe0026a8bc2459bdc5ac9623e5fb666724a715e0acbc96ba30c5d4cc7"
+checksum = "78476cbe9e3f808dcecab86afe42d573863c63e149c62e6e379ed2522743e626"
 dependencies = [
  "half",
+ "num",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "24.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8500df05060d86fdc53e9b5cb32e51bfeaacc040fdeced3eb99ac0d59200ff45"
+checksum = "4d916feee158c485dad4f701cba31bc9a90a8db87d9df8e2aa8adc0c20a2bbb9"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -150,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "24.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5438183d2f3404f57418847a06a3925037916f80ed8aefc904276b41e7f90322"
+checksum = "9fdfed4af8da422c6ea108ae216325a9b8e020602c333cb31648a6d95178923a"
 dependencies = [
  "arrow",
  "base64",
@@ -168,9 +170,37 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "24.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d1fef01f25e1452c86fa6887f078de8e0aaeeb828370feab205944cfc30e27"
+checksum = "0f9406eb7834ca6bd8350d1baa515d18b9fcec487eddacfb62f5e19511f7bd37"
+
+[[package]]
+name = "arrow-select"
+version = "26.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6593a01586751c74498495d2f5a01fcd438102b52965c11dd98abf4ebcacef37"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "bzip2",
+ "flate2",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-stream"
@@ -195,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -366,6 +396,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,14 +569,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bdec06a3db088da76fc28cb0877b8b5438ca6b6025e04d975bace0fd85df19"
+checksum = "e7a8411475928479fe57af18698626f0a44f3c29153e051dce45f7455c08a6d5"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
+ "async-compression",
  "async-trait",
  "bytes",
+ "bzip2",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
@@ -533,6 +586,7 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-row",
  "datafusion-sql",
+ "flate2",
  "futures",
  "glob",
  "hashbrown",
@@ -545,6 +599,7 @@ dependencies = [
  "parking_lot",
  "parquet",
  "paste",
+ "percent-encoding",
  "pin-project-lite",
  "rand",
  "smallvec",
@@ -552,17 +607,19 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "url",
  "uuid",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "506eab038bf2d39ac02c22be30b019873ca01f887148b939d309a0e9523f4515"
+checksum = "15f1ffcbc1f040c9ab99f41db1c743d95aff267bb2e7286aaa010738b7402251"
 dependencies = [
  "arrow",
+ "chrono",
  "object_store",
  "ordered-float 3.1.0",
  "parquet",
@@ -571,21 +628,22 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d2810e369c735d69479e27fe8410e97a76ed07484aa9b3ad7c039efa504257"
+checksum = "1883d9590d303ef38fa295567e7fdb9f8f5f511fcc167412d232844678cd295c"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
  "datafusion-common",
+ "log",
  "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f3b80326243629d02e33f37e955a7114781c6c44caf9d8b254618157de7143"
+checksum = "2127d46d566ab3463d70da9675fc07b9d634be8d17e80d0e1ce79600709fe651"
 dependencies = [
  "arrow",
  "async-trait",
@@ -599,34 +657,40 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bf3b7ae861d351a85174fd4fddb29d249950b2f23671318971960452b4b9ab"
+checksum = "0d108b6fe8eeb317ecad1d74619e8758de49cccc8c771b56c97962fd52eaae23"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
+ "arrow-buffer",
+ "arrow-schema",
  "blake2",
  "blake3",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-row",
+ "half",
  "hashbrown",
+ "itertools",
  "lazy_static",
  "md-5",
+ "num-traits",
  "ordered-float 3.1.0",
  "paste",
  "rand",
  "regex",
  "sha2",
  "unicode-segmentation",
+ "uuid",
 ]
 
 [[package]]
 name = "datafusion-row"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f44a2a722719c569b437b3aa2108a99dc911369e8d86c44e6293225c3387147"
+checksum = "43537b6377d506e4788bf21e9ed943340e076b48ca4d077e6ea4405ca5e54a1c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -636,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98493e04385c924d1d3d7ab8739c41f1ebf676a46863181103a0fb9c7168fa9"
+checksum = "244d08d4710e1088d9c0949c9b5b8d68d9cf2cde7203134a4cc389e870fe2354"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -787,12 +851,11 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flatbuffers"
-version = "2.1.2"
+version = "22.9.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b428b715fdbdd1c364b84573b5fdc0f84f8e423661b9f398735278bc7f2b6a"
+checksum = "8ce016b9901aef3579617931fbb2df8fc9a9f7cb95a16eb8acc8148209bb9e70"
 dependencies = [
  "bitflags",
- "smallvec",
  "thiserror",
 ]
 
@@ -823,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -838,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -848,15 +911,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -865,15 +928,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -882,21 +945,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1374,12 +1437,15 @@ dependencies = [
  "async-trait",
  "chrono",
  "datafusion",
+ "datafusion-common",
  "datafusion-expr",
+ "datafusion-optimizer",
  "datafusion-physical-expr",
  "datafusion-sql",
  "futures",
  "log",
  "object_store",
+ "parking_lot",
  "proptest",
  "rusqlite",
  "snmalloc-rs",
@@ -1537,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2168fee79ee3e7695905bc3a48777d807f82d956f821186fa7a2601c1295a73e"
+checksum = "56ce10a205d9f610ae3532943039c34c145930065ce0c4284134c897fe6073b1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1610,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "24.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fd590f0672998df84503d1bcbebc69732583d03cc3495c7dd8d3e5a1d8437f"
+checksum = "3bf8fa7ab6572791325a8595f55dc532dde88b996ae10a5ca8a2db746784ecc4"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1626,7 +1692,6 @@ dependencies = [
  "lz4",
  "num",
  "num-bigint",
- "rand",
  "seq-macro",
  "snap",
  "thrift",
@@ -2135,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0781f2b6bd03e5adf065c8e772b49eaea9f640d06a1b9130330fe8bd2563f4fd"
+checksum = "86be66ea0b2b22749cfa157d16e2e84bf793e626a3375f4d378dc289fa03affb"
 dependencies = [
  "log",
 ]
@@ -2580,9 +2645,9 @@ checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "uuid"
-version = "1.1.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 dependencies = [
  "getrandom",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-arrow = "24.0.0"
-arrow-flight = "24.0.0"
+arrow = "26.0.0"
+arrow-flight = "26.0.0"
 tonic = "0.8.2"
 tokio = "1.21.2"
 rustyline = "10.0.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,12 +6,14 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-datafusion = "13.0.0"
-datafusion-expr = "13.0.0"
-datafusion-physical-expr = "13.0.0"
-datafusion-sql = "13.0.0"
-object_store = "0.5.0"
-sqlparser = "0.25.0"
+datafusion = "14.0.0"
+datafusion-common = "14.0.0"
+datafusion-optimizer = "14.0.0"
+datafusion-expr = "14.0.0"
+datafusion-physical-expr = "14.0.0"
+datafusion-sql = "14.0.0"
+object_store = "0.5.1"
+sqlparser = "0.26.0"
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same value
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }
@@ -21,12 +23,13 @@ tracing-futures = "0.2.5"
 
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "signal"] }
 
-async-trait = "0.1.57"
-futures = "0.3.24"
+async-trait = "0.1.58"
+futures = "0.3.25"
 
-arrow-flight = "24.0.0"
+arrow-flight = "26.0.0"
 tonic = "0.8.2"
 
+parking_lot = "0.12.1"
 snmalloc-rs = "0.3.3"
 
 rusqlite = { version = "0.28.0", features = ["bundled"] }

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -985,7 +985,10 @@ mod tests {
             .unwrap();
 
         // Register the table with Apache Arrow DataFusion.
-        context.metadata_manager.register_tables(&context, &runtime).unwrap();
+        context
+            .metadata_manager
+            .register_tables(&context, &runtime)
+            .unwrap();
     }
 
     #[test]
@@ -1125,10 +1128,9 @@ mod tests {
 pub mod test_util {
     use super::*;
 
-    use std::sync::RwLock;
-
     use datafusion::execution::context::{SessionConfig, SessionContext, SessionState};
     use datafusion::execution::runtime_env::RuntimeEnv;
+    use parking_lot::RwLock;
     use tempfile;
 
     use crate::models::ErrorBound;

--- a/server/src/optimizer/mod.rs
+++ b/server/src/optimizer/mod.rs
@@ -20,13 +20,13 @@ use async_trait::async_trait;
 
 use datafusion::error::Result;
 use datafusion::execution::context::{QueryPlanner, SessionState};
-use datafusion::logical_plan::LogicalPlan;
 use datafusion::optimizer::optimizer::OptimizerRule;
 use datafusion::optimizer::OptimizerConfig;
 use datafusion::physical_optimizer::optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::planner::DefaultPhysicalPlanner;
 use datafusion::physical_plan::{ExecutionPlan, PhysicalPlanner};
 use datafusion::prelude::SessionConfig;
+use datafusion_expr::logical_plan::LogicalPlan;
 use tracing::debug;
 
 pub struct LogOptimizerRule {}

--- a/server/src/optimizer/model_simple_aggregates.rs
+++ b/server/src/optimizer/model_simple_aggregates.rs
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 use std::any::Any;
+use std::cmp::PartialEq;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
@@ -229,6 +230,12 @@ impl Display for ModelCountPhysicalExpr {
     }
 }
 
+impl PartialEq<dyn Any> for ModelCountPhysicalExpr {
+    fn eq(&self, other: &dyn Any) -> bool {
+        self == other
+    }
+}
+
 impl PhysicalExpr for ModelCountPhysicalExpr {
     fn as_any(&self) -> &dyn Any {
         self
@@ -268,6 +275,17 @@ impl PhysicalExpr for ModelCountPhysicalExpr {
         let mut result = Int64Array::builder(1);
         result.append_value(count);
         Ok(ColumnarValue::Array(Arc::new(result.finish())))
+    }
+
+    fn children(&self) -> Vec<Arc<dyn PhysicalExpr>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        Ok(self)
     }
 }
 
@@ -313,6 +331,12 @@ impl Display for ModelMinPhysicalExpr {
     }
 }
 
+impl PartialEq<dyn Any> for ModelMinPhysicalExpr {
+    fn eq(&self, other: &dyn Any) -> bool {
+        self == other
+    }
+}
+
 impl PhysicalExpr for ModelMinPhysicalExpr {
     fn as_any(&self) -> &dyn Any {
         self
@@ -337,6 +361,17 @@ impl PhysicalExpr for ModelMinPhysicalExpr {
         let mut result = ValueArray::builder(1);
         result.append_value(min);
         Ok(ColumnarValue::Array(Arc::new(result.finish())))
+    }
+
+    fn children(&self) -> Vec<Arc<dyn PhysicalExpr>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        Ok(self)
     }
 }
 
@@ -385,6 +420,12 @@ impl Display for ModelMaxPhysicalExpr {
     }
 }
 
+impl PartialEq<dyn Any> for ModelMaxPhysicalExpr {
+    fn eq(&self, other: &dyn Any) -> bool {
+        self == other
+    }
+}
+
 impl PhysicalExpr for ModelMaxPhysicalExpr {
     fn as_any(&self) -> &dyn Any {
         self
@@ -409,6 +450,17 @@ impl PhysicalExpr for ModelMaxPhysicalExpr {
         let mut result = ValueArray::builder(1);
         result.append_value(max);
         Ok(ColumnarValue::Array(Arc::new(result.finish())))
+    }
+
+    fn children(&self) -> Vec<Arc<dyn PhysicalExpr>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        Ok(self)
     }
 }
 
@@ -454,6 +506,12 @@ pub struct ModelSumPhysicalExpr {}
 impl Display for ModelSumPhysicalExpr {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "ModelSumPhysicalExpr(Float32)")
+    }
+}
+
+impl PartialEq<dyn Any> for ModelSumPhysicalExpr {
+    fn eq(&self, other: &dyn Any) -> bool {
+        self == other
     }
 }
 
@@ -509,6 +567,17 @@ impl PhysicalExpr for ModelSumPhysicalExpr {
         result.append_value(sum as f32);
         Ok(ColumnarValue::Array(Arc::new(result.finish())))
     }
+
+    fn children(&self) -> Vec<Arc<dyn PhysicalExpr>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        Ok(self)
+    }
 }
 
 #[derive(Debug)]
@@ -553,6 +622,12 @@ pub struct ModelAvgPhysicalExpr {}
 impl Display for ModelAvgPhysicalExpr {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "ModelAvgPhysicalExpr(Float32)")
+    }
+}
+
+impl PartialEq<dyn Any> for ModelAvgPhysicalExpr {
+    fn eq(&self, other: &dyn Any) -> bool {
+        self == other
     }
 }
 
@@ -611,6 +686,17 @@ impl PhysicalExpr for ModelAvgPhysicalExpr {
         result.append_value(sum as Value);
         result.append_value(count as Value);
         Ok(ColumnarValue::Array(Arc::new(result.finish())))
+    }
+
+    fn children(&self) -> Vec<Arc<dyn PhysicalExpr>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        Ok(self)
     }
 }
 

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -208,8 +208,7 @@ impl FlightServiceHandler {
             )
             .map_err(|error| Status::invalid_argument(error.to_string()))?;
 
-            // unwrap() is safe to use since write() only fails if the RwLock is poisoned.
-            let mut storage_engine = self.context.storage_engine.write().unwrap();
+            let mut storage_engine = self.context.storage_engine.write();
 
             // Note that the storage engine returns when the data is stored in memory, which means
             // the data could be lost if the system crashes right after ingesting the data.

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -232,11 +232,11 @@ impl TableProvider for ModelTable {
         // Request the matching files from the storage engine.
         let mut key_object_metas = {
             // TODO: make the storage engine support multiple parallel readers.
-            let mut storage_engines = self.context.storage_engine.write();
+            let mut storage_engine = self.context.storage_engine.write();
 
             // unwrap() is safe to use as get_compressed_files() only fails if a
             // non-existing hash is passed or if end time is before start time.
-            storage_engines
+            storage_engine
                 .get_compressed_files(&keys, None, None)
                 .unwrap()
         };

--- a/server/src/tables.rs
+++ b/server/src/tables.rs
@@ -232,8 +232,7 @@ impl TableProvider for ModelTable {
         // Request the matching files from the storage engine.
         let mut key_object_metas = {
             // TODO: make the storage engine support multiple parallel readers.
-            // unwrap() is safe as read() only fails if the RwLock is poisoned.
-            let mut storage_engines = self.context.storage_engine.write().unwrap();
+            let mut storage_engines = self.context.storage_engine.write();
 
             // unwrap() is safe to use as get_compressed_files() only fails if a
             // non-existing hash is passed or if end time is before start time.


### PR DESCRIPTION
This PR primarily updates Apache Arrow DataFusion to [v14.0.0](https://crates.io/crates/datafusion/14.0.0) and fixes all known breaking changes. New versions of Apache Arrow DataFusion usually have breaking changes, so updating to each new release ensures that the number of changes required does not accumulate. The files have purposely only been changed to the degree necessary to fix the breaking changes. The breaking changes this time are mainly caused by ongoing process of splitting Apache Arrow DataFusion into sub-crates, additional methods being added to the [`PhysicalExpr`](https://docs.rs/datafusion-physical-expr/14.0.0/datafusion_physical_expr/trait.PhysicalExpr.html) trait, and [`combine_filters()`](https://docs.rs/datafusion/13.0.0/datafusion/logical_plan/fn.combine_filters.html) seemingly being replaced with [`conjunction`](https://docs.rs/datafusion-optimizer/14.0.0/datafusion_optimizer/utils/fn.conjunction.html).