### PR TITLE
Use ParquetRecordBatchStream in StorageEngine

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -266,7 +266,13 @@ fn setup_ctrl_c_handler(context: &Arc<Context>, runtime: &Arc<Runtime>) {
         // Errors are consciously ignored as the program should terminate if the
         // handler cannot be registered as buffers otherwise cannot be flushed.
         tokio::signal::ctrl_c().await.unwrap();
-        ctrl_c_context.storage_engine.write().await.flush().unwrap();
+        ctrl_c_context
+            .storage_engine
+            .write()
+            .await
+            .flush()
+            .await
+            .unwrap();
         std::process::exit(0)
     });
 }

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -1195,12 +1195,15 @@ pub mod test_util {
     pub fn get_test_context(path: &Path) -> Arc<Context> {
         let metadata_manager = get_test_metadata_manager(path);
         let session = get_test_session_context();
-        let storage_engine = RwLock::new(StorageEngine::new(
-            None,
-            path.to_owned(),
-            metadata_manager.clone(),
-            true,
-        ));
+        let runtime = Runtime::new().unwrap();
+        let storage_engine = RwLock::new(
+            runtime
+                .block_on(async {
+                    StorageEngine::try_new(path.to_owned(), None, metadata_manager.clone(), true)
+                        .await
+                })
+                .unwrap(),
+        );
 
         Arc::new(Context {
             metadata_manager,

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 
 use bytes::BufMut;
 use datafusion::arrow::compute;
-use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::parquet::errors::ParquetError;
 use futures::StreamExt;
 use object_store::local::LocalFileSystem;
@@ -156,36 +155,39 @@ impl DataTransfer {
     /// Once successfully transferred, the data is deleted from local storage. Return [`Ok`] if the
     /// files were transferred successfully, otherwise [`ParquetError`].
     async fn transfer_data(&mut self, table_name: &str) -> Result<(), ParquetError> {
-        // Read all files that correspond stored for the table with table_name.
+        // Read all files that is currently stored for the table with table_name.
         let path = format!("compressed/{}", table_name).into();
-        let list_stream = self
+        let object_metas = self
             .local_data_folder_object_store
             .list(Some(&path))
             .await
-            .map_err(|error: object_store::Error| ParquetError::General(error.to_string()))?;
+            .map_err(|error: object_store::Error| ParquetError::General(error.to_string()))?
+            .filter_map(|maybe_meta| async { maybe_meta.ok() });
 
-        let object_metas = list_stream
-            .filter_map(|maybe_meta| async { maybe_meta.ok() })
-            .collect::<Vec<_>>()
-            .await
-            .into_iter();
+        // Combine the Apache Parquet files into a single RecordBatch.
+        let read_object_metas_and_record_batches = object_metas.filter_map(|meta| async {
+            let path = self.local_data_folder_path.to_string_lossy();
+            let file_path = PathBuf::from(format!("{}/{}", path, meta.location));
+
+            // The path of the Apache Parquet files read to produce the record batches are also
+            // returned to ensure that only the read files are deleted after the transfer.
+            if let Ok(record_batch) =
+                StorageEngine::read_batch_from_apache_parquet_file(file_path.as_path()).await
+            {
+                Some((meta, record_batch))
+            } else {
+                None
+            }
+        });
+
+        let (read_object_metas, record_batches): (Vec<_>, Vec<_>) =
+            read_object_metas_and_record_batches.unzip().await;
 
         debug!(
             "Transferring {} compressed files for the table '{}'.",
-            object_metas.len(),
+            read_object_metas.len(),
             table_name
         );
-
-        // Combine the Apache Parquet files into a single RecordBatch.
-        let record_batches = object_metas
-            .clone()
-            .filter_map(|meta| {
-                let path = self.local_data_folder_path.to_string_lossy();
-                let file_path = PathBuf::from(format!("{}/{}", path, meta.location));
-
-                StorageEngine::read_batch_from_apache_parquet_file(file_path.as_path()).ok()
-            })
-            .collect::<Vec<RecordBatch>>();
 
         let schema = record_batches[0].schema();
         let combined = compute::concat_batches(&schema, &record_batches)?;
@@ -210,7 +212,7 @@ impl DataTransfer {
             .map_err(|error: object_store::Error| ParquetError::General(error.to_string()))?;
 
         // Delete the transferred files from local storage.
-        for meta in object_metas.clone() {
+        for meta in &read_object_metas {
             self.local_data_folder_object_store
                 .delete(&meta.location)
                 .await
@@ -218,7 +220,7 @@ impl DataTransfer {
         }
 
         // Delete the transferred files from the in-memory tracking of compressed files.
-        let transferred_bytes: usize = object_metas.map(|meta| meta.size).sum();
+        let transferred_bytes: usize = read_object_metas.iter().map(|meta| meta.size).sum();
         *self.compressed_files.get_mut(table_name).unwrap() -= transferred_bytes;
 
         debug!(
@@ -380,7 +382,7 @@ mod tests {
             .unwrap();
         data_transfer.transfer_data(&TABLE_NAME).await.unwrap();
 
-        assert_data_transferred(vec![parquet_path], target_dir, data_transfer);
+        assert_data_transferred(vec![parquet_path], target_dir, data_transfer).await;
     }
 
     #[tokio::test]
@@ -400,7 +402,7 @@ mod tests {
             .unwrap();
         data_transfer.transfer_data(&TABLE_NAME).await.unwrap();
 
-        assert_data_transferred(vec![path_1, path_2], target_dir, data_transfer);
+        assert_data_transferred(vec![path_1, path_2], target_dir, data_transfer).await;
     }
 
     #[tokio::test]
@@ -416,7 +418,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_data_transferred(vec![parquet_path], target_dir, data_transfer);
+        assert_data_transferred(vec![parquet_path], target_dir, data_transfer).await;
     }
 
     #[tokio::test]
@@ -429,7 +431,7 @@ mod tests {
         // Since the max batch size is 1 byte smaller than 3 compressed files, the data should be transferred immediately.
         let (target_dir, data_transfer) = create_data_transfer_component(temp_dir.path()).await;
 
-        assert_data_transferred(vec![path_1, path_2, path_3], target_dir, data_transfer);
+        assert_data_transferred(vec![path_1, path_2, path_3], target_dir, data_transfer).await;
     }
 
     #[tokio::test]
@@ -441,12 +443,16 @@ mod tests {
 
         data_transfer.flush().await.unwrap();
 
-        assert_data_transferred(vec![path_1, path_2], target_dir, data_transfer);
+        assert_data_transferred(vec![path_1, path_2], target_dir, data_transfer).await;
     }
 
     /// Assert that the files in `paths` are all removed, a file has been created in `target_dir`,
     /// and that the hashmap containing the compressed files size is set to 0.
-    fn assert_data_transferred(paths: Vec<PathBuf>, target: TempDir, data_transfer: DataTransfer) {
+    async fn assert_data_transferred(
+        paths: Vec<PathBuf>,
+        target: TempDir,
+        data_transfer: DataTransfer,
+    ) {
         for path in &paths {
             assert!(!path.exists());
         }
@@ -458,8 +464,9 @@ mod tests {
         assert!(target_path.exists());
 
         // The file should have 3 * number_of_files rows since each compressed file has 3 rows.
-        let batch =
-            StorageEngine::read_batch_from_apache_parquet_file(target_path.as_path()).unwrap();
+        let batch = StorageEngine::read_batch_from_apache_parquet_file(target_path.as_path())
+            .await
+            .unwrap();
         assert_eq!(batch.num_rows(), 3 * paths.len());
 
         assert_eq!(

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -43,6 +43,7 @@ use crate::{storage, StorageEngine};
 //       transferring the same data multiple times or deleting files that are currently used
 //       elsewhere.
 
+#[allow(dead_code)]
 pub struct DataTransfer {
     /// Path to the folder containing all compressed data managed by the [`StorageEngine`].
     local_data_folder_path: PathBuf,
@@ -108,6 +109,7 @@ impl DataTransfer {
         Ok(data_transfer)
     }
 
+    #[allow(dead_code)]
     /// Insert the compressed file into the files to be transferred. Retrieve the size of the file
     /// and add it to the total size of the current local files in the table with `table_name`.
     pub async fn add_compressed_file(

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -36,13 +36,15 @@ use std::sync::Arc;
 use datafusion::arrow::compute::kernels::aggregate;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use datafusion::parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
 use datafusion::parquet::arrow::ArrowWriter;
 use datafusion::parquet::basic::Compression;
 use datafusion::parquet::errors::ParquetError;
 use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
+use futures::StreamExt;
 use object_store::path::Path as ObjectStorePath;
 use object_store::{ObjectMeta, ObjectStore};
+use tokio::fs::File as TokioFile;
 use tonic::Status;
 
 use crate::errors::ModelarDbError;
@@ -136,17 +138,16 @@ impl StorageEngine {
 
     /// Pass `data_points` to [`UncompressedDataManager`]. Return [`Ok`] if all of the data points
     /// were successfully inserted, otherwise return [`Err`].
-    pub fn insert_data_points(
+    pub async fn insert_data_points(
         &mut self,
         model_table: &ModelTableMetadata,
         data_points: &RecordBatch,
     ) -> Result<(), String> {
         // TODO: When the compression component is changed, just insert the data points.
-        let compressed_segments = self.uncompressed_data_manager.insert_data_points(
-            &mut self.metadata_manager,
-            model_table,
-            data_points,
-        )?;
+        let compressed_segments = self
+            .uncompressed_data_manager
+            .insert_data_points(&mut self.metadata_manager, model_table, data_points)
+            .await?;
 
         for segments in compressed_segments {
             self.compressed_data_manager
@@ -168,10 +169,10 @@ impl StorageEngine {
 
     /// Flush all of the data the [`StorageEngine`] is currently storing in memory to disk. If all
     /// of the data is successfully flushed to disk, return [`Ok`], otherwise return [`String`].
-    pub fn flush(&mut self) -> Result<(), String> {
+    pub async fn flush(&mut self) -> Result<(), String> {
         // TODO: When the compression component is changed, just flush before managers.
         // Flush UncompressedDataManager.
-        let compressed_buffers = self.uncompressed_data_manager.flush();
+        let compressed_buffers = self.uncompressed_data_manager.flush().await;
         let hash_to_table_name = self
             .metadata_manager
             .get_mapping_from_hash_to_table_name()
@@ -295,7 +296,7 @@ impl StorageEngine {
     /// Read all rows from the Apache Parquet file at the location given by `file_path` and return
     /// them as a [`RecordBatch`]. If the file could not be read successfully, [`ParquetError`] is
     /// returned.
-    pub fn read_batch_from_apache_parquet_file(
+    pub async fn read_batch_from_apache_parquet_file(
         file_path: &Path,
     ) -> Result<RecordBatch, ParquetError> {
         let error = ParquetError::General(format!(
@@ -303,12 +304,14 @@ impl StorageEngine {
             file_path.display()
         ));
 
-        // Create a reader that can be used to read an Apache Parquet file.
-        let file = File::open(file_path).map_err(|_e| error.clone())?;
-        let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
-        let mut reader = builder.with_batch_size(usize::MAX).build()?;
+        // Create a stream that can be used to read an Apache Parquet file.
+        let file = TokioFile::open(file_path)
+            .await
+            .map_err(|_e| error.clone())?;
+        let builder = ParquetRecordBatchStreamBuilder::new(file).await?;
+        let mut stream = builder.with_batch_size(usize::MAX).build()?;
 
-        let record_batch = reader.next().ok_or(error)??;
+        let record_batch = stream.next().await.ok_or(error)??;
         Ok(record_batch)
     }
 
@@ -786,35 +789,35 @@ mod tests {
         assert!(!parquet_path.exists());
     }
 
-    #[test]
-    fn test_read_entire_apache_parquet_file() {
+    #[tokio::test]
+    async fn test_read_entire_apache_parquet_file() {
         let file_name = "test.parquet".to_owned();
         let (_temp_dir, path, batch) = create_apache_parquet_file_in_temp_dir(file_name);
 
-        let result = StorageEngine::read_batch_from_apache_parquet_file(path.as_path());
+        let result = StorageEngine::read_batch_from_apache_parquet_file(path.as_path()).await;
 
         assert!(result.is_ok());
         assert_eq!(batch, result.unwrap());
     }
 
-    #[test]
-    fn test_read_from_non_apache_parquet_file() {
+    #[tokio::test]
+    async fn test_read_from_non_apache_parquet_file() {
         let temp_dir = tempdir().unwrap();
         let path = temp_dir.path().join("test.txt");
         File::create(path.clone()).unwrap();
 
         let result = StorageEngine::read_batch_from_apache_parquet_file(path.as_path());
 
-        assert!(result.is_err());
+        assert!(result.await.is_err());
     }
 
-    #[test]
-    fn test_read_from_non_existent_path() {
+    #[tokio::test]
+    async fn test_read_from_non_existent_path() {
         let temp_dir = tempdir().unwrap();
         let path = temp_dir.path().join("none.parquet");
         let result = StorageEngine::read_batch_from_apache_parquet_file(path.as_path());
 
-        assert!(result.is_err());
+        assert!(result.await.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR replaces [`ParquetRecordBatchReader`](https://docs.rs/parquet/latest/parquet/arrow/arrow_reader/struct.ParquetRecordBatchReader.html) with the async [`ParquetRecordBatchStream`](https://docs.rs/parquet/latest/parquet/arrow/async_reader/struct.ParquetRecordBatchStream.html) in [`StorageEngine.read_batch_from_apache_parquet_file()`](https://github.com/ModelarData/ModelarDB-RS/blob/dev/storage-async/server/src/storage/mod.rs#L311) and moves creation of [`DataTransfer`](https://github.com/ModelarData/ModelarDB-RS/blob/dev/storage-async/server/src/storage/data_transfer.rs) to [`StorageEngine::try_new()`](https://github.com/ModelarData/ModelarDB-RS/blob/dev/storage-async/server/src/storage/mod.rs#L96). The scope of this PR was initially to make reading from and writing to local storage async, but this does not currently seem possible as the [`parquet`](https://docs.rs/parquet/29.0.0/parquet/index.html) crate does not seem to provide an async [`ArrowWriter`](https://docs.rs/parquet/latest/parquet/arrow/arrow_writer/struct.ArrowWriter.html) and [`rusqlite`](https://docs.rs/rusqlite/latest/rusqlite/) does not seem to provide an async API 
