### PR TITLE
Made data transfer async and added action to flush the edge

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -127,6 +127,7 @@ fn main() -> Result<(), String> {
         .map_err(|error| format!("Unable to create a MetadataManager: {}", error))?;
     let session = create_session_context(data_folders.query_data_folder);
     let storage_engine = RwLock::new(StorageEngine::new(
+        data_transfer,
         data_folders.local_data_folder,
         metadata_manager.clone(),
         true,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -99,16 +99,28 @@ fn main() -> Result<(), String> {
         Runtime::new().map_err(|error| format!("Unable to create a Tokio Runtime: {}", error))?,
     );
 
-    // Ensure the remote data folder can be accessed. The check is performed after
-    // parse_command_line_arguments() as the Tokio Runtime is required.
-    if let Some(remote_data_folder) = data_folders.remote_data_folder {
-        runtime.block_on(async {
+    // Ensure the remote data folder can be accessed and set up the data transfer component if the
+    // remote data folder exists. The check is performed after parse_command_line_arguments() as the
+    // Tokio Runtime is required.
+    let data_transfer = if let Some(remote_data_folder) = data_folders.remote_data_folder {
+        Some(runtime.block_on(async {
             remote_data_folder
                 .get(&Path::from(""))
                 .await
-                .map_err(|error| error.to_string())
-        })?;
-    }
+                .map_err(|error| error.to_string())?;
+
+            // TODO: Make the transfer batch size in bytes part of the user-configurable settings.
+            storage::data_transfer::DataTransfer::try_new(
+                data_folders.local_data_folder.clone(),
+                remote_data_folder,
+                5000,
+            )
+            .await
+            .map_err(|error| error.to_string())
+        })?)
+    } else {
+        None
+    };
 
     // Create the components for the Context.
     let metadata_manager = MetadataManager::try_new(&data_folders.local_data_folder)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -99,9 +99,9 @@ fn main() -> Result<(), String> {
         Runtime::new().map_err(|error| format!("Unable to create a Tokio Runtime: {}", error))?,
     );
 
-    // Ensure the remote data folder can be accessed and set up the data transfer component if the
-    // remote data folder exists. The check is performed after parse_command_line_arguments() as the
-    // Tokio Runtime is required.
+    // Check if a remote data folder was provided and can be accessed. If so, the data transfer
+    // component is initialized. These checks are performed after parse_command_line_arguments()
+    // as the Tokio Runtime is required.
     let data_transfer = if let Some(remote_data_folder) = data_folders.remote_data_folder {
         Some(runtime.block_on(async {
             remote_data_folder
@@ -113,7 +113,7 @@ fn main() -> Result<(), String> {
             storage::data_transfer::DataTransfer::try_new(
                 data_folders.local_data_folder.clone(),
                 remote_data_folder,
-                5000,
+                64 * 1024 * 1024, // 64 MiB.
             )
             .await
             .map_err(|error| error.to_string())

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -1142,6 +1142,7 @@ pub mod test_util {
         let metadata_manager = get_test_metadata_manager(path);
         let session = get_test_session_context();
         let storage_engine = RwLock::new(StorageEngine::new(
+            None,
             path.to_owned(),
             metadata_manager.clone(),
             true,

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -37,6 +37,7 @@ use datafusion::arrow::{
     ipc::writer::IpcWriteOptions, record_batch::RecordBatch,
 };
 use datafusion::catalog::schema::SchemaProvider;
+use datafusion::parquet::errors::ParquetError;
 use datafusion::prelude::ParquetReadOptions;
 use futures::{stream, Stream, StreamExt};
 use tokio::runtime::Runtime;
@@ -508,6 +509,18 @@ impl FlightService for FlightServiceHandler {
 
             // Confirm the table was created.
             Ok(Response::new(Box::pin(stream::empty())))
+        } else if action.r#type == "FlushEdge" {
+            let mut storage_engine = self.context.storage_engine.write().await;
+            storage_engine.flush();
+
+            if let Some(data_transfer) = storage_engine.compressed_data_manager.data_transfer.as_mut() {
+                data_transfer.flush_compressed_files()
+                    .await
+                    .map_err(|error: ParquetError| Status::internal(error.to_string()))?;
+            }
+
+            // Confirm the data was flushed.
+            Ok(Response::new(Box::pin(stream::empty())))
         } else {
             Err(Status::unimplemented("Action not implemented."))
         }
@@ -524,7 +537,13 @@ impl FlightService for FlightServiceHandler {
                 .to_owned(),
         };
 
-        let output = stream::iter(vec![Ok(create_command_statement_update_action)]);
+        let flush_edge_action = ActionType {
+            r#type: "FlushEdge".to_owned(),
+            description: "Flush uncompressed data to disk by compressing and saving the data and \
+            flush all compressed data to the remote object store.".to_owned()
+        };
+
+        let output = stream::iter(vec![Ok(create_command_statement_update_action), Ok(flush_edge_action)]);
         Ok(Response::new(Box::pin(output)))
     }
 }

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -513,8 +513,13 @@ impl FlightService for FlightServiceHandler {
             let mut storage_engine = self.context.storage_engine.write().await;
             storage_engine.flush();
 
-            if let Some(data_transfer) = storage_engine.compressed_data_manager.data_transfer.as_mut() {
-                data_transfer.flush_compressed_files()
+            if let Some(data_transfer) = storage_engine
+                .compressed_data_manager
+                .data_transfer
+                .as_mut()
+            {
+                data_transfer
+                    .flush_compressed_files()
                     .await
                     .map_err(|error: ParquetError| Status::internal(error.to_string()))?;
             }
@@ -540,10 +545,15 @@ impl FlightService for FlightServiceHandler {
         let flush_edge_action = ActionType {
             r#type: "FlushEdge".to_owned(),
             description: "Flush uncompressed data to disk by compressing and saving the data and \
-            flush all compressed data to the remote object store.".to_owned()
+            flush all compressed data to the remote object store."
+                .to_owned(),
         };
 
-        let output = stream::iter(vec![Ok(create_command_statement_update_action), Ok(flush_edge_action)]);
+        let output = stream::iter(vec![
+            Ok(create_command_statement_update_action),
+            Ok(flush_edge_action),
+        ]);
+
         Ok(Response::new(Box::pin(output)))
     }
 }

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -35,9 +35,9 @@ use crate::StorageEngine;
 
 /// Stores data points compressed as models in memory to batch compressed data before saving it to
 /// Apache Parquet files.
-pub(super) struct CompressedDataManager {
+pub struct CompressedDataManager {
     /// Component to manage the quantity of saved compressed data and transfer the data when necessary.
-    data_transfer: Option<DataTransfer>,
+    pub data_transfer: Option<DataTransfer>,
     /// Path to the folder containing all compressed data managed by the [`StorageEngine`].
     data_folder_path: PathBuf,
     /// The compressed segments before they are saved to persistent storage.

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -35,9 +35,9 @@ use crate::StorageEngine;
 
 /// Stores data points compressed as models in memory to batch compressed data before saving it to
 /// Apache Parquet files.
-pub struct CompressedDataManager {
-    /// Component to manage the quantity of saved compressed data and transfer the data when necessary.
-    pub data_transfer: Option<DataTransfer>,
+pub(super) struct CompressedDataManager {
+    /// Component that transfers saved compressed data to the remote data folder when it is necessary.
+    pub(super) data_transfer: Option<DataTransfer>,
     /// Path to the folder containing all compressed data managed by the [`StorageEngine`].
     data_folder_path: PathBuf,
     /// The compressed segments before they are saved to persistent storage.

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -28,6 +28,7 @@ use tracing::info;
 use tracing::{debug, debug_span};
 
 use crate::errors::ModelarDbError;
+use crate::storage::data_transfer::DataTransfer;
 use crate::storage::time_series::CompressedTimeSeries;
 use crate::types::{CompressedSchema, Timestamp};
 use crate::StorageEngine;
@@ -35,6 +36,8 @@ use crate::StorageEngine;
 /// Stores data points compressed as models in memory to batch compressed data before saving it to
 /// Apache Parquet files.
 pub(super) struct CompressedDataManager {
+    /// Component to manage the quantity of saved compressed data and transfer the data when necessary.
+    data_transfer: Option<DataTransfer>,
     /// Path to the folder containing all compressed data managed by the [`StorageEngine`].
     data_folder_path: PathBuf,
     /// The compressed segments before they are saved to persistent storage.
@@ -51,11 +54,13 @@ pub(super) struct CompressedDataManager {
 
 impl CompressedDataManager {
     pub(super) fn new(
+        data_transfer: Option<DataTransfer>,
         data_folder_path: PathBuf,
         compressed_reserved_memory_in_bytes: usize,
         compressed_schema: CompressedSchema,
     ) -> Self {
         Self {
+            data_transfer,
             data_folder_path,
             // TODO: Maybe create with estimated capacity to avoid reallocation.
             compressed_data: HashMap::new(),
@@ -333,6 +338,7 @@ mod tests {
         (
             temp_dir,
             CompressedDataManager::new(
+                None,
                 data_folder_path,
                 metadata_manager.compressed_reserved_memory_in_bytes,
                 metadata_manager.get_compressed_schema(),

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -39,10 +39,16 @@ use crate::{storage, StorageEngine};
 // TODO: When the storage engine is changed to use object store for everything, receive
 //       the object store directly through the parameters instead.
 // TODO: Handle the case where a connection can not be established when transferring data.
-// TODO: If there is a remote data folder, initialize the data transfer component in main.
 // TODO: When compressed data is saved, add the compressed file to the data transfer component.
 // TODO: Handle deleting the files after the transfer is complete in a safe way to avoid transferring
 //       the same data multiple times or deleting files that are currently used elsewhere.
+
+// TODO: Remove all uses of block_on in the data transfer component.
+// TODO: If there is a remote data folder, initialize the data transfer component in main.
+// TODO: Pass the data transfer component to the storage engine (maybe to compressed data manager).
+// TODO: Create a new function to move all compressed data to the remote store.
+// TODO: Add a test for this function.
+// TODO: Create a new action (add to list actions) that flushes the memory and the on-disk files.
 
 pub struct DataTransfer {
     /// Tokio runtime for executing asynchronous tasks.
@@ -119,6 +125,11 @@ impl DataTransfer {
         }
 
         Ok(())
+    }
+
+    /// Transfer all compressed files currently in the data folder to the remote object store.
+    pub(super) fn flush_compressed_files(&mut self) {
+        // TODO: Iterate over the keys in the compressed files hashmap and call the transfer data function for each key.
     }
 
     /// Transfer the data corresponding to `key` to the remote object store. Once successfully
@@ -378,6 +389,11 @@ mod tests {
         // The transferred file should have a time range file name that matches the compressed data.
         assert!(target_dir.path().join(format!("{}/compressed/0-3.parquet", KEY)).exists());
         assert_eq!(*data_transfer.compressed_files.get(&KEY).unwrap(), 0 as usize);
+    }
+
+    #[test]
+    fn test_flush_compressed_files() {
+
     }
 
     /// Set up a data folder with a key folder that has a single compressed file in it.

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -123,7 +123,9 @@ impl DataTransfer {
     }
 
     /// Transfer all compressed files currently in the data folder to the remote object store.
-    /// Return [`Ok`] if all files were transferred successfully, otherwise [`ParquetError`].
+    /// Return [`Ok`] if all files were transferred successfully, otherwise [`ParquetError`]. Note
+    /// that if the function fails, some of the compressed files may still have been transferred. Since
+    /// the data is transferred separately for each key, the function can be called again if it failed.
     pub(crate) async fn flush_compressed_files(&mut self) -> Result<(), ParquetError> {
         for (key, size_in_bytes) in self.compressed_files.clone().iter() {
             if size_in_bytes > &(0 as usize) {

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -42,9 +42,6 @@ use crate::{storage, StorageEngine};
 // TODO: Handle deleting the files after the transfer is complete in a safe way to avoid transferring
 //       the same data multiple times or deleting files that are currently used elsewhere.
 
-// TODO: Create a new action (add to list actions) that flushes the memory and the on-disk files.
-// TODO: Run Rustfmt.
-
 pub struct DataTransfer {
     /// Path to the folder containing all compressed data managed by the [`StorageEngine`].
     local_data_folder_path: PathBuf,
@@ -157,7 +154,11 @@ impl DataTransfer {
             .await
             .into_iter();
 
-        debug!("Transferring {} compressed files from key '{}'.", object_metas.len(), key);
+        debug!(
+            "Transferring {} compressed files from key '{}'.",
+            object_metas.len(),
+            key
+        );
 
         // Combine the Apache Parquet files into a single RecordBatch.
         let record_batches = object_metas
@@ -443,7 +444,9 @@ mod tests {
         }
 
         // The transferred file should have a time range file name that matches the compressed data.
-        let target_path = target.path().join(format!("{}/compressed/0-3.parquet", KEY));
+        let target_path = target
+            .path()
+            .join(format!("{}/compressed/0-3.parquet", KEY));
         assert!(target_path.exists());
 
         // The file should have 3 * number_of_files rows since each compressed file has 3 rows.

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -44,6 +44,7 @@ use crate::get_array;
 use crate::metadata::model_table_metadata::ModelTableMetadata;
 use crate::metadata::MetadataManager;
 use crate::storage::compressed_data_manager::CompressedDataManager;
+use crate::storage::data_transfer::DataTransfer;
 use crate::storage::segment::FinishedSegment;
 use crate::storage::uncompressed_data_manager::UncompressedDataManager;
 use crate::types::{Timestamp, TimestampArray};
@@ -79,6 +80,7 @@ pub struct StorageEngine {
 
 impl StorageEngine {
     pub fn new(
+        data_transfer: Option<DataTransfer>,
         data_folder_path: PathBuf,
         metadata_manager: MetadataManager,
         compress_directly: bool,
@@ -92,6 +94,7 @@ impl StorageEngine {
         );
 
         let compressed_data_manager = CompressedDataManager::new(
+            data_transfer,
             data_folder_path,
             metadata_manager.compressed_reserved_memory_in_bytes,
             metadata_manager.get_compressed_schema(),
@@ -443,6 +446,7 @@ mod tests {
         (
             temp_dir,
             StorageEngine::new(
+                None,
                 data_folder_path_buf,
                 metadata_test_util::get_test_metadata_manager(data_folder_path.as_path()),
                 false,

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -75,7 +75,7 @@ pub struct StorageEngine {
     /// Manager that contains and controls all uncompressed data.
     uncompressed_data_manager: UncompressedDataManager,
     /// Manager that contains and controls all compressed data.
-    compressed_data_manager: CompressedDataManager,
+    pub compressed_data_manager: CompressedDataManager,
 }
 
 impl StorageEngine {

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -21,7 +21,7 @@ mod compressed_data_manager;
 mod segment;
 mod time_series;
 mod uncompressed_data_manager;
-mod data_transfer;
+pub(crate) mod data_transfer;
 
 use std::ffi::OsStr;
 use std::fs::File;


### PR DESCRIPTION
This PR removed all use of the Tokio runtime within the data transfer component (previously used for `runtime.block_on()`) and converts the data transfer component to instead use async/await. This means that the data transfer component can now be invoked from another async function, such as from the Arrow flight endpoints. 

Further, the PR also adds a new action to make it possible to flush the entire edge. This action first flushes uncompressed memory to disk and then flushes all compressed data saved on disk to the remote store if possible. 