### PR TITLE
Added data transfer component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,6 +1372,7 @@ version = "0.1.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
+ "bytes",
  "chrono",
  "datafusion",
  "datafusion-expr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,6 @@ dependencies = [
  "arrow-flight",
  "async-trait",
  "bytes",
- "chrono",
  "datafusion",
  "datafusion-common",
  "datafusion-expr",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,6 +11,7 @@ datafusion-expr = "13.0.0"
 datafusion-physical-expr = "13.0.0"
 datafusion-sql = "13.0.0"
 object_store = "0.5.0"
+bytes = "1"
 sqlparser = "0.25.0"
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same value

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -83,7 +83,6 @@ fn main() -> Result<(), String> {
             .map_err(|error| format!("Unable to create a MetadataManager: {}", error))?;
         let session = create_session_context();
         let storage_engine = RwLock::new(StorageEngine::new(
-            runtime.clone(),
             data_folder_path.clone(),
             metadata_manager.clone(),
             true,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -28,14 +28,14 @@ mod storage;
 mod tables;
 mod types;
 
-use std::{fs};
+use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use datafusion::execution::context::{SessionConfig, SessionContext, SessionState};
 use datafusion::execution::runtime_env::RuntimeEnv;
 use object_store::{aws::AmazonS3Builder, local::LocalFileSystem, path::Path, ObjectStore};
-use tokio::runtime::{Runtime};
+use tokio::runtime::Runtime;
 use tokio::sync::RwLock;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -114,7 +114,6 @@ fn main() -> Result<(), String> {
     let metadata_manager = MetadataManager::try_new(&data_folders.local_data_folder)
         .map_err(|error| format!("Unable to create a MetadataManager: {}", error))?;
     let session = create_session_context(data_folders.query_data_folder);
-
     let storage_engine = RwLock::new(StorageEngine::new(
         data_folders.local_data_folder,
         metadata_manager.clone(),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -83,6 +83,7 @@ fn main() -> Result<(), String> {
             .map_err(|error| format!("Unable to create a MetadataManager: {}", error))?;
         let session = create_session_context();
         let storage_engine = RwLock::new(StorageEngine::new(
+            runtime.clone(),
             data_folder_path.clone(),
             metadata_manager.clone(),
             true,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -304,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_edge_command_line_arguments_without_blob_store() {
+    fn test_parse_edge_command_line_arguments_without_remote_object_store() {
         setup_environment();
         let tempdir = tempfile::tempdir().unwrap();
         let tempdir_str = tempdir.path().to_str().unwrap();
@@ -316,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_edge_command_line_arguments_without_mode_and_blob_store() {
+    fn test_parse_edge_command_line_arguments_without_mode_and_remote_object_store() {
         setup_environment();
         let tempdir = tempfile::tempdir().unwrap();
         let tempdir_str = tempdir.path().to_str().unwrap();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -28,7 +28,7 @@ mod storage;
 mod tables;
 mod types;
 
-use std::fs;
+use std::{env, fs};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -99,22 +99,35 @@ fn main() -> Result<(), String> {
         Runtime::new().map_err(|error| format!("Unable to create a Tokio Runtime: {}", error))?,
     );
 
-    // Ensure the remote data folder can be accessed. The check is performed
-    // after parse_command_line_arguments() as the Tokio Runtime is required.
-    if let Some(remote_data_folder) = data_folders.remote_data_folder {
+    // Ensure the remote data folder can be accessed and set up the data transfer component if the
+    // remote data folder exists. The check is performed after parse_command_line_arguments() as the
+    // Tokio Runtime is required.
+    let data_transfer = if let Some(remote_data_folder) = data_folders.remote_data_folder {
         runtime.block_on(async {
             remote_data_folder
                 .get(&Path::from(""))
                 .await
                 .map_err(|error| error.to_string())
         })?;
-    }
+
+        // TODO: Make the transfer batch size in bytes part of the user-configurable settings.
+        storage::data_transfer::DataTransfer::try_new(
+            runtime.clone(),
+            data_folders.local_data_folder.clone(),
+            remote_data_folder,
+            5000,
+        ).ok()
+    } else {
+        None
+    };
 
     // Create the components for the Context.
     let metadata_manager = MetadataManager::try_new(&data_folders.local_data_folder)
         .map_err(|error| format!("Unable to create a MetadataManager: {}", error))?;
     let session = create_session_context(data_folders.query_data_folder);
+
     let storage_engine = RwLock::new(StorageEngine::new(
+        data_transfer,
         data_folders.local_data_folder,
         metadata_manager.clone(),
         true,

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -1141,7 +1141,6 @@ pub mod test_util {
     pub fn get_test_context(path: &Path) -> Arc<Context> {
         let metadata_manager = get_test_metadata_manager(path);
         let session = get_test_session_context();
-
         let storage_engine = RwLock::new(StorageEngine::new(
             path.to_owned(),
             metadata_manager.clone(),

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -1139,7 +1139,10 @@ pub mod test_util {
     pub fn get_test_context(path: &Path) -> Arc<Context> {
         let metadata_manager = get_test_metadata_manager(path);
         let session = get_test_session_context();
+        let runtime = Arc::new(Runtime::new().unwrap());
+
         let storage_engine = RwLock::new(StorageEngine::new(
+            runtime,
             path.to_owned(),
             metadata_manager.clone(),
             true,

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -1141,10 +1141,8 @@ pub mod test_util {
     pub fn get_test_context(path: &Path) -> Arc<Context> {
         let metadata_manager = get_test_metadata_manager(path);
         let session = get_test_session_context();
-        let runtime = Arc::new(Runtime::new().unwrap());
 
         let storage_engine = RwLock::new(StorageEngine::new(
-            runtime,
             path.to_owned(),
             metadata_manager.clone(),
             true,

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -232,7 +232,7 @@ mod tests {
     use object_store::local::LocalFileSystem;
     use tempfile::{tempdir, TempDir};
 
-    use crate::{storage};
+    use crate::storage;
     use crate::metadata::test_util as metadata_test_util;
     use crate::storage::test_util;
 

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -15,8 +15,8 @@
 
 //! Support for managing all compressed data that is inserted into the [`StorageEngine`].
 
-use std::io::Error as IOError;
 use std::collections::{HashMap, VecDeque};
+use std::io::Error as IOError;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -141,7 +141,7 @@ impl CompressedDataManager {
                         &query_data_folder,
                         &meta.location,
                     )
-                        .await
+                    .await
                     {
                         return Some((key.to_string(), meta));
                     };
@@ -232,8 +232,8 @@ mod tests {
     use object_store::local::LocalFileSystem;
     use tempfile::{tempdir, TempDir};
 
-    use crate::storage;
     use crate::metadata::test_util as metadata_test_util;
+    use crate::storage;
     use crate::storage::test_util;
 
     const KEY: u64 = 1;

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -161,6 +161,7 @@ impl CompressedDataManager {
         }
     }
 
+    // TODO: After saving, the file location should be given to the data transfer component.
     /// Save the compressed data corresponding to `key` to disk. The size of the saved compressed
     /// data is added back to the remaining reserved memory.
     fn save_compressed_data(&mut self, key: &u64) {

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -211,7 +211,7 @@ mod tests {
 
     use tempfile::{tempdir, TempDir};
 
-    use crate::get_array;
+    use crate::{get_array, storage};
     use crate::metadata::test_util as metadata_test_util;
     use crate::storage::test_util;
     use crate::types::TimestampArray;
@@ -336,15 +336,8 @@ mod tests {
         assert_eq!(files.len(), 1);
 
         // The file should have the first start time and the last end time as the file name.
-        let start_times = get_array!(segment, 2, TimestampArray);
-        let end_times = get_array!(segment, 3, TimestampArray);
-        let expected_file_path = format!(
-            "{}/compressed/{}-{}.parquet",
-            KEY,
-            start_times.value(0),
-            end_times.value(end_times.len() - 1)
-        );
-
+        let file_name = storage::create_time_range_file_name(&segment);
+        let expected_file_path = format!("{}/compressed/{}", KEY, file_name);
         let expected_full_path = data_manager.data_folder_path.join(expected_file_path);
         assert_eq!(*files.get(0).unwrap(), expected_full_path)
     }

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -1,0 +1,58 @@
+/* Copyright 2022 The ModelarDB Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Support for efficiently transferring data to a blob store in the cloud. Data saved locally on
+//! disk is managed here until it is of a sufficient size to be transferred efficiently. Furthermore,
+//! the component ensures that local data is kept on disk until a reliable connection is established.
+
+// TODO: Files should be combined when transferring data.
+// TODO: When data is done transferring, the files should be deleted from local storage.
+// TODO: A system should be in place to keep track of the location of certain data to avoid duplicate data between edge and cloud.
+// TODO: Add a user configuration in the metadata component that makes it possible to change the batch size of when to send.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use crate::errors::ModelarDbError;
+
+pub(super) struct DataTransfer {
+    /// Map from keys to the combined size in bytes of the compressed files saved under the key.
+    compressed_files: HashMap<u64, u64>,
+    /// The number of bytes that is required before transferring a batch of data to the blob store.
+    transfer_batch_size_in_bytes: usize,
+}
+
+impl DataTransfer {
+    // TODO: This should look through local storage to retrieve files that should be transferred.
+    pub(super) fn new(transfer_batch_size_in_bytes: usize) -> Self {
+        Self {
+            compressed_files: HashMap::new(),
+            transfer_batch_size_in_bytes,
+        }
+    }
+
+    /// Insert the location of the compressed file into the files to be transferred. Also retrieve
+    /// the size of the file and add it to the total size of the current local files under the key.
+    pub(super) fn insert_compressed_file() {
+        // TODO: If the combined size of the files is larger than the batch size, transfer the data to the blob store.
+    }
+
+    /// Transfer the data corresponding to `key` to the blob store. Once successfully transferred,
+    /// delete the data from local storage.
+    fn transfer_data() {
+        // TODO: Read all files that correspond to the key.
+        // TODO: Transfer the read data to the blob store.
+        // TODO: Delete the transferred files from local storage.
+    }
+}

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -39,12 +39,9 @@ use crate::{storage, StorageEngine};
 
 // TODO: When the storage engine is changed to use object store for everything, receive
 //       the object store directly through the parameters instead.
-// TODO: Set up the data transfer component based on whether the system is running on edge or cloud.
-// TODO: When a compressed file is saved, add the file to the data transfer component.
 // TODO: Handle the case where a connection can not be established when transferring data.
-// TODO: Use is_path_an_apache_parquet_file when merged.
 
-pub(super) struct DataTransfer {
+pub struct DataTransfer {
     /// Tokio runtime for executing asynchronous tasks.
     runtime: Arc<Runtime>,
     /// Path to the folder containing all compressed data managed by the [`StorageEngine`].
@@ -63,7 +60,7 @@ impl DataTransfer {
     /// Create a new data transfer instance and initialize it with the compressed files already
     /// existing in `data_folder_path`. If `data_folder_path` or a path within `data_folder_path`
     /// could not be read, return [`IOError`].
-    pub(super) fn try_new(
+    pub fn try_new(
         runtime: Arc<Runtime>,
         data_folder_path: PathBuf,
         target_object_store: Arc<dyn ObjectStore>,
@@ -110,7 +107,7 @@ impl DataTransfer {
 
     /// Insert the compressed file into the files to be transferred. Retrieve the size of the file
     /// and add it to the total size of the current local files under the key.
-    pub(super) fn add_compressed_file(&mut self, key: &u64, file_path: &Path) -> Result<(), IOError> {
+    pub fn add_compressed_file(&mut self, key: &u64, file_path: &Path) -> Result<(), IOError> {
         let file_size = file_path.metadata()?.len() as usize;
         *self.compressed_files.entry(*key).or_insert(0) += file_size;
 
@@ -226,8 +223,8 @@ mod tests {
     #[test]
     fn test_include_existing_files_on_start_up() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let parquet_path = create_compressed_file(temp_dir.path(), "test");
-        let (_target_dir, mut data_transfer) = create_data_transfer_component(temp_dir.path());
+        create_compressed_file(temp_dir.path(), "test");
+        let (_target_dir, data_transfer) = create_data_transfer_component(temp_dir.path());
 
         assert_eq!(*data_transfer.compressed_files.get(&KEY).unwrap(), COMPRESSED_FILE_SIZE)
     }
@@ -356,12 +353,12 @@ mod tests {
     #[test]
     fn test_transfer_if_reaching_batch_size_on_start_up() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let path_1 = create_compressed_file(temp_dir.path(), "test_1");
-        let path_2 = create_compressed_file(temp_dir.path(), "test_2");
-        let path_3 = create_compressed_file(temp_dir.path(), "test_3");
+        create_compressed_file(temp_dir.path(), "test_1");
+        create_compressed_file(temp_dir.path(), "test_2");
+        create_compressed_file(temp_dir.path(), "test_3");
 
         // Since the max batch size is 1 byte smaller than 3 compressed files, the data should be transferred immediately.
-        let (target_dir, mut data_transfer) = create_data_transfer_component(temp_dir.path());
+        let (target_dir, data_transfer) = create_data_transfer_component(temp_dir.path());
 
         assert!(target_dir.path().join(format!("{}/compressed/0-3.parquet", KEY)).exists());
         assert_eq!(*data_transfer.compressed_files.get(&KEY).unwrap(), 0 as usize);

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -210,6 +210,42 @@ mod tests {
     fn test_transfer_if_reaching_batch_size_on_start_up() {}
 
     #[test]
+    fn test_empty_path_is_not_compressed_file() {
+        let path = object_store::path::Path::from("");
+        assert!(DataTransfer::path_is_compressed_file(path).is_none());
+    }
+
+    #[test]
+    fn test_folder_path_is_not_compressed_file() {
+        let path = object_store::path::Path::from("4330327753845164038/compressed");
+        assert!(DataTransfer::path_is_compressed_file(path).is_none());
+    }
+
+    #[test]
+    fn test_non_key_folder_is_not_compressed_file() {
+        let path = object_store::path::Path::from("test/compressed/test.parquet");
+        assert!(DataTransfer::path_is_compressed_file(path).is_none());
+    }
+
+    #[test]
+    fn test_key_folder_without_compressed_folder_is_not_compressed_file() {
+        let path = object_store::path::Path::from("4330327753845164038/test/test.parquet");
+        assert!(DataTransfer::path_is_compressed_file(path).is_none());
+    }
+
+    #[test]
+    fn test_non_parquet_file_is_not_compressed_file() {
+        let path = object_store::path::Path::from("4330327753845164038/compressed/test.txt");
+        assert!(DataTransfer::path_is_compressed_file(path).is_none());
+    }
+
+    #[test]
+    fn test_compressed_file_is_compressed_file() {
+        let path = object_store::path::Path::from("4330327753845164038/compressed/test.parquet");
+        assert_eq!(DataTransfer::path_is_compressed_file(path), Some(4330327753845164038));
+    }
+
+    #[test]
     fn test_add_compressed_file_into_new_key() {
         let temp_dir = tempfile::tempdir().unwrap();
         let (_target_dir, mut data_transfer) = create_data_transfer_component(temp_dir.path());

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -96,8 +96,8 @@ impl DataTransfer {
     /// Return the key if `path` is a key folder containing compressed data, otherwise [`None`].
     fn path_contains_compressed_files(path: &Path) -> Option<u64> {
         if path.is_dir() && path.join("compressed").is_dir() {
-            // Convert the path name to the 64-bit key and return it if possible.
-            let key = path.to_string_lossy().to_string();
+            // Convert the directory name to the 64-bit key and return it if possible.
+            let key = path.file_name().unwrap().to_string_lossy().to_string();
             key.parse::<u64>().ok()
         } else {
             None
@@ -112,6 +112,8 @@ impl DataTransfer {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::fs::File;
     use std::path::PathBuf;
     use std::sync::Arc;
 
@@ -131,23 +133,38 @@ mod tests {
     }
 
     #[test]
-    fn test_file_contains_compressed_files() {
+    fn test_file_does_not_contain_compressed_files() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("test.txt");
+        File::create(path.clone()).unwrap();
 
+        assert!(DataTransfer::path_contains_compressed_files(path.as_path()).is_none());
     }
 
     #[test]
-    fn test_empty_folder_contains_compressed_files() {
-
+    fn test_empty_folder_does_not_contain_compressed_files() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        assert!(DataTransfer::path_contains_compressed_files(temp_dir.path()).is_none());
     }
 
     #[test]
-    fn test_non_empty_folder_without_compressed_folder_contains_compressed_files() {
+    fn test_non_empty_folder_without_compressed_folder_does_not_contain_compressed_files() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("1668574317311628292/uncompressed");
+        fs::create_dir_all(path.clone()).unwrap();
 
+        let key_path = temp_dir.path().join("1668574317311628292");
+        assert!(DataTransfer::path_contains_compressed_files(key_path.as_path()).is_none());
     }
 
     #[test]
     fn test_compressed_folder_contains_compressed_files() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("1668574317311628292/compressed");
+        fs::create_dir_all(path.clone()).unwrap();
 
+        let key_path = temp_dir.path().join("1668574317311628292");
+        assert!(DataTransfer::path_contains_compressed_files(key_path.as_path()).is_some());
     }
 
     #[test]

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -17,11 +17,6 @@
 //! disk is managed here until it is of a sufficient size to be transferred efficiently. Furthermore,
 //! the component ensures that local data is kept on disk until a reliable connection is established.
 
-// TODO: Files should be combined when transferring data.
-// TODO: When data is done transferring, the files should be deleted from local storage.
-// TODO: A system should be in place to keep track of the location of certain data to avoid duplicate data between edge and cloud.
-// TODO: Add a user configuration in the metadata component that makes it possible to change the batch size of when to send.
-
 use std::collections::HashMap;
 use std::fs;
 use std::io::Error as IOError;
@@ -42,7 +37,6 @@ pub(super) struct DataTransfer {
     transfer_batch_size_in_bytes: usize,
 }
 
-// TODO: Add function and tests for flushing the instance of compressed data saved locally.
 impl DataTransfer {
     /// Create a new data transfer instance and initialize it with the compressed files already
     /// existing in `data_folder_path`. If `data_folder_path` or a path within `data_folder_path`
@@ -92,6 +86,11 @@ impl DataTransfer {
         }
 
         Ok(())
+    }
+
+    /// Transfer all compressed files currently in the data folder to the target blob store.
+    pub(super) fn flush_compressed_files(&mut self) {
+        // TODO: Iterate over the keys in the compressed files hashmap and call the transfer data function for each key.
     }
 
     /// Transfer the data corresponding to `key` to the blob store. Once successfully transferred,
@@ -164,7 +163,9 @@ mod tests {
     }
 
     #[test]
-    fn test_transfer_if_reaching_batch_size_on_start_up() {}
+    fn test_transfer_if_reaching_batch_size_on_start_up() {
+
+    }
 
     #[test]
     fn test_file_does_not_contain_compressed_files() {
@@ -266,7 +267,14 @@ mod tests {
     }
 
     #[test]
-    fn test_transfer_if_reaching_batch_size_when_adding() {}
+    fn test_flush_compressed_files() {
+
+    }
+
+    #[test]
+    fn test_transfer_if_reaching_batch_size_when_adding() {
+
+    }
 
     #[test]
     fn test_transfer_single_file() {

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -42,9 +42,9 @@ impl DataTransfer {
         }
     }
 
-    /// Insert the location of the compressed file into the files to be transferred. Also retrieve
-    /// the size of the file and add it to the total size of the current local files under the key.
-    pub(super) fn insert_compressed_file() {
+    /// Insert the compressed file into the files to be transferred. Retrieve the size of the file
+    /// and add it to the total size of the current local files under the key.
+    pub(super) fn add_compressed_file() {
         // TODO: If the combined size of the files is larger than the batch size, transfer the data to the blob store.
     }
 
@@ -54,5 +54,45 @@ impl DataTransfer {
         // TODO: Read all files that correspond to the key.
         // TODO: Transfer the read data to the blob store.
         // TODO: Delete the transferred files from local storage.
+
+        // TODO: Handle the base where a connection can not be established.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_include_existing_files_on_start_up() {
+
+    }
+
+    #[test]
+    fn test_add_compressed_file_into_new_key() {
+
+    }
+
+    #[test]
+    fn test_add_compressed_file_into_existing_key() {
+
+    }
+
+    #[test]
+    fn test_transfer_when_reaching_batch_size() {
+
+    }
+
+    #[test]
+    fn test_transfer_single_file() {
+        // TODO: Check that the file has been deleted.
+    }
+
+    #[test]
+    fn test_transfer_multiple_files() {
+        // TODO: Check that the files have been deleted.
+    }
+
+    fn create_data_transfer_component() {
+        // TODO: Create a target object store.
+        // TODO: Create a data transfer component.
     }
 }

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -133,9 +133,13 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::storage::data_transfer::DataTransfer;
+    use crate::storage::test_util;
+    use crate::StorageEngine;
 
     #[test]
-    fn test_include_existing_files_on_start_up() {}
+    fn test_include_existing_files_on_start_up() {
+
+    }
 
     #[test]
     fn test_transfer_if_reaching_batch_size_on_start_up() {}
@@ -177,7 +181,20 @@ mod tests {
 
     #[test]
     fn test_get_total_compressed_files_size() {
+        let temp_dir = tempfile::tempdir().unwrap();
 
+        // Create a folder with a text file and an Apache Parquet file.
+        let txt_path = temp_dir.path().join("test.txt");
+        fs::write(txt_path.clone(), "test content").unwrap();
+
+        assert_eq!(DataTransfer::get_total_compressed_files_size(temp_dir.path()), 0);
+
+        let batch = test_util::get_compressed_segment_record_batch();
+        let parquet_path = temp_dir.path().join("test_parquet.parquet");
+        StorageEngine::write_batch_to_apache_parquet_file(batch.clone(), parquet_path.as_path()).unwrap();
+
+        // Only the size of the Apache Parquet file should be counted.
+        assert_eq!(DataTransfer::get_total_compressed_files_size(temp_dir.path()), 2503);
     }
 
     #[test]

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -41,6 +41,8 @@ use crate::{storage, StorageEngine};
 // TODO: Handle the case where a connection can not be established when transferring data.
 // TODO: If there is a remote data folder, initialize the data transfer component in main.
 // TODO: When compressed data is saved, add the compressed file to the data transfer component.
+// TODO: Handle deleting the files after the transfer is complete in a safe way to avoid transferring
+//       the same data multiple times or deleting files that are currently used elsewhere.
 
 pub struct DataTransfer {
     /// Tokio runtime for executing asynchronous tasks.

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -21,6 +21,7 @@ mod compressed_data_manager;
 mod segment;
 mod time_series;
 mod uncompressed_data_manager;
+mod data_transfer;
 
 use std::ffi::OsStr;
 use std::fs;

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -44,7 +44,6 @@ use crate::get_array;
 use crate::metadata::model_table_metadata::ModelTableMetadata;
 use crate::metadata::MetadataManager;
 use crate::storage::compressed_data_manager::CompressedDataManager;
-use crate::storage::data_transfer::DataTransfer;
 use crate::storage::segment::FinishedSegment;
 use crate::storage::uncompressed_data_manager::UncompressedDataManager;
 use crate::types::{Timestamp, TimestampArray};
@@ -80,7 +79,6 @@ pub struct StorageEngine {
 
 impl StorageEngine {
     pub fn new(
-        data_transfer: Option<DataTransfer>,
         data_folder_path: PathBuf,
         metadata_manager: MetadataManager,
         compress_directly: bool,
@@ -94,7 +92,6 @@ impl StorageEngine {
         );
 
         let compressed_data_manager = CompressedDataManager::new(
-            data_transfer,
             data_folder_path.clone(),
             metadata_manager.compressed_reserved_memory_in_bytes,
             metadata_manager.get_compressed_schema(),

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -21,11 +21,11 @@ mod compressed_data_manager;
 mod segment;
 mod time_series;
 mod uncompressed_data_manager;
-pub mod data_transfer;
+mod data_transfer;
 
 use std::ffi::OsStr;
 use std::fs::File;
-use std::io::{Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -92,7 +92,7 @@ impl StorageEngine {
         );
 
         let compressed_data_manager = CompressedDataManager::new(
-            data_folder_path.clone(),
+            data_folder_path,
             metadata_manager.compressed_reserved_memory_in_bytes,
             metadata_manager.get_compressed_schema(),
         );
@@ -251,7 +251,7 @@ impl StorageEngine {
 
 /// Create an Apache ArrowWriter that writes to `writer`. If the writer could not be created
 /// return [`ParquetError`].
-pub fn create_apache_arrow_writer<W: Write>(
+pub(self) fn create_apache_arrow_writer<W: Write>(
     writer: W,
     schema: SchemaRef
 ) -> Result<ArrowWriter<W>, ParquetError> {
@@ -265,9 +265,8 @@ pub fn create_apache_arrow_writer<W: Write>(
     Ok(writer)
 }
 
-// TODO: Maybe add error handling to this.
 /// Create a file name that uses the first start timestamp and the last end timestamp from `batch`.
-pub fn create_time_range_file_name(batch: &RecordBatch) -> String {
+pub(self) fn create_time_range_file_name(batch: &RecordBatch) -> String {
     let start_times = get_array!(batch, 2, TimestampArray);
     let end_times = get_array!(batch, 3, TimestampArray);
 

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -25,7 +25,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 
 use crate::storage;
 use crate::storage::StorageEngine;
-use crate::types::{CompressedSchema};
+use crate::types::CompressedSchema;
 
 /// A single compressed time series, containing one or more compressed segments and providing
 /// functionality for appending segments and saving all segments to a single Apache Parquet file.

--- a/server/src/storage/time_series.rs
+++ b/server/src/storage/time_series.rs
@@ -101,7 +101,6 @@ impl CompressedTimeSeries {
 mod tests {
     use super::*;
 
-    use datafusion::arrow::array::Array;
     use tempfile::tempdir;
 
     use crate::metadata::test_util as metadata_test_util;


### PR DESCRIPTION
This PR includes a new component to handle transferring compressed data to a remote object store. It should be noted that the data transfer component is working and tested separately but it is not yet included in the flow of the complete system. This is mainly due to the data transfer component currently using `runtime.block_on` which cannot be used from within the storage engine since the storage engine is invoked from an async function (`do_put`).

When the storage engine has been made async, the data transfer component can also be made async and can then be included in the complete data flow. 