### PR TITLE
Support querying local and remote folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
+ "serde",
  "time",
  "wasm-bindgen",
  "winapi",
@@ -773,6 +774,15 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endian-type"
@@ -1127,6 +1137,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1214,12 @@ name = "io-lifetimes"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
+name = "ipnet"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "itertools"
@@ -1608,12 +1637,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce10a205d9f610ae3532943039c34c145930065ce0c4284134c897fe6073b1"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "futures",
  "itertools",
  "parking_lot",
  "percent-encoding",
+ "quick-xml",
+ "rand",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
  "snafu",
  "tokio",
  "tracing",
@@ -1876,6 +1912,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e21a144a0ffb5fad7b464babcdab934a325ad69b7c0373bcfef5cbd9799ca9"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +2032,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +2112,27 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -2076,6 +2198,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "seq-macro"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2218,20 @@ name = "serde"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -2093,6 +2239,18 @@ version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
+ "itoa 1.0.3",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa 1.0.3",
  "ryu",
  "serde",
@@ -2197,6 +2355,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqlparser"
@@ -2389,6 +2553,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -2627,6 +2802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,6 +2919,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,6 +2958,35 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
 name = "which"
@@ -2850,6 +3072,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,12 +438,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1001,7 +998,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1442,7 +1439,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -1464,7 +1461,6 @@ version = "0.1.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
- "chrono",
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
@@ -2480,17 +2476,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,12 +2865,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -34,8 +34,6 @@ snmalloc-rs = "0.3.3"
 
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 
-chrono = "0.4.22"
-
 [dev-dependencies]
 proptest = "1.0.0"
 tempfile = "3.3.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,7 +12,7 @@ datafusion-optimizer = "14.0.0"
 datafusion-expr = "14.0.0"
 datafusion-physical-expr = "14.0.0"
 datafusion-sql = "14.0.0"
-object_store = "0.5.1"
+object_store = { version = "0.5.1", features = ["aws"] }
 sqlparser = "0.26.0"
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same value

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -275,7 +275,7 @@ mod tests {
         let DataFolders {
             local_data_folder,
             remote_data_folder,
-            query_data_folder,
+            query_data_folder: _query_data_folder,
         } = parse_command_line_arguments(input).unwrap();
 
         // Equals cannot be applied to type dyn object_store::ObjectStore.
@@ -298,7 +298,7 @@ mod tests {
         let DataFolders {
             local_data_folder,
             remote_data_folder,
-            query_data_folder,
+            query_data_folder: _query_data_folder,
         } = parse_command_line_arguments(input).unwrap();
 
         // Equals cannot be applied to type dyn object_store::ObjectStore.
@@ -316,7 +316,7 @@ mod tests {
         let DataFolders {
             local_data_folder,
             remote_data_folder,
-            query_data_folder,
+            query_data_folder: _query_data_folder,
         } = parse_command_line_arguments(input).unwrap();
 
         // Equals cannot be applied to type dyn object_store::ObjectStore.
@@ -334,7 +334,7 @@ mod tests {
         let DataFolders {
             local_data_folder,
             remote_data_folder,
-            query_data_folder,
+            query_data_folder: _query_data_folder,
         } = parse_command_line_arguments(input).unwrap();
 
         // Equals cannot be applied to type dyn object_store::ObjectStore.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -34,9 +34,9 @@ use std::sync::Arc;
 
 use datafusion::execution::context::{SessionConfig, SessionContext, SessionState};
 use datafusion::execution::runtime_env::RuntimeEnv;
-use object_store::{aws::AmazonS3Builder, local::LocalFileSystem, ObjectStore};
-use parking_lot::RwLock;
+use object_store::{aws::AmazonS3Builder, local::LocalFileSystem, path::Path, ObjectStore};
 use tokio::runtime::Runtime;
+use tokio::sync::RwLock;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::metadata::MetadataManager;
@@ -45,6 +45,19 @@ use crate::storage::StorageEngine;
 
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+
+/// Folders for storing metadata and Apache Parquet files.
+pub struct DataFolders {
+    /// Folder for storing metadata and Apache Parquet files on the local file
+    /// system.
+    pub local_data_folder: PathBuf, // PathBuf to support complex operations.
+    /// Folder for storing Apache Parquet files in a remote object store.
+    pub remote_data_folder: Option<Arc<dyn ObjectStore>>,
+    /// Folder from which Apache Parquet files will be read during query
+    /// execution. It is equivalent to `local_data_folder` when deployed on the
+    /// edge and `remote_data_folder` when deployed in the cloud.
+    pub query_data_folder: Arc<dyn ObjectStore>,
+}
 
 /// Provides access to the system's configuration and components.
 pub struct Context {
@@ -56,52 +69,65 @@ pub struct Context {
     pub storage_engine: RwLock<StorageEngine>,
 }
 
-/// Setup tracing, construct a `Context`, initialize tables and model tables in
-/// the path given by the first command line argument, initialize a CTRL+C
-/// handler that flushes the data in memory to disk, and start the Apache Arrow
-/// Flight interface. Returns [`Error`] formatted as a [`String`] if metadata
-/// cannot be read or the Apache Arrow Flight interface cannot be started.
+/// Setup tracing that prints to stdout, parse the command line arguments to a
+/// [`DataFolders`], construct a [`Context`] with the systems components,
+/// initialize the tables and model tables in the metadata database, initialize
+/// a CTRL+C handler that flushes the data in memory to disk, and start the
+/// Apache Arrow Flight interface. Returns [`Error`] formatted as a [`String`]
+/// if the command line arguments cannot be parsed, the metadata cannot be read
+/// from the database or the Apache Arrow Flight interface cannot be started.
 fn main() -> Result<(), String> {
-    // A layer that logs events to stdout.
+    // Initialize a tracing layer that logs events to stdout.
     let stdout_log = tracing_subscriber::fmt::layer();
     tracing_subscriber::registry().with(stdout_log).init();
 
     let mut args = std::env::args();
-    args.next(); // Skip executable.
+    args.next(); // Skip the executable.
 
     // Collect at most the maximum number of command line arguments plus one.
     // The plus one argument is collected to trigger the default pattern in
     // parse_command_line_arguments() if too many arguments are passed without
     // collecting more command line arguments than required for that pattern.
-    let arguments_required: Vec<String> = args.by_ref().take(4).collect();
-    let arguments_required: Vec<&str> = arguments_required.iter().map(|arg| arg.as_str()).collect();
-    let (local_data_folder, maybe_blob_store_data_folder, query_data_folder) =
-        parse_command_line_arguments(&arguments_required)?;
-
-    // Ensure the local data folder exists before making it a LocalFileSystem.
-    let data_folder_path = PathBuf::from(local_data_folder);
-    fs::create_dir_all(data_folder_path.as_path())
-        .map_err(|error| format!("Unable to create {}: {}", local_data_folder, error))?;
-    let local_data_folder = command_line_argument_to_local_folder(local_data_folder);
+    let arguments: Vec<String> = args.by_ref().take(4).collect();
+    let arguments: Vec<&str> = arguments.iter().map(|arg| arg.as_str()).collect();
+    let data_folders = parse_command_line_arguments(&arguments)?;
 
     // Create a Tokio runtime for executing asynchronous tasks. The runtime is
-    // not part of the context to make it easier to pass the runtime to the
-    // components in the context.
+    // not in the context so it can be passed to the components in the context.
     let runtime = Arc::new(
         Runtime::new().map_err(|error| format!("Unable to create a Tokio Runtime: {}", error))?,
     );
 
-    // Create Context components.
-    let metadata_manager = MetadataManager::try_new(&data_folder_path)
+    // Ensure the local data folder can be accessed.
+    fs::create_dir_all(&data_folders.local_data_folder).map_err(|error| {
+        format!(
+            "Unable to create {}: {}",
+            data_folders.local_data_folder.to_string_lossy(),
+            error
+        )
+    })?;
+
+    // Ensure the remote data folder can be accessed.
+    if let Some(remote_data_folder) = data_folders.remote_data_folder {
+        runtime.block_on(async {
+            remote_data_folder
+                .get(&Path::from(""))
+                .await
+                .map_err(|error| error.to_string())
+        })?;
+    }
+
+    // Create the components for the Context.
+    let metadata_manager = MetadataManager::try_new(&data_folders.local_data_folder)
         .map_err(|error| format!("Unable to create a MetadataManager: {}", error))?;
-    let session = create_session_context();
+    let session = create_session_context(data_folders.query_data_folder);
     let storage_engine = RwLock::new(StorageEngine::new(
-        data_folder_path.clone(),
+        data_folders.local_data_folder,
         metadata_manager.clone(),
         true,
     ));
 
-    // Create Context.
+    // Create the Context.
     let context = Arc::new(Context {
         metadata_manager,
         session,
@@ -122,85 +148,92 @@ fn main() -> Result<(), String> {
     // Setup CTRL+C handler.
     setup_ctrl_c_handler(&context, &runtime);
 
-    // Start Interface.
+    // Start the Apache Arrow Flight interface.
     remote::start_arrow_flight_server(context, &runtime, 9999)
         .map_err(|error| error.to_string())?;
 
     Ok(())
 }
 
-/// Parse the command lines arguments into a triple containing the data folder
-/// to use on the local file system, the data folder to use on blob store if it
-/// was specified, and the data folder to use when executing queries. If the
-/// necessary command line arguments are not provided, too many arguments are
-/// provided, or if the provided arguments are malformed, [`None`] is returned.
-fn parse_command_line_arguments<'a>(
-    arguments: &'a [&'a str],
-) -> Result<(&'a str, Option<Box<dyn ObjectStore>>, Box<dyn ObjectStore>), String> {
+/// Parse the command lines arguments into an instance of [`DataFolders`]. If
+/// the necessary command line arguments are not provided, too many arguments
+/// are provided, or if the arguments are malformed, [`Error`] is returned.
+fn parse_command_line_arguments(arguments: &[&str]) -> Result<DataFolders, String> {
     // Match the provided command line arguments to the supported inputs.
     match arguments {
-        &["cloud", local_data_folder, blob_store_data_folder] => Ok((
-            local_data_folder,
-            Some(command_line_argument_to_blob_store(blob_store_data_folder)?),
-            command_line_argument_to_blob_store(blob_store_data_folder)?,
-        )),
-        &["edge", local_data_folder, blob_store_data_folder] => Ok((
-            local_data_folder,
-            Some(command_line_argument_to_blob_store(blob_store_data_folder)?),
-            command_line_argument_to_local_folder(local_data_folder)?,
-        )),
-        &["edge", local_data_folder] => Ok((
-            local_data_folder,
-            None,
-            command_line_argument_to_local_folder(local_data_folder)?,
-        )),
-        &[local_data_folder] => Ok((
-            local_data_folder,
-            None,
-            command_line_argument_to_local_folder(local_data_folder)?,
-        )),
+        &["cloud", local_data_folder, remote_data_folder] => Ok(DataFolders {
+            local_data_folder: PathBuf::from(local_data_folder),
+            remote_data_folder: Some(argument_to_remote_object_store(remote_data_folder)?),
+            query_data_folder: argument_to_remote_object_store(remote_data_folder)?,
+        }),
+        &["edge", local_data_folder, remote_data_folder] => Ok(DataFolders {
+            local_data_folder: PathBuf::from(local_data_folder),
+            remote_data_folder: Some(argument_to_remote_object_store(remote_data_folder)?),
+            query_data_folder: argument_to_local_object_store(local_data_folder)?,
+        }),
+        &["edge", local_data_folder] => Ok(DataFolders {
+            local_data_folder: PathBuf::from(local_data_folder),
+            remote_data_folder: None,
+            query_data_folder: argument_to_local_object_store(local_data_folder)?,
+        }),
+        &[local_data_folder] => Ok(DataFolders {
+            local_data_folder: PathBuf::from(local_data_folder),
+            remote_data_folder: None,
+            query_data_folder: argument_to_local_object_store(local_data_folder)?,
+        }),
         _ => {
             // The errors are consciously ignored as the program is terminating.
             let binary_path = std::env::current_exe().unwrap();
             let binary_name = binary_path.file_name().unwrap().to_str().unwrap();
             Err(format!(
-                "Usage: {} [mode] local_data_folder [blob_store_data_folder].",
+                "Usage: {} [mode] local_data_folder [remote_data_folder].",
                 binary_name
             ))
         }
     }
 }
 
-fn command_line_argument_to_local_folder(argument: &str) -> Result<Box<dyn ObjectStore>, String> {
+/// Create an [`ObjectStore`] that represents the local path in `argument`.
+fn argument_to_local_object_store(argument: &str) -> Result<Arc<dyn ObjectStore>, String> {
     let object_store =
         LocalFileSystem::new_with_prefix(argument).map_err(|error| error.to_string())?;
-    Ok(Box::new(object_store))
+    Ok(Arc::new(object_store))
 }
 
-fn command_line_argument_to_blob_store(argument: &str) -> Result<Box<dyn ObjectStore>, String> {
+/// Create an [`ObjectStore`] that represents the remote path in `argument`.
+fn argument_to_remote_object_store(argument: &str) -> Result<Arc<dyn ObjectStore>, String> {
     if let Some(bucket_name) = argument.strip_prefix("s3://") {
         let object_store = AmazonS3Builder::from_env()
             .with_bucket_name(bucket_name)
             .build()
             .map_err(|error| error.to_string())?;
-        Ok(Box::new(object_store))
+        Ok(Arc::new(object_store))
     } else {
-        Err("Blob store must be s3://.".to_owned())
+        Err("Remote data folder must be s3://bucket-name.".to_owned())
     }
 }
 
-/// Create a new `SessionContext` for interacting with Apache Arrow
-/// DataFusion. The `SessionContext` is constructed with the default
-/// configuration, default resource managers, the local file system as the
-/// only object store, and additional optimizer rules that rewrite simple
-/// aggregate queries to be executed directly on the models instead of on
-/// reconstructed data points for model tables.
-fn create_session_context() -> SessionContext {
+/// Create a new [`SessionContext`] for interacting with Apache Arrow
+/// DataFusion. The [`SessionContext`] is constructed with the default
+/// configuration, default resource managers, the local file system and if
+/// provided the remote object store as [`ObjectStores`](ObjectStore), and
+/// additional optimizer rules that rewrite simple aggregate queries to be
+/// executed directly on the segments containing metadata and models instead of
+/// on reconstructed data points created from the segments for model tables.
+fn create_session_context(query_data_folder: Arc<dyn ObjectStore>) -> SessionContext {
     let config = SessionConfig::new();
+
     let runtime = Arc::new(RuntimeEnv::default());
+    runtime.register_object_store(
+        storage::QUERY_DATA_FOLDER_SCHEME_AND_HOST,
+        storage::QUERY_DATA_FOLDER_SCHEME_AND_HOST,
+        query_data_folder,
+    );
+
     let state = SessionState::with_config_rt(config, runtime).with_physical_optimizer_rules(vec![
         Arc::new(model_simple_aggregates::ModelSimpleAggregatesPhysicalOptimizerRule {}),
     ]);
+
     SessionContext::with_state(state)
 }
 
@@ -213,7 +246,7 @@ fn setup_ctrl_c_handler(context: &Arc<Context>, runtime: &Arc<Runtime>) {
         // Errors are consciously ignored as the program should terminate if the
         // handler cannot be registered as buffers otherwise cannot be flushed.
         tokio::signal::ctrl_c().await.unwrap();
-        ctrl_c_context.storage_engine.write().flush();
+        ctrl_c_context.storage_engine.write().await.flush();
         std::process::exit(0)
     });
 }
@@ -239,12 +272,15 @@ mod tests {
         let tempdir_str = tempdir.path().to_str().unwrap();
         let input = &["cloud", tempdir_str, "s3://bucket"];
 
-        let (local_data_folder, blob_store_data_folder, _query_data_folder) =
-            parse_command_line_arguments(input).unwrap();
+        let DataFolders {
+            local_data_folder,
+            remote_data_folder,
+            query_data_folder,
+        } = parse_command_line_arguments(input).unwrap();
 
         // Equals cannot be applied to type dyn object_store::ObjectStore.
-        assert_eq!(local_data_folder, tempdir_str);
-        blob_store_data_folder.unwrap();
+        assert_eq!(local_data_folder, PathBuf::from(tempdir_str));
+        remote_data_folder.unwrap();
     }
 
     #[test]
@@ -259,12 +295,15 @@ mod tests {
         let tempdir_str = tempdir.path().to_str().unwrap();
         let input = &["edge", tempdir_str, "s3://bucket"];
 
-        let (local_data_folder, blob_store_data_folder, _query_data_folder) =
-            parse_command_line_arguments(input).unwrap();
+        let DataFolders {
+            local_data_folder,
+            remote_data_folder,
+            query_data_folder,
+        } = parse_command_line_arguments(input).unwrap();
 
         // Equals cannot be applied to type dyn object_store::ObjectStore.
-        assert_eq!(local_data_folder, tempdir_str);
-        blob_store_data_folder.unwrap();
+        assert_eq!(local_data_folder, PathBuf::from(tempdir_str));
+        remote_data_folder.unwrap();
     }
 
     #[test]
@@ -274,12 +313,15 @@ mod tests {
         let tempdir_str = tempdir.path().to_str().unwrap();
         let input = &["edge", tempdir_str];
 
-        let (local_data_folder, blob_store_data_folder, _query_data_folder) =
-            parse_command_line_arguments(input).unwrap();
+        let DataFolders {
+            local_data_folder,
+            remote_data_folder,
+            query_data_folder,
+        } = parse_command_line_arguments(input).unwrap();
 
         // Equals cannot be applied to type dyn object_store::ObjectStore.
-        assert_eq!(local_data_folder, tempdir_str);
-        assert!(blob_store_data_folder.is_none());
+        assert_eq!(local_data_folder, PathBuf::from(tempdir_str));
+        assert!(remote_data_folder.is_none());
     }
 
     #[test]
@@ -289,12 +331,15 @@ mod tests {
         let tempdir_str = tempdir.path().to_str().unwrap();
         let input = &[tempdir_str];
 
-        let (local_data_folder, blob_store_data_folder, _query_data_folder) =
-            parse_command_line_arguments(input).unwrap();
+        let DataFolders {
+            local_data_folder,
+            remote_data_folder,
+            query_data_folder,
+        } = parse_command_line_arguments(input).unwrap();
 
         // Equals cannot be applied to type dyn object_store::ObjectStore.
-        assert_eq!(local_data_folder, tempdir_str);
-        assert!(blob_store_data_folder.is_none());
+        assert_eq!(local_data_folder, PathBuf::from(tempdir_str));
+        assert!(remote_data_folder.is_none());
     }
 
     #[test]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 
 use datafusion::execution::context::{SessionConfig, SessionContext, SessionState};
 use datafusion::execution::runtime_env::RuntimeEnv;
+use object_store::{aws::AmazonS3Builder, local::LocalFileSystem, ObjectStore};
 use parking_lot::RwLock;
 use tokio::runtime::Runtime;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -68,60 +69,124 @@ fn main() -> Result<(), String> {
     let mut args = std::env::args();
     args.next(); // Skip executable.
 
-    if let Some(data_folder) = args.next() {
-        // Ensure the data folder exists.
-        let data_folder_path = PathBuf::from(&data_folder);
-        fs::create_dir_all(data_folder_path.as_path())
-            .map_err(|error| format!("Unable to create {}: {}", &data_folder, error))?;
+    // Collect at most the maximum number of command line arguments plus one.
+    // The plus one argument is collected to trigger the default pattern in
+    // parse_command_line_arguments() if too many arguments are passed without
+    // collecting more command line arguments than required for that pattern.
+    let arguments_required: Vec<String> = args.by_ref().take(4).collect();
+    let arguments_required: Vec<&str> = arguments_required.iter().map(|arg| arg.as_str()).collect();
+    let (local_data_folder, maybe_blob_store_data_folder, query_data_folder) =
+        parse_command_line_arguments(&arguments_required)?;
 
-        // Create a Tokio runtime for executing asynchronous tasks. The runtime is not part of the
-        // context to make it easier to pass the runtime to components in the context.
-        let runtime = Arc::new(
-            Runtime::new()
-                .map_err(|error| format!("Unable to create a Tokio Runtime: {}", error))?,
-        );
+    // Ensure the local data folder exists before making it a LocalFileSystem.
+    let data_folder_path = PathBuf::from(local_data_folder);
+    fs::create_dir_all(data_folder_path.as_path())
+        .map_err(|error| format!("Unable to create {}: {}", local_data_folder, error))?;
+    let local_data_folder = command_line_argument_to_local_folder(local_data_folder);
 
-        // Create Context components.
-        let metadata_manager = MetadataManager::try_new(&data_folder_path)
-            .map_err(|error| format!("Unable to create a MetadataManager: {}", error))?;
-        let session = create_session_context();
-        let storage_engine = RwLock::new(StorageEngine::new(
-            data_folder_path.clone(),
-            metadata_manager.clone(),
-            true,
-        ));
+    // Create a Tokio runtime for executing asynchronous tasks. The runtime is
+    // not part of the context to make it easier to pass the runtime to the
+    // components in the context.
+    let runtime = Arc::new(
+        Runtime::new().map_err(|error| format!("Unable to create a Tokio Runtime: {}", error))?,
+    );
 
-        // Create Context.
-        let context = Arc::new(Context {
-            metadata_manager,
-            session,
-            storage_engine,
-        });
+    // Create Context components.
+    let metadata_manager = MetadataManager::try_new(&data_folder_path)
+        .map_err(|error| format!("Unable to create a MetadataManager: {}", error))?;
+    let session = create_session_context();
+    let storage_engine = RwLock::new(StorageEngine::new(
+        data_folder_path.clone(),
+        metadata_manager.clone(),
+        true,
+    ));
 
-        // Register tables and model tables.
-        context
-            .metadata_manager
-            .register_tables(&context, &runtime)
-            .map_err(|error| format!("Unable to register tables: {}", error))?;
+    // Create Context.
+    let context = Arc::new(Context {
+        metadata_manager,
+        session,
+        storage_engine,
+    });
 
-        context
-            .metadata_manager
-            .register_model_tables(&context)
-            .map_err(|error| format!("Unable to register model tables: {}", error))?;
+    // Register tables and model tables.
+    context
+        .metadata_manager
+        .register_tables(&context, &runtime)
+        .map_err(|error| format!("Unable to register tables: {}", error))?;
 
-        // Setup CTRL+C handler.
-        setup_ctrl_c_handler(&context, &runtime);
+    context
+        .metadata_manager
+        .register_model_tables(&context)
+        .map_err(|error| format!("Unable to register model tables: {}", error))?;
 
-        // Start Interface.
-        remote::start_arrow_flight_server(context, &runtime, 9999)
-            .map_err(|error| error.to_string())?
-    } else {
-        // The errors are consciously ignored as the program is terminating.
-        let binary_path = std::env::current_exe().unwrap();
-        let binary_name = binary_path.file_name().unwrap().to_str().unwrap();
-        eprintln!("Usage: {} path_to_data_folder.", binary_name);
-    }
+    // Setup CTRL+C handler.
+    setup_ctrl_c_handler(&context, &runtime);
+
+    // Start Interface.
+    remote::start_arrow_flight_server(context, &runtime, 9999)
+        .map_err(|error| error.to_string())?;
+
     Ok(())
+}
+
+/// Parse the command lines arguments into a triple containing the data folder
+/// to use on the local file system, the data folder to use on blob store if it
+/// was specified, and the data folder to use when executing queries. If the
+/// necessary command line arguments are not provided, too many arguments are
+/// provided, or if the provided arguments are malformed, [`None`] is returned.
+fn parse_command_line_arguments<'a>(
+    arguments: &'a [&'a str],
+) -> Result<(&'a str, Option<Box<dyn ObjectStore>>, Box<dyn ObjectStore>), String> {
+    // Match the provided command line arguments to the supported inputs.
+    match arguments {
+        &["cloud", local_data_folder, blob_store_data_folder] => Ok((
+            local_data_folder,
+            Some(command_line_argument_to_blob_store(blob_store_data_folder)?),
+            command_line_argument_to_blob_store(blob_store_data_folder)?,
+        )),
+        &["edge", local_data_folder, blob_store_data_folder] => Ok((
+            local_data_folder,
+            Some(command_line_argument_to_blob_store(blob_store_data_folder)?),
+            command_line_argument_to_local_folder(local_data_folder)?,
+        )),
+        &["edge", local_data_folder] => Ok((
+            local_data_folder,
+            None,
+            command_line_argument_to_local_folder(local_data_folder)?,
+        )),
+        &[local_data_folder] => Ok((
+            local_data_folder,
+            None,
+            command_line_argument_to_local_folder(local_data_folder)?,
+        )),
+        _ => {
+            // The errors are consciously ignored as the program is terminating.
+            let binary_path = std::env::current_exe().unwrap();
+            let binary_name = binary_path.file_name().unwrap().to_str().unwrap();
+            Err(format!(
+                "Usage: {} [mode] local_data_folder [blob_store_data_folder].",
+                binary_name
+            ))
+        }
+    }
+}
+
+fn command_line_argument_to_local_folder(argument: &str) -> Result<Box<dyn ObjectStore>, String> {
+    let object_store =
+        LocalFileSystem::new_with_prefix(argument).map_err(|error| error.to_string())?;
+    Ok(Box::new(object_store))
+}
+
+fn command_line_argument_to_blob_store(argument: &str) -> Result<Box<dyn ObjectStore>, String> {
+    if let Some(bucket_name) = argument.strip_prefix("s3://") {
+        let object_store = AmazonS3Builder::from_env()
+            .with_bucket_name(bucket_name)
+            .build()
+            .map_err(|error| error.to_string())?;
+        Ok(Box::new(object_store))
+    } else {
+        Err("Blob store must be s3://.".to_owned())
+    }
 }
 
 /// Create a new `SessionContext` for interacting with Apache Arrow
@@ -151,4 +216,97 @@ fn setup_ctrl_c_handler(context: &Arc<Context>, runtime: &Arc<Runtime>) {
         ctrl_c_context.storage_engine.write().flush();
         std::process::exit(0)
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::env;
+
+    use tempfile;
+
+    // Tests for parse_command_line_arguments().
+    #[test]
+    fn test_parse_empty_command_line_arguments() {
+        assert!(parse_command_line_arguments(&[]).is_err());
+    }
+
+    #[test]
+    fn test_parse_cloud_command_line_arguments() {
+        setup_environment();
+        let tempdir = tempfile::tempdir().unwrap();
+        let tempdir_str = tempdir.path().to_str().unwrap();
+        let input = &["cloud", tempdir_str, "s3://bucket"];
+
+        let (local_data_folder, blob_store_data_folder, _query_data_folder) =
+            parse_command_line_arguments(input).unwrap();
+
+        // Equals cannot be applied to type dyn object_store::ObjectStore.
+        assert_eq!(local_data_folder, tempdir_str);
+        blob_store_data_folder.unwrap();
+    }
+
+    #[test]
+    fn test_parse_incomplete_cloud_command_line_arguments() {
+        assert!(parse_command_line_arguments(&["cloud", "s3://bucket"]).is_err())
+    }
+
+    #[test]
+    fn test_parse_edge_full_command_line_arguments() {
+        setup_environment();
+        let tempdir = tempfile::tempdir().unwrap();
+        let tempdir_str = tempdir.path().to_str().unwrap();
+        let input = &["edge", tempdir_str, "s3://bucket"];
+
+        let (local_data_folder, blob_store_data_folder, _query_data_folder) =
+            parse_command_line_arguments(input).unwrap();
+
+        // Equals cannot be applied to type dyn object_store::ObjectStore.
+        assert_eq!(local_data_folder, tempdir_str);
+        blob_store_data_folder.unwrap();
+    }
+
+    #[test]
+    fn test_parse_edge_command_line_arguments_without_blob_store() {
+        setup_environment();
+        let tempdir = tempfile::tempdir().unwrap();
+        let tempdir_str = tempdir.path().to_str().unwrap();
+        let input = &["edge", tempdir_str];
+
+        let (local_data_folder, blob_store_data_folder, _query_data_folder) =
+            parse_command_line_arguments(input).unwrap();
+
+        // Equals cannot be applied to type dyn object_store::ObjectStore.
+        assert_eq!(local_data_folder, tempdir_str);
+        assert!(blob_store_data_folder.is_none());
+    }
+
+    #[test]
+    fn test_parse_edge_command_line_arguments_without_mode_and_blob_store() {
+        setup_environment();
+        let tempdir = tempfile::tempdir().unwrap();
+        let tempdir_str = tempdir.path().to_str().unwrap();
+        let input = &[tempdir_str];
+
+        let (local_data_folder, blob_store_data_folder, _query_data_folder) =
+            parse_command_line_arguments(input).unwrap();
+
+        // Equals cannot be applied to type dyn object_store::ObjectStore.
+        assert_eq!(local_data_folder, tempdir_str);
+        assert!(blob_store_data_folder.is_none());
+    }
+
+    #[test]
+    fn test_parse_incomplete_edge_command_line_arguments() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let tempdir_str = tempdir.path().to_str().unwrap();
+        let input = &[tempdir_str, "s3://bucket"];
+
+        assert!(parse_command_line_arguments(input).is_err())
+    }
+
+    fn setup_environment() {
+        env::set_var("AWS_DEFAULT_REGION", "");
+    }
 }

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -1130,8 +1130,8 @@ pub mod test_util {
 
     use datafusion::execution::context::{SessionConfig, SessionContext, SessionState};
     use datafusion::execution::runtime_env::RuntimeEnv;
-    use parking_lot::RwLock;
     use tempfile;
+    use tokio::sync::RwLock;
 
     use crate::models::ErrorBound;
     use crate::storage::StorageEngine;

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -208,7 +208,7 @@ impl FlightServiceHandler {
             )
             .map_err(|error| Status::invalid_argument(error.to_string()))?;
 
-            let mut storage_engine = self.context.storage_engine.write();
+            let mut storage_engine = self.context.storage_engine.write().await;
 
             // Note that the storage engine returns when the data is stored in memory, which means
             // the data could be lost if the system crashes right after ingesting the data.

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -16,10 +16,13 @@
 //! Support for managing all compressed data that is inserted into the [`StorageEngine`].
 
 use std::collections::{HashMap, VecDeque};
-use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use datafusion::arrow::record_batch::RecordBatch;
+use futures::StreamExt;
+use object_store::path::Path as ObjectStorePath;
+use object_store::{ObjectMeta, ObjectStore};
 use tracing::info;
 use tracing::{debug, debug_span};
 
@@ -98,10 +101,11 @@ impl CompressedDataManager {
     /// Return the file path to each on-disk compressed file that corresponds to `key`. If some
     /// compressed data that corresponds to `key` is still in memory, save the data to disk first.
     /// If `key` does not correspond to any data, [`DataRetrievalError`](ModelarDbError::DataRetrievalError) is returned.
-    pub(super) fn save_and_get_saved_compressed_files(
+    pub(super) async fn save_and_get_saved_compressed_files(
         &mut self,
         key: &u64,
-    ) -> Result<Vec<PathBuf>, ModelarDbError> {
+        query_data_folder: &Arc<dyn ObjectStore>,
+    ) -> Result<Vec<(String, ObjectMeta)>, ModelarDbError> {
         // If there is any compressed data in memory, save it first.
         if self.compressed_data.contains_key(key) {
             // Remove the data from the queue of compressed time series that are ready to be saved.
@@ -112,30 +116,38 @@ impl CompressedDataManager {
             self.save_compressed_data(key);
         }
 
-        // Read the directory that contains the compressed data corresponding to the key.
-        let key_path = self.data_folder_path.join(format!("{}/compressed", key));
-        let dir = fs::read_dir(key_path).map_err(|error| {
-            ModelarDbError::DataRetrievalError(format!(
-                "Compressed data could not be found for key '{}': {}",
-                key,
-                error.to_string()
-            ))
-        })?;
+        // List all files in query_data_folder for key.
+        let key_path = ObjectStorePath::from(format!("{}/compressed/", key));
+        let key_files = query_data_folder
+            .list(Some(&key_path))
+            .await
+            .map_err(|error| {
+                ModelarDbError::DataRetrievalError(format!(
+                    "Compressed data could not be found for key '{}': {}",
+                    key,
+                    error.to_string()
+                ))
+            })?;
 
-        // Return all files in the path that are parquet files.
-        Ok(dir
-            .filter_map(|maybe_dir_entry| {
-                if let Ok(dir_entry) = maybe_dir_entry {
-                    if StorageEngine::is_path_an_apache_parquet_file(dir_entry.path().as_path()) {
-                        Some(dir_entry.path())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
+        // Return all Apache Parquet files stored for key.
+        let key_files = key_files
+            .filter_map(|maybe_meta| async {
+                if let Ok(meta) = maybe_meta {
+                    if StorageEngine::is_path_an_apache_parquet_file(
+                        &query_data_folder,
+                        &meta.location,
+                    )
+                    .await
+                    {
+                        return Some((key.to_string(), meta));
+                    };
+                };
+                None
             })
-            .collect())
+            .collect::<Vec<(String, ObjectMeta)>>()
+            .await;
+
+        Ok(key_files)
     }
 
     /// Save [`CompressedTimeSeries`] to disk until the reserved memory limit is no longer exceeded.
@@ -179,22 +191,24 @@ impl CompressedDataManager {
     }
 }
 
-/// Return [`true`] if `file_path` has a file name that is within the time range given by
-/// `start_time` and `end_time`, otherwise [`false`]. Assumes `file_path` has a file stem with
-/// the format: `start_timestamp-end_timestamp`, where both `start_timestamp` and `end_timestamp`
-/// are of the same unit as `start_time` and `end_time`.
+/// Return [`true`] if `file name` contains timestamps that overlaps with the
+/// time range given by `start_time` and `end_time`, otherwise [`false`].
+/// Assumes `file_name` has the following format:
+/// `start_timestamp-end_timestamp`, where both `start_timestamp` and
+/// `end_timestamp` are of the same unit as `start_time` and `end_time`.
 pub(super) fn is_compressed_file_within_time_range(
-    file_path: &PathBuf,
+    file_name: &str,
     start_time: Timestamp,
     end_time: Timestamp,
 ) -> bool {
-    // unwrap() is safe to use since file_path is created and provided internally.
-    let file_name = file_path.file_stem().unwrap().to_str().unwrap();
-    let split_file_name: Vec<&str> = file_name.split("-").collect();
+    let hyphen_index = file_name.find('-').unwrap();
+    let dot_index = file_name.find('.').unwrap();
 
     // unwrap() is safe to use since the file name structure is internally generated.
-    let file_start_time = split_file_name.get(0).unwrap().parse::<i64>().unwrap();
-    let file_end_time = split_file_name.get(1).unwrap().parse::<i64>().unwrap();
+    let file_start_time = file_name[0..hyphen_index].parse::<i64>().unwrap();
+    let file_end_time = file_name[hyphen_index + 1..dot_index]
+        .parse::<i64>()
+        .unwrap();
 
     let ends_after_start = file_end_time >= start_time;
     let starts_before_end = file_start_time <= end_time;
@@ -208,6 +222,7 @@ mod tests {
     use super::*;
     use std::path::Path;
 
+    use object_store::local::LocalFileSystem;
     use tempfile::{tempdir, TempDir};
 
     use crate::get_array;
@@ -320,15 +335,18 @@ mod tests {
     }
 
     // Tests for get_saved_compressed_files().
-    #[test]
-    fn test_can_get_saved_compressed_files() {
+    #[tokio::test]
+    async fn test_can_get_saved_compressed_files() {
         let segment = test_util::get_compressed_segment_record_batch();
         let (_temp_dir, mut data_manager) = create_compressed_data_manager();
 
         data_manager.insert_compressed_segment(KEY, segment.clone());
         data_manager.save_compressed_data(&KEY);
 
-        let result = data_manager.save_and_get_saved_compressed_files(&KEY);
+        let object_store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let result = data_manager
+            .save_and_get_saved_compressed_files(&KEY, &object_store)
+            .await;
         assert!(result.is_ok());
 
         let files = result.unwrap();
@@ -345,11 +363,12 @@ mod tests {
         );
 
         let expected_full_path = data_manager.data_folder_path.join(expected_file_path);
-        assert_eq!(*files.get(0).unwrap(), expected_full_path)
+        let expected_full_path = ObjectStorePath::from_filesystem_path(expected_full_path).unwrap();
+        assert_eq!(files.get(0).unwrap().1.location, expected_full_path)
     }
 
-    #[test]
-    fn test_save_in_memory_compressed_data_when_getting_saved_compressed_files() {
+    #[tokio::test]
+    async fn test_save_in_memory_compressed_data_when_getting_saved_compressed_files() {
         let segment = test_util::get_compressed_segment_record_batch_with_time(1000);
         let (_temp_dir, mut data_manager) = create_compressed_data_manager();
 
@@ -360,52 +379,61 @@ mod tests {
         let segment_2 = test_util::get_compressed_segment_record_batch_with_time(2000);
         data_manager.insert_compressed_segment(KEY, segment_2.clone());
 
-        let result = data_manager.save_and_get_saved_compressed_files(&KEY);
+        let object_store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let result = data_manager
+            .save_and_get_saved_compressed_files(&KEY, &object_store)
+            .await;
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap().len(), 2);
     }
 
-    #[test]
-    fn test_cannot_get_saved_compressed_files_from_non_existent_key() {
+    #[tokio::test]
+    async fn test_cannot_get_saved_compressed_files_from_non_existent_key() {
         let segment = test_util::get_compressed_segment_record_batch();
         let (_temp_dir, mut data_manager) = create_compressed_data_manager();
 
         data_manager.insert_compressed_segment(KEY, segment);
         data_manager.save_compressed_data(&KEY);
 
-        let result = data_manager.save_and_get_saved_compressed_files(&999);
+        let object_store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
+        let result = data_manager
+            .save_and_get_saved_compressed_files(&999, &object_store)
+            .await;
         assert!(result.is_err());
     }
 
     // Tests for is_compressed_file_within_time_range().
     #[test]
     fn test_compressed_file_ends_within_time_range() {
-        let file_path = PathBuf::from("test/1-10.parquet");
-        assert!(is_compressed_file_within_time_range(&file_path, 5, 15))
+        assert!(is_compressed_file_within_time_range("1-10.parquet", 5, 15))
     }
 
     #[test]
     fn test_compressed_file_starts_within_time_range() {
-        let file_path = PathBuf::from("test/10-20.parquet");
-        assert!(is_compressed_file_within_time_range(&file_path, 5, 15))
+        assert!(is_compressed_file_within_time_range("10-20.parquet", 5, 15))
     }
 
     #[test]
     fn test_compressed_file_is_within_time_range() {
-        let file_path = PathBuf::from("test/10-20.parquet");
-        assert!(is_compressed_file_within_time_range(&file_path, 1, 30))
+        assert!(is_compressed_file_within_time_range("10-20.parquet", 1, 30))
     }
 
     #[test]
     fn test_compressed_file_is_before_time_range() {
-        let file_path = PathBuf::from("test/1-10.parquet");
-        assert!(!is_compressed_file_within_time_range(&file_path, 20, 30))
+        assert!(!is_compressed_file_within_time_range(
+            "1-10.parquet",
+            20,
+            30
+        ))
     }
 
     #[test]
     fn test_compressed_file_is_after_time_range() {
-        let file_path = PathBuf::from("test/20-30.parquet");
-        assert!(!is_compressed_file_within_time_range(&file_path, 1, 10))
+        assert!(!is_compressed_file_within_time_range(
+            "20-30.parquet",
+            1,
+            10
+        ))
     }
 }


### PR DESCRIPTION
This PR adds support for querying tables stored in a local (local file system) or remote (object stores) data folder through the [`object_store`](https://docs.rs/object_store/latest/object_store/) crate. In addition to the unit tests, this PR has been manually tested using [Minio](https://minio.io/) and [`AmazonS3Builder`](https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html). Thus, the remote data folder is purposely limited to S3-compatible object stores as [`GoogleCloudStorageBuilder`](https://docs.rs/object_store/latest/object_store/gcp/struct.GoogleCloudStorageBuilder.html) and [`MicrosoftAzureBuilder`](https://docs.rs/object_store/latest/object_store/azure/struct.MicrosoftAzureBuilder.html) could not be tested. As part of the process of converting [`storage`](https://github.com/ModelarData/ModelarDB-RS/tree/master/server/src/storage) from synchronous to asynchronous I/O, [`parking_lot::RwLock`](https://amanieu.github.io/parking_lot/parking_lot/struct.RwLock.html) have been replaced with [`tokio::sync::RwLock`](https://docs.rs/tokio/latest/tokio/sync/struct.RwLock.html) for [`Context.storage_engine`](https://github.com/ModelarData/ModelarDB-RS/blob/master/server/src/main.rs#L55) as [`parking_lot::RwLock`](https://amanieu.github.io/parking_lot/parking_lot/struct.RwLock.html) cannot be used within an async context and [`tokio::sync::RwLock`](https://docs.rs/tokio/latest/tokio/sync/struct.RwLock.html)'s methods are async.

The PR adds two additional parameters to `modelardbd` to specify the remote data folder and if queries should be executed against the local or remote data folder. Thus `modelardbd` now accepts the following arguments `modelardbd [mode] local_data_folder [remote_data_folder]` where `mode` is either `edge` (queries will be executed against the local data folder) or `cloud` (queries will be executed against the remote data folder). As a remote data folder may not be required in `edge` mode, e.g., if `modelardbd` is deployed on a single node and [data transfer](https://github.com/ModelarData/ModelarDB-RS/tree/dev/data-transfer) is disabled, `remote_data_folder` is optional in `edge` mode and `mode` defaults to `edge`. Thus, `modelardbd` can be started as follows:

```
modelardbd edge ~/Data s3://modelardbd
modelardbd edge ~/Data
modelardbd ~/Data

modelardbd cloud ~/Data s3://modelardbd
```

To provide the credentials for S3 the required environment variable described in [`AmazonS3Builder.from_env()`](https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.from_env) must be set. The [README](https://github.com/ModelarData/ModelarDB-RS/blob/master/README.md) has purposely not been updated as querying the remote data folder is of very limited value until [data transfer](https://github.com/ModelarData/ModelarDB-RS/tree/dev/data-transfer) is complete and `cargo run --bin modelardbd path_to_data_folder` is still supported as `mode` and `remote_data_folder` is optional as described above.