### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,38 +85,35 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "arrow"
-version = "26.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24e2bcd431a4aa0ff003fdd2dc21c78cfb42f31459c89d2312c2746fe17a5ac"
+checksum = "aed9849f86164fad5cb66ce4732782b15f1bc97f8febab04e782c20cce9d4b6c"
 dependencies = [
  "ahash 0.8.2",
  "arrow-array",
  "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
  "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
  "arrow-schema",
  "arrow-select",
- "bitflags",
  "chrono",
  "comfy-table",
- "csv",
- "flatbuffers",
  "half",
- "hashbrown",
- "indexmap",
- "lazy_static",
- "lexical-core",
+ "hashbrown 0.13.1",
  "multiversion",
  "num",
  "regex",
  "regex-syntax",
- "serde_json",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "26.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9044300874385f19e77cbf90911e239bd23630d8f23bb0f948f9067998a13b7"
+checksum = "6b8504cf0a6797e908eecf221a865e7d339892720587f87c8b90262863015b08"
 dependencies = [
  "ahash 0.8.2",
  "arrow-buffer",
@@ -124,25 +121,59 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown",
+ "hashbrown 0.13.1",
  "num",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "26.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78476cbe9e3f808dcecab86afe42d573863c63e149c62e6e379ed2522743e626"
+checksum = "d6de64a27cea684b24784647d9608314bc80f7c4d55acb44a425e05fab39d916"
 dependencies = [
  "half",
  "num",
 ]
 
 [[package]]
-name = "arrow-data"
-version = "26.0.0"
+name = "arrow-cast"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d916feee158c485dad4f701cba31bc9a90a8db87d9df8e2aa8adc0c20a2bbb9"
+checksum = "bec4a54502eefe05923c385c90a005d69474fa06ca7aa2a2b123c9f9532f6178"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "chrono",
+ "lexical-core",
+ "num",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7902bbf8127eac48554fe902775303377047ad49a9fd473c2b8cb399d092080"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "lazy_static",
+ "lexical-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4882efe617002449d5c6b5de9ddb632339074b36df8a96ea7147072f1faa8a"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -152,16 +183,20 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "26.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fdfed4af8da422c6ea108ae216325a9b8e020602c333cb31648a6d95178923a"
+checksum = "4164981ac7c8e7f8a194b70490f1c27e6616fe44554f6e14b97487eab9cb4100"
 dependencies = [
- "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ipc",
+ "arrow-schema",
  "base64",
  "bytes",
  "futures",
  "proc-macro2",
  "prost",
+ "prost-build",
  "prost-derive",
  "tokio",
  "tonic",
@@ -169,16 +204,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-schema"
-version = "26.0.0"
+name = "arrow-ipc"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9406eb7834ca6bd8350d1baa515d18b9fcec487eddacfb62f5e19511f7bd37"
+checksum = "fa0703a6de2785828561b03a4d7793ecd333233e1b166316b4bfc7cfce55a4a7"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd23fc8c6d251f96cd63b96fece56bbb9710ce5874a627cb786e2600673595a"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap",
+ "num",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f143882a80be168538a60e298546314f50f11f2a288c8d73e11108da39d26"
 
 [[package]]
 name = "arrow-select"
-version = "26.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6593a01586751c74498495d2f5a01fcd438102b52965c11dd98abf4ebcacef37"
+checksum = "520406331d4ad60075359524947ebd804e479816439af82bcb17f8d280d9b38c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -189,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba45b8163c49ab5f972e59a8a5a03b6d2972619d486e19ec9fe744f7c2753d3c"
+checksum = "fa3d466004a8b4cb1bc34044240a2fd29d17607e2e3bd613eb44fd48e8100da3"
 dependencies = [
  "bstr 1.0.1",
  "doc-comment",
@@ -214,6 +281,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+ "xz2",
 ]
 
 [[package]]
@@ -239,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -256,9 +324,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -274,9 +342,9 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "sync_wrapper",
- "tokio",
  "tower",
  "tower-http",
  "tower-layer",
@@ -285,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
 dependencies = [
  "async-trait",
  "bytes",
@@ -295,6 +363,7 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -417,9 +486,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bzip2"
@@ -468,6 +537,43 @@ dependencies = [
  "num-traits",
  "serde",
  "winapi",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0acbd8d28a0a60d7108d7ae850af6ba34cf2d1257fc646980e5f97ce14275966"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -695,7 +801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -703,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a8411475928479fe57af18698626f0a44f3c29153e051dce45f7455c08a6d5"
+checksum = "b75a088adf79515b04fd3895c1a14dc249c8f7a7f27b59870a05546fe9a55542"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -714,6 +820,7 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
+ "dashmap",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-optimizer",
@@ -723,13 +830,12 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
- "hashbrown",
+ "hashbrown 0.13.1",
  "itertools",
  "lazy_static",
  "log",
  "num_cpus",
  "object_store",
- "ordered-float 3.4.0",
  "parking_lot",
  "parquet",
  "paste",
@@ -737,47 +843,48 @@ dependencies = [
  "pin-project-lite",
  "rand",
  "smallvec",
- "sqlparser",
+ "sqllogictest",
+ "sqlparser 0.27.0",
  "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "url",
  "uuid",
+ "xz2",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1ffcbc1f040c9ab99f41db1c743d95aff267bb2e7286aaa010738b7402251"
+checksum = "7b17262b899f79afdf502846d1138a8b48441afe24dc6e07c922105289248137"
 dependencies = [
  "arrow",
  "chrono",
  "object_store",
- "ordered-float 3.4.0",
  "parquet",
- "sqlparser",
+ "sqlparser 0.27.0",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1883d9590d303ef38fa295567e7fdb9f8f5f511fcc167412d232844678cd295c"
+checksum = "533d2226b4636a1306d1f6f4ac02e436947c5d6e8bfc85f6d8f91a425c10a407"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
  "datafusion-common",
  "log",
- "sqlparser",
+ "sqlparser 0.27.0",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2127d46d566ab3463d70da9675fc07b9d634be8d17e80d0e1ce79600709fe651"
+checksum = "ce7ba274267b6baf1714a67727249aa56d648c8814b0f4c43387fbe6d147e619"
 dependencies = [
  "arrow",
  "async-trait",
@@ -785,15 +892,15 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
- "hashbrown",
+ "hashbrown 0.13.1",
  "log",
 ]
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d108b6fe8eeb317ecad1d74619e8758de49cccc8c771b56c97962fd52eaae23"
+checksum = "f35cb53e6c2f9c40accdf45aef2be7fde030ea3051b1145a059d96109e65b0bf"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -806,12 +913,11 @@ dependencies = [
  "datafusion-expr",
  "datafusion-row",
  "half",
- "hashbrown",
+ "hashbrown 0.13.1",
  "itertools",
  "lazy_static",
  "md-5",
  "num-traits",
- "ordered-float 3.4.0",
  "paste",
  "rand",
  "regex",
@@ -822,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-row"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43537b6377d506e4788bf21e9ed943340e076b48ca4d077e6ea4405ca5e54a1c"
+checksum = "27c77b1229ae5cf6a6e0e2ba43ed4e98131dbf1cc4a97fad17c94230b32e0812"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -834,15 +940,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244d08d4710e1088d9c0949c9b5b8d68d9cf2cde7203134a4cc389e870fe2354"
+checksum = "569423fa8a50db39717080949e3b4f8763582b87baf393cc3fcf27cc21467ba7"
 dependencies = [
- "arrow",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-expr",
- "sqlparser",
+ "sqlparser 0.27.0",
 ]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "difflib"
@@ -1188,12 +1300,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash 0.8.2",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1207,6 +1328,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -1250,6 +1380,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1341,7 +1477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1374,6 +1510,18 @@ name = "ipnet"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itertools"
@@ -1486,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "libm"
@@ -1505,6 +1653,17 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libtest-mimic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b603516767d1ab23d0de09d023e62966c3322f7148297c35cf3d97aa8b37fa"
+dependencies = [
+ "clap",
+ "termcolor",
+ "threadpool",
 ]
 
 [[package]]
@@ -1562,10 +1721,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.5.0"
+name = "lzma-sys"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "md-5"
@@ -1643,7 +1813,6 @@ dependencies = [
  "datafusion-expr",
  "datafusion-optimizer",
  "datafusion-physical-expr",
- "datafusion-sql",
  "futures",
  "libc",
  "log",
@@ -1655,7 +1824,7 @@ dependencies = [
  "rusqlite",
  "serial_test",
  "snmalloc-rs",
- "sqlparser",
+ "sqlparser 0.28.0",
  "sysinfo",
  "tempfile",
  "tokio",
@@ -1813,7 +1982,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1852,21 +2021,18 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "ordered-float"
-version = "1.1.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
-name = "ordered-float"
-version = "3.4.0"
+name = "os_str_bytes"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84eb1409416d254e4a9c8fa56cc24701755025b458f0fcd8e59e1f5f40c23bf"
-dependencies = [
- "num-traits",
-]
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "overload"
@@ -1899,26 +2065,34 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "26.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf8fa7ab6572791325a8595f55dc532dde88b996ae10a5ca8a2db746784ecc4"
+checksum = "21433e9209111bb3720b747f2f137e0d115af1af0420a7a1c26b6e88227fa353"
 dependencies = [
  "ahash 0.8.2",
- "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
  "base64",
  "brotli",
  "bytes",
  "chrono",
  "flate2",
  "futures",
- "hashbrown",
+ "hashbrown 0.13.1",
  "lz4",
  "num",
  "num-bigint",
+ "paste",
  "seq-macro",
  "snap",
  "thrift",
  "tokio",
+ "twox-hash",
  "zstd",
 ]
 
@@ -2086,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
+checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2659,10 +2833,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "sqlparser"
-version = "0.26.0"
+name = "sqllogictest"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86be66ea0b2b22749cfa157d16e2e84bf793e626a3375f4d378dc289fa03affb"
+checksum = "ba41e01d229d7725401de371e323851f82d839d68732a06162405362b60852fe"
+dependencies = [
+ "async-trait",
+ "difference",
+ "futures",
+ "glob",
+ "humantime",
+ "itertools",
+ "libtest-mimic",
+ "regex",
+ "tempfile",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba319938d4bfe250a769ac88278b629701024fe16f34257f9563bc628081970"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249ae674b9f636b8ff64d8bfe218774cf05a26de40fd9f358669dccc4c0a9d7d"
 dependencies = [
  "log",
 ]
@@ -2678,6 +2880,12 @@ name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -2723,9 +2931,9 @@ checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
 name = "sysinfo"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375d5fd899e32847b8566e10598d6e9f1d9b55ec6de3cdf9e7da4bdc51371bc"
+checksum = "29ddf41e393a9133c81d5f0974195366bd57082deac6e0eb02ed39b8341c2bb6"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -2795,14 +3003,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "thrift"
-version = "0.16.0"
+name = "threadpool"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09678c4cdbb4eed72e18b7c2af1329c69825ed16fcbac62d083fc3e2b0590ff0"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float 1.1.1",
+ "ordered-float",
 ]
 
 [[package]]
@@ -2831,9 +3048,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2908,9 +3125,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b9af819e54b8f33d453655bef9b9acc171568fb49523078d0cc4e7484200ec"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3076,6 +3293,16 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
 
 [[package]]
 name = "typenum"
@@ -3406,19 +3633,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+name = "xz2"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.0+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8148aa921e9d53217ab9322f8553bd130f7ae33489db68b381d76137d2e6374"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "6.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "a6cf39f730b440bab43da8fb5faf5f254574462f73f260f85f7987f32154ff17"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-arrow = "26.0.0"
-arrow-flight = "26.0.0"
-tonic = "0.8.2"
-tokio = "1.21.2"
+arrow = "28.0.0"
+arrow-flight = "28.0.0"
+tonic = "0.8.3"
+tokio = "1.22.0"
 rustyline = "10.0.0"
 dirs = "4.0.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,15 +6,14 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-datafusion = "14.0.0"
-datafusion-common = "14.0.0"
-datafusion-optimizer = "14.0.0"
-datafusion-expr = "14.0.0"
-datafusion-physical-expr = "14.0.0"
-datafusion-sql = "14.0.0"
+datafusion = "15.0.0"
+datafusion-common = "15.0.0"
+datafusion-optimizer = "15.0.0"
+datafusion-expr = "15.0.0"
+datafusion-physical-expr = "15.0.0"
 object_store = { version = "0.5.1", features = ["aws"] }
-sqlparser = "0.26.0"
-bytes = "1"
+sqlparser = "0.28.0"
+bytes = "1.3.0"
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same value
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }
@@ -22,13 +21,13 @@ tracing = { version = "0.1.37", features = ["max_level_debug", "release_max_leve
 tracing-subscriber = "0.3.16"
 tracing-futures = "0.2.5"
 
-tokio = { version = "1.21.2", features = ["rt-multi-thread", "signal"] }
+tokio = { version = "1.22.0", features = ["rt-multi-thread", "signal"] }
 
-async-trait = "0.1.58"
+async-trait = "0.1.59"
 futures = "0.3.25"
 
-arrow-flight = "26.0.0"
-tonic = "0.8.2"
+arrow-flight = "28.0.0"
+tonic = "0.8.3"
 
 parking_lot = "0.12.1"
 snmalloc-rs = "0.3.3"
@@ -38,12 +37,12 @@ rusqlite = { version = "0.28.0", features = ["bundled"] }
 [dev-dependencies]
 proptest = "1.0.0"
 tempfile = "3.3.0"
-rand = "0.8.4"
-assert_cmd = "2.0.4"
-prost = "0.11.0"
-libc = "0.2"
+rand = "0.8.5"
+assert_cmd = "2.0.7"
+prost = "0.11.3"
+libc = "0.2.138"
 serial_test = "0.9.0"
-sysinfo = "0.26.7"
+sysinfo = "0.26.8"
 
 [[test]]
 name = "integration"

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -274,7 +274,7 @@ impl MetadataManager {
     pub fn compute_keys_using_fields_and_tags(
         &self,
         table_name: &str,
-        columns: &Option<Vec<usize>>,
+        columns: Option<&Vec<usize>>,
         fallback_field_column: u64,
         tag_predicates: &[(&str, &str)],
     ) -> Result<Vec<TimeSeriesId>> {
@@ -823,7 +823,7 @@ mod tests {
         let metadata_manager = test_util::get_test_metadata_manager(temp_dir.path());
 
         assert!(metadata_manager
-            .compute_keys_using_fields_and_tags("model_table", &None, 10, &[])
+            .compute_keys_using_fields_and_tags("model_table", None, 10, &[])
             .is_err());
     }
 
@@ -840,7 +840,7 @@ mod tests {
 
         // Lookup keys using fields and tags for an empty table.
         let keys = metadata_manager
-            .compute_keys_using_fields_and_tags("model_table", &None, 10, &[])
+            .compute_keys_using_fields_and_tags("model_table", None, 10, &[])
             .unwrap();
         assert!(keys.is_empty());
     }
@@ -854,7 +854,7 @@ mod tests {
 
         // Lookup all keys for the table by not passing any fields or tags.
         let keys = metadata_manager
-            .compute_keys_using_fields_and_tags("model_table", &None, 10, &[])
+            .compute_keys_using_fields_and_tags("model_table", None, 10, &[])
             .unwrap();
         assert_eq!(2, keys.len());
     }
@@ -868,7 +868,7 @@ mod tests {
 
         // Lookup the keys for the fallback column by only requesting tag columns.
         let keys = metadata_manager
-            .compute_keys_using_fields_and_tags("model_table", &Some(vec![0]), 10, &[])
+            .compute_keys_using_fields_and_tags("model_table", Some(&vec![0]), 10, &[])
             .unwrap();
         assert_eq!(1, keys.len());
     }
@@ -885,13 +885,13 @@ mod tests {
 
         // Lookup all keys for the table by not requesting keys for columns.
         let keys = metadata_manager
-            .compute_keys_using_fields_and_tags("model_table", &None, 10, &[])
+            .compute_keys_using_fields_and_tags("model_table", None, 10, &[])
             .unwrap();
         assert_eq!(4, keys.len());
 
         // Lookup keys for the table by requesting keys for a specific field column.
         let keys = metadata_manager
-            .compute_keys_using_fields_and_tags("model_table", &Some(vec![1]), 10, &[])
+            .compute_keys_using_fields_and_tags("model_table", Some(&vec![1]), 10, &[])
             .unwrap();
         assert_eq!(2, keys.len());
     }
@@ -908,13 +908,13 @@ mod tests {
 
         // Lookup all keys for the table by not requesting keys for a tag value.
         let keys = metadata_manager
-            .compute_keys_using_fields_and_tags("model_table", &None, 10, &[])
+            .compute_keys_using_fields_and_tags("model_table", None, 10, &[])
             .unwrap();
         assert_eq!(4, keys.len());
 
         // Lookup keys for the table by requesting keys for a specific tag value.
         let keys = metadata_manager
-            .compute_keys_using_fields_and_tags("model_table", &None, 10, &[("tag", "tag_value1")])
+            .compute_keys_using_fields_and_tags("model_table", None, 10, &[("tag", "tag_value1")])
             .unwrap();
         assert_eq!(2, keys.len());
     }

--- a/server/src/optimizer/mod.rs
+++ b/server/src/optimizer/mod.rs
@@ -78,4 +78,8 @@ impl PhysicalOptimizerRule for LogPhysicalOptimizerRule {
     fn name(&self) -> &str {
         "log_physical_optimizer_rule"
     }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
 }

--- a/server/src/optimizer/model_simple_aggregates.rs
+++ b/server/src/optimizer/model_simple_aggregates.rs
@@ -753,7 +753,7 @@ impl Accumulator for ModelAvgAccumulator {
         unreachable!()
     }
 
- fn size(&self) -> usize {
+    fn size(&self) -> usize {
         mem::size_of_val(self)
     }
 }

--- a/server/src/optimizer/model_simple_aggregates.rs
+++ b/server/src/optimizer/model_simple_aggregates.rs
@@ -15,6 +15,7 @@
 use std::any::Any;
 use std::cmp::PartialEq;
 use std::fmt::{Display, Formatter};
+use std::mem;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, BinaryArray, Float32Array, Int64Array, UInt8Array};
@@ -127,6 +128,10 @@ impl PhysicalOptimizerRule for ModelSimpleAggregatesPhysicalOptimizerRule {
 
     fn name(&self) -> &str {
         "ModelSimpleAggregatesPhysicalOptimizerRule"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
     }
 }
 
@@ -319,6 +324,10 @@ impl Accumulator for ModelCountAccumulator {
     fn evaluate(&self) -> Result<ScalarValue> {
         unreachable!()
     }
+
+    fn size(&self) -> usize {
+        mem::size_of_val(self)
+    }
 }
 
 //Min
@@ -408,6 +417,10 @@ impl Accumulator for ModelMinAccumulator {
     fn evaluate(&self) -> Result<ScalarValue> {
         unreachable!()
     }
+
+    fn size(&self) -> usize {
+        mem::size_of_val(self)
+    }
 }
 
 //Max
@@ -496,6 +509,10 @@ impl Accumulator for ModelMaxAccumulator {
 
     fn evaluate(&self) -> Result<ScalarValue> {
         unreachable!()
+    }
+
+    fn size(&self) -> usize {
+        mem::size_of_val(self)
     }
 }
 
@@ -612,6 +629,10 @@ impl Accumulator for ModelSumAccumulator {
 
     fn evaluate(&self) -> Result<ScalarValue> {
         unreachable!()
+    }
+
+    fn size(&self) -> usize {
+        mem::size_of_val(self)
     }
 }
 
@@ -730,5 +751,9 @@ impl Accumulator for ModelAvgAccumulator {
 
     fn evaluate(&self) -> Result<ScalarValue> {
         unreachable!()
+    }
+
+ fn size(&self) -> usize {
+        mem::size_of_val(self)
     }
 }

--- a/server/src/parser.rs
+++ b/server/src/parser.rs
@@ -507,8 +507,8 @@ fn column_defs_to_schema(column_defs: &Vec<ColumnDef>) -> Result<Schema, DataFus
 // datafusion::arrow::datatypes::DataType and it was changed to a private instance method in
 // datafusion-sql v15.0.0. As Apache Arrow DataFusion no longer seems to provide an API for
 // converting from SQLDataType to DataType, the version of convert_simple_data_type() in
-// datafusion-sql v14.0.0 has been copied to parser.rs and have been updated according to the
-// changes made in datafusion-sql v15.0.0 to the greatest degree possible. As the private function
+// datafusion-sql v14.0.0 has been copied to parser.rs and has been updated according to the changes
+// made in datafusion-sql v15.0.0 to the greatest degree possible. As the private function
 // make_decimal_type() is used by convert_simple_data_type() it has also been copied from
 // datafusion-sql v15.0.0. As these functions have been copied from datafusion-sql they should be
 // updated whenever a new version of datafusion-sql is released. Also significant effort should be
@@ -518,7 +518,7 @@ fn column_defs_to_schema(column_defs: &Vec<ColumnDef>) -> Result<Schema, DataFus
 /// Convert a simple [`SQLDataType`] to the relational representation of the [`DataType`]. This
 /// function is copied from [datafusion-sql v14.0.0] and updated with the changes in [datafusion-sql
 /// v15.0.0] as it was changed from a public function to a private method in [datafusion-sql
-/// v15.0.0]. Both versions of datafusion-sql was released under Apache-2.0.
+/// v15.0.0]. Both versions of datafusion-sql were released under version 2.0 of the Apache License.
 ///
 /// [datafusion-sql v14.0.0]: https://github.com/apache/arrow-datafusion/blob/14.0.0/datafusion/sql/src/planner.rs#L2812
 /// [datafusion-sql v15.0.0]: https://github.com/apache/arrow-datafusion/blob/15.0.0/datafusion/sql/src/planner.rs#L2790
@@ -611,7 +611,7 @@ pub fn convert_simple_data_type(sql_type: &SQLDataType) -> DataFusionResult<Data
 }
 
 /// Return a validated [`DataType`] for the specified `precision` and `scale`. This function is
-/// copied from [datafusion-sql v15.0.0] which was released under Apache-2.0.
+/// copied from [datafusion-sql v15.0.0] which was released under version 2.0 of the Apache License.
 ///
 /// [datafusion-sql v15.0.0]: https://github.com/apache/arrow-datafusion/blob/15.0.0/datafusion/sql/src/utils.rs#L506
 fn make_decimal_type(precision: Option<u64>, scale: Option<u64>) -> DataFusionResult<DataType> {

--- a/server/src/parser.rs
+++ b/server/src/parser.rs
@@ -18,12 +18,14 @@
 //!
 //! [sqlparser]: https://crates.io/crates/sqlparser
 
-use datafusion::arrow::datatypes::{ArrowPrimitiveType, Field, Schema};
-use datafusion::common::DataFusionError;
-use datafusion_sql::planner;
+use datafusion::arrow::datatypes::{
+    ArrowPrimitiveType, DataType, Field, Schema, TimeUnit, DECIMAL128_MAX_PRECISION,
+    DECIMAL_DEFAULT_SCALE,
+};
+use datafusion::common::{DataFusionError, Result as DataFusionResult};
 use sqlparser::ast::{
-    ColumnDef, ColumnOption, ColumnOptionDef, DataType, HiveDistributionStyle, HiveFormat, Ident,
-    ObjectName, Statement, TimezoneInfo,
+    ColumnDef, ColumnOption, ColumnOptionDef, DataType as SQLDataType, ExactNumberInfo,
+    HiveDistributionStyle, HiveFormat, Ident, ObjectName, Statement, TimezoneInfo,
 };
 use sqlparser::dialect::{Dialect, GenericDialect};
 use sqlparser::keywords::Keyword;
@@ -107,7 +109,7 @@ impl ModelarDbDialect {
             let mut options = vec![];
 
             let data_type = match data_type.to_uppercase().as_str() {
-                "TIMESTAMP" => DataType::Timestamp(TimezoneInfo::None),
+                "TIMESTAMP" => SQLDataType::Timestamp(None, TimezoneInfo::None),
                 "FIELD" => {
                     // An error bound may also be specified for field columns.
                     let error_bound = if parser.peek_token() == Token::LParen {
@@ -126,9 +128,9 @@ impl ModelarDbDialect {
                         option: ColumnOption::Comment(error_bound.to_string()),
                     });
 
-                    DataType::Real
+                    SQLDataType::Real
                 }
-                "TAG" => DataType::Text,
+                "TAG" => SQLDataType::Text,
                 column_type => {
                     return Err(ParserError::ParserError(format!(
                         "Expected TIMESTAMP, FIELD, or TAG, found: {}.",
@@ -178,7 +180,7 @@ impl ModelarDbDialect {
     /// and `options`.
     fn new_column_def(
         column_name: &str,
-        data_type: DataType,
+        data_type: SQLDataType,
         options: Vec<ColumnOptionDef>,
     ) -> ColumnDef {
         ColumnDef {
@@ -356,7 +358,7 @@ fn semantic_checks_for_create_model_table(
     // Check that one timestamp column exists.
     let timestamp_column_indices = compute_indices_of_columns_with_data_type(
         &column_defs,
-        DataType::Timestamp(TimezoneInfo::None),
+        SQLDataType::Timestamp(None, TimezoneInfo::None),
     );
 
     if timestamp_column_indices.len() != 1 {
@@ -367,7 +369,7 @@ fn semantic_checks_for_create_model_table(
 
     // Compute the indices of the tag columns.
     let tag_column_indices =
-        compute_indices_of_columns_with_data_type(&column_defs, DataType::Text);
+        compute_indices_of_columns_with_data_type(&column_defs, SQLDataType::Text);
 
     // Extract the error bounds for the field columns.
     let error_bounds = extract_error_bounds_for_field_columns(column_defs)?;
@@ -464,7 +466,7 @@ fn check_unsupported_feature_is_disabled(enabled: bool, feature: &str) -> Result
 /// Compute the indices of all columns in `column_defs` with `data_type`.
 fn compute_indices_of_columns_with_data_type(
     column_defs: &Vec<ColumnDef>,
-    data_type: DataType,
+    data_type: SQLDataType,
 ) -> Vec<usize> {
     column_defs
         .iter()
@@ -480,11 +482,12 @@ fn column_defs_to_schema(column_defs: &Vec<ColumnDef>) -> Result<Schema, DataFus
     let mut fields = Vec::with_capacity(column_defs.len());
 
     for column_def in column_defs {
-        let data_type = if column_def.data_type == DataType::Timestamp(TimezoneInfo::None) {
+        let data_type = if column_def.data_type == SQLDataType::Timestamp(None, TimezoneInfo::None)
+        {
             // TIMESTAMP is manually converted as planner uses TimeUnit::Nanosecond.
             ArrowTimestamp::DATA_TYPE
         } else {
-            planner::convert_simple_data_type(&column_def.data_type)?
+            convert_simple_data_type(&column_def.data_type)?
         };
 
         fields.push(Field::new(
@@ -497,12 +500,147 @@ fn column_defs_to_schema(column_defs: &Vec<ColumnDef>) -> Result<Schema, DataFus
     Ok(Schema::new(fields))
 }
 
+/* Start of code copied from datafusion-sql v14.0.0/v15.0.0. */
+// The following two functions have been copied from datafusion-sql v14.0.0/v15.0.0 as parser.rs
+// used the version of convert_simple_data_type() implemented as a free function in datafusion-sql
+// v14.0.0 to convert from sqlparser::ast::DataType (SQLDataType) to
+// datafusion::arrow::datatypes::DataType and it was changed to a private instance method in
+// datafusion-sql v15.0.0. As Apache Arrow DataFusion no longer seems to provide an API for
+// converting from SQLDataType to DataType, the version of convert_simple_data_type() in
+// datafusion-sql v14.0.0 has been copied to parser.rs and have been updated according to the
+// changed made in datafusion-sql v15.0.0 to the greatest degree possible. As the private function
+// make_decimal_type() is used by convert_simple_data_type() it has also been copied from
+// datafusion-sql v15.0.0. As these functions have been copied from datafusion-sql they should be
+// updated whenever a new version of datafusion-sql is released. Also significant effort should be
+// made to try an replace these two functions with calls to Apache Arrow DataFusion's public API
+// whenever a new version of Apache Arrow DataFusion is released.
+
+// This function is copied from datafusion-sql v14.0.0/v15.0.0 which was released under Apache-2.0.
+// https://github.com/apache/arrow-datafusion/blob/14.0.0/datafusion/sql/src/planner.rs#L2812
+// https://github.com/apache/arrow-datafusion/blob/15.0.0/datafusion/sql/src/planner.rs#L2790
+/// Convert SQL simple data type to relational representation of data type
+pub fn convert_simple_data_type(sql_type: &SQLDataType) -> DataFusionResult<DataType> {
+    match sql_type {
+        SQLDataType::Boolean => Ok(DataType::Boolean),
+        SQLDataType::TinyInt(_) => Ok(DataType::Int8),
+        SQLDataType::SmallInt(_) => Ok(DataType::Int16),
+        SQLDataType::Int(_) | SQLDataType::Integer(_) => Ok(DataType::Int32),
+        SQLDataType::BigInt(_) => Ok(DataType::Int64),
+        SQLDataType::UnsignedTinyInt(_) => Ok(DataType::UInt8),
+        SQLDataType::UnsignedSmallInt(_) => Ok(DataType::UInt16),
+        SQLDataType::UnsignedInt(_) | SQLDataType::UnsignedInteger(_) => Ok(DataType::UInt32),
+        SQLDataType::UnsignedBigInt(_) => Ok(DataType::UInt64),
+        SQLDataType::Float(_) => Ok(DataType::Float32),
+        SQLDataType::Real => Ok(DataType::Float32),
+        SQLDataType::Double | SQLDataType::DoublePrecision => Ok(DataType::Float64),
+        SQLDataType::Char(_)
+        | SQLDataType::Varchar(_)
+        | SQLDataType::Text
+        | SQLDataType::String => Ok(DataType::Utf8),
+        SQLDataType::Timestamp(None, tz_info) => {
+            let tz = if matches!(tz_info, TimezoneInfo::Tz)
+                || matches!(tz_info, TimezoneInfo::WithTimeZone)
+            {
+                Some("+00:00".to_string())
+            } else {
+                None
+            };
+            Ok(DataType::Timestamp(TimeUnit::Nanosecond, tz))
+        }
+        SQLDataType::Date => Ok(DataType::Date32),
+        SQLDataType::Time(None, tz_info) => {
+            if matches!(tz_info, TimezoneInfo::None)
+                || matches!(tz_info, TimezoneInfo::WithoutTimeZone)
+            {
+                Ok(DataType::Time64(TimeUnit::Nanosecond))
+            } else {
+                // We don't support TIMETZ and TIME WITH TIME ZONE for now.
+                Err(DataFusionError::NotImplemented(format!(
+                    "Unsupported SQL type {:?}",
+                    sql_type
+                )))
+            }
+        }
+        SQLDataType::Numeric(exact_number_info)
+        |SQLDataType::Decimal(exact_number_info) => {
+            let (precision, scale) = match *exact_number_info {
+                ExactNumberInfo::None => (None, None),
+                ExactNumberInfo::Precision(precision) => (Some(precision), None),
+                ExactNumberInfo::PrecisionAndScale(precision, scale) => {
+                    (Some(precision), Some(scale))
+                }
+            };
+            make_decimal_type(precision, scale)
+        }
+        SQLDataType::Bytea => Ok(DataType::Binary),
+        // Explicitly list all other types so that if sqlparser
+        // adds/changes the `SQLDataType` the compiler will tell us on upgrade
+        // and avoid bugs like https://github.com/apache/arrow-datafusion/issues/3059.
+        SQLDataType::Nvarchar(_)
+        | SQLDataType::Uuid
+        | SQLDataType::Binary(_)
+        | SQLDataType::Varbinary(_)
+        | SQLDataType::Blob(_)
+        | SQLDataType::Datetime(_)
+        | SQLDataType::Interval
+        | SQLDataType::Regclass
+        | SQLDataType::Custom(_, _)
+        | SQLDataType::Array(_)
+        | SQLDataType::Enum(_)
+        | SQLDataType::Set(_)
+        | SQLDataType::MediumInt(_)
+        | SQLDataType::UnsignedMediumInt(_)
+        | SQLDataType::Character(_)
+        | SQLDataType::CharacterVarying(_)
+        | SQLDataType::CharVarying(_)
+        | SQLDataType::CharacterLargeObject(_)
+        | SQLDataType::CharLargeObject(_)
+        // Precision is not supported.
+        | SQLDataType::Timestamp(Some(_), _)
+        // Precision is not supported.
+        | SQLDataType::Time(Some(_), _)
+        | SQLDataType::Dec(_)
+        | SQLDataType::Clob(_) => Err(DataFusionError::NotImplemented(format!(
+            "Unsupported SQL type {:?}",
+            sql_type
+        ))),
+    }
+}
+
+// This function is copied from datafusion-sql v15.0.0 which was released under Apache-2.0.
+// https://github.com/apache/arrow-datafusion/blob/15.0.0/datafusion/sql/src/utils.rs#L506
+/// Returns a validated `DataType` for the specified precision and scale.
+fn make_decimal_type(precision: Option<u64>, scale: Option<u64>) -> DataFusionResult<DataType> {
+    // PostgreSQL like behavior.
+    let (precision, scale) = match (precision, scale) {
+        (Some(p), Some(s)) => (p as u8, s as i8),
+        (Some(p), None) => (p as u8, 0),
+        (None, Some(_)) => {
+            return Err(DataFusionError::Internal(
+                "Cannot specify only scale for decimal data type".to_string(),
+            ))
+        }
+        (None, None) => (DECIMAL128_MAX_PRECISION, DECIMAL_DEFAULT_SCALE),
+    };
+
+    // Apache Arrow decimal is i128 meaning 38 maximum decimal digits.
+    if precision == 0 || precision > DECIMAL128_MAX_PRECISION || scale.unsigned_abs() > precision {
+        Err(DataFusionError::Internal(format!(
+            "Decimal(precision = {}, scale = {}) should satisfy `0 < precision <= 38`, and `scale <= precision`.",
+            precision, scale
+        )))
+    } else {
+        Ok(DataType::Decimal128(precision, scale))
+    }
+}
+/* End of code copied from datafusion-sql v14.0.0/v15.0.0. */
+
 /// Extract the error bounds from the fields columns in `column_defs`.
 fn extract_error_bounds_for_field_columns(
     column_defs: &Vec<ColumnDef>,
 ) -> Result<Vec<ErrorBound>, ParserError> {
     let field_column_indices =
-        compute_indices_of_columns_with_data_type(column_defs, DataType::Real);
+        compute_indices_of_columns_with_data_type(column_defs, SQLDataType::Real);
     let mut error_bounds = vec![];
 
     for field_column_index in field_column_indices {
@@ -545,20 +683,20 @@ mod tests {
             let expected_columns = vec![
                 ModelarDbDialect::new_column_def(
                     "timestamp",
-                    DataType::Timestamp(TimezoneInfo::None),
+                    SQLDataType::Timestamp(None, TimezoneInfo::None),
                     vec![],
                 ),
                 ModelarDbDialect::new_column_def(
                     "field_one",
-                    DataType::Real,
+                    SQLDataType::Real,
                     new_column_option_def_error_bound(0),
                 ),
                 ModelarDbDialect::new_column_def(
                     "field_two",
-                    DataType::Real,
+                    SQLDataType::Real,
                     new_column_option_def_error_bound(10),
                 ),
-                ModelarDbDialect::new_column_def("tag", DataType::Text, vec![]),
+                ModelarDbDialect::new_column_def("tag", SQLDataType::Text, vec![]),
             ];
             assert!(columns == expected_columns);
         } else {
@@ -599,7 +737,7 @@ mod tests {
         assert!(tokenize_and_parse_sql(
             "CREATE TABLE table_name(timestamp TIMESTAMP, field FIELD, field FIELD(10), tag TAG)",
         )
-        .is_err());
+        .is_ok());
     }
 
     #[test]

--- a/server/src/parser.rs
+++ b/server/src/parser.rs
@@ -508,17 +508,20 @@ fn column_defs_to_schema(column_defs: &Vec<ColumnDef>) -> Result<Schema, DataFus
 // datafusion-sql v15.0.0. As Apache Arrow DataFusion no longer seems to provide an API for
 // converting from SQLDataType to DataType, the version of convert_simple_data_type() in
 // datafusion-sql v14.0.0 has been copied to parser.rs and have been updated according to the
-// changed made in datafusion-sql v15.0.0 to the greatest degree possible. As the private function
+// changes made in datafusion-sql v15.0.0 to the greatest degree possible. As the private function
 // make_decimal_type() is used by convert_simple_data_type() it has also been copied from
 // datafusion-sql v15.0.0. As these functions have been copied from datafusion-sql they should be
 // updated whenever a new version of datafusion-sql is released. Also significant effort should be
-// made to try an replace these two functions with calls to Apache Arrow DataFusion's public API
+// made to try and replace these two functions with calls to Apache Arrow DataFusion's public API
 // whenever a new version of Apache Arrow DataFusion is released.
 
-// This function is copied from datafusion-sql v14.0.0/v15.0.0 which was released under Apache-2.0.
-// https://github.com/apache/arrow-datafusion/blob/14.0.0/datafusion/sql/src/planner.rs#L2812
-// https://github.com/apache/arrow-datafusion/blob/15.0.0/datafusion/sql/src/planner.rs#L2790
-/// Convert SQL simple data type to relational representation of data type
+/// Convert a simple [`SQLDataType`] to the relational representation of the [`DataType`]. This
+/// function is copied from [datafusion-sql v14.0.0] and updated with the changes in [datafusion-sql
+/// v15.0.0] as it was changed from a public function to a private method in [datafusion-sql
+/// v15.0.0]. Both versions of datafusion-sql was released under Apache-2.0.
+///
+/// [datafusion-sql v14.0.0]: https://github.com/apache/arrow-datafusion/blob/14.0.0/datafusion/sql/src/planner.rs#L2812
+/// [datafusion-sql v15.0.0]: https://github.com/apache/arrow-datafusion/blob/15.0.0/datafusion/sql/src/planner.rs#L2790
 pub fn convert_simple_data_type(sql_type: &SQLDataType) -> DataFusionResult<DataType> {
     match sql_type {
         SQLDataType::Boolean => Ok(DataType::Boolean),
@@ -562,7 +565,7 @@ pub fn convert_simple_data_type(sql_type: &SQLDataType) -> DataFusionResult<Data
             }
         }
         SQLDataType::Numeric(exact_number_info)
-        |SQLDataType::Decimal(exact_number_info) => {
+        | SQLDataType::Decimal(exact_number_info) => {
             let (precision, scale) = match *exact_number_info {
                 ExactNumberInfo::None => (None, None),
                 ExactNumberInfo::Precision(precision) => (Some(precision), None),
@@ -607,9 +610,10 @@ pub fn convert_simple_data_type(sql_type: &SQLDataType) -> DataFusionResult<Data
     }
 }
 
-// This function is copied from datafusion-sql v15.0.0 which was released under Apache-2.0.
-// https://github.com/apache/arrow-datafusion/blob/15.0.0/datafusion/sql/src/utils.rs#L506
-/// Returns a validated `DataType` for the specified precision and scale.
+/// Return a validated [`DataType`] for the specified `precision` and `scale`. This function is
+/// copied from [datafusion-sql v15.0.0] which was released under Apache-2.0.
+///
+/// [datafusion-sql v15.0.0]: https://github.com/apache/arrow-datafusion/blob/15.0.0/datafusion/sql/src/utils.rs#L506
 fn make_decimal_type(precision: Option<u64>, scale: Option<u64>) -> DataFusionResult<DataType> {
     // PostgreSQL like behavior.
     let (precision, scale) = match (precision, scale) {
@@ -617,7 +621,7 @@ fn make_decimal_type(precision: Option<u64>, scale: Option<u64>) -> DataFusionRe
         (Some(p), None) => (p as u8, 0),
         (None, Some(_)) => {
             return Err(DataFusionError::Internal(
-                "Cannot specify only scale for decimal data type".to_string(),
+                "Cannot specify only scale for decimal data type.".to_string(),
             ))
         }
         (None, None) => (DECIMAL128_MAX_PRECISION, DECIMAL_DEFAULT_SCALE),


### PR DESCRIPTION
This PR primarily updates Apache Arrow DataFusion to [v15.0.0](https://crates.io/crates/datafusion/15.0.0) and fixes all known breaking changes. New versions of Apache Arrow DataFusion usually have breaking changes, so updating to each new release ensures that the number of changes required does not accumulate. The changes in v15.0.0 generally only required minor fixes for the code and the tests. However, as `convert_simple_data_type()` has been changed from a public function in Apache Arrow DataFusion [v14.0.0](https://github.com/apache/arrow-datafusion/blob/14.0.0/datafusion/sql/src/planner.rs#L2812) to a private method in Apache Arrow DataFusion [v15.0.0](https://github.com/apache/arrow-datafusion/blob/15.0.0/datafusion/sql/src/planner.rs#L2790) without the addition of a new alternative API for translating types, the v14.0.0 version of `convert_simple_data_type()` and a private function it calls had to be copied to [parser.rs.](https://github.com/ModelarData/ModelarDB-RS/blob/dev/update-dependencies/server/src/parser.rs#L503) until an alternative solution can be found.