### PR TITLE
Update Microsoft Windows in CI

### DIFF
--- a/.github/workflows/cargo-test-on-pr.yml
+++ b/.github/workflows/cargo-test-on-pr.yml
@@ -13,15 +13,10 @@ jobs:
   cargo_build_and_test:
     name: Cargo Build and Test
 
-    # snmalloc requires Visual Studio 2017 or Visual Studio 2019 to build on Microsoft Windows
-    # https://github.com/microsoft/snmalloc/blob/main/docs/BUILDING.md
-    # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2016-Readme.md
-    # https://github.com/microsoft/snmalloc/issues/525#issuecomment-1128901104
-    # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, macos-latest, windows-2019]
+        operating-system: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
 
 ### Windows
 1. Install a supported version of [Visual Studio](https://visualstudio.microsoft.com/vs/older-downloads/) with Visual C++:
-   * Visual Studio 2017 ([Supported](https://github.com/microsoft/snmalloc/blob/main/docs/BUILDING.md#building-on-windows))
-   * Visual Studio 2019 ([Supported](https://github.com/microsoft/snmalloc/issues/525#issuecomment-1128901104))
-   * Note that Visual Studio 2022 is **not** supported.
+   * Visual Studio 2019 ([Supported](https://github.com/microsoft/snmalloc/blob/main/docs/BUILDING.md#building-on-windows))
+   * Visual Studio 2022 ([Supported](https://github.com/microsoft/snmalloc/blob/main/docs/BUILDING.md#building-on-windows))
 2. Install [CMake](https://cmake.org/) and select one of the following options during installation:
    * _Add CMake to the system PATH for all users_
    * _Add CMake to the system PATH for current user_


### PR DESCRIPTION
This PR updates the version of Microsoft Windows used in GitHub Actions as [snmalloc](https://github.com/microsoft/snmalloc/blob/main/docs/BUILDING.md#building-on-windows) no longer lists Visual Studio 2017 as a supported version and now lists Visual Studio 2022 as a supported version.