### PR TITLE
Add irregular time series testing and randomly generated data to current tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,6 +1781,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "proptest",
+ "rand",
  "rusqlite",
  "serial_test",
  "snmalloc-rs",
@@ -1790,6 +1791,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "tracing-futures",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,7 +1791,6 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
- "tracing-futures",
  "tracing-subscriber",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,7 +24,6 @@ tonic = "0.8.3"
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }
 tracing = { version = "0.1.37", features = ["max_level_debug", "release_max_level_info"] }
 tracing-subscriber = "0.3.16"
-tracing-futures = "0.2.5"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,6 +23,20 @@ tonic = "0.8.3"
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }
 tracing = { version = "0.1.37", features = ["max_level_debug", "release_max_level_info"] }
 tracing-subscriber = "0.3.16"
+tracing-futures = "0.2.5"
+
+tokio = { version = "1.22.0", features = ["rt-multi-thread", "signal"] }
+
+async-trait = "0.1.59"
+futures = "0.3.25"
+
+arrow-flight = "28.0.0"
+tonic = "0.8.3"
+
+parking_lot = "0.12.1"
+snmalloc-rs = "0.3.3"
+
+rusqlite = { version = "0.28.0", features = ["bundled"] }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,6 +13,7 @@ datafusion = "15.0.0"
 futures = "0.3.25"
 object_store = { version = "0.5.1", features = ["aws"] }
 parking_lot = "0.12.1"
+rand = "0.8.5"
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 snmalloc-rs = "0.3.3"
 sqlparser = "0.27.0"
@@ -24,19 +25,6 @@ log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_in
 tracing = { version = "0.1.37", features = ["max_level_debug", "release_max_level_info"] }
 tracing-subscriber = "0.3.16"
 tracing-futures = "0.2.5"
-
-tokio = { version = "1.22.0", features = ["rt-multi-thread", "signal"] }
-
-async-trait = "0.1.59"
-futures = "0.3.25"
-
-arrow-flight = "28.0.0"
-tonic = "0.8.3"
-
-parking_lot = "0.12.1"
-snmalloc-rs = "0.3.3"
-
-rusqlite = { version = "0.28.0", features = ["bundled"] }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -457,7 +457,7 @@ mod tests {
             &uncompressed_timestamps,
             &uncompressed_values,
             error_bound,
-            &test_util::get_compressed_schema(),
+            &test_util::compressed_schema(),
         )
         .unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
@@ -503,7 +503,7 @@ mod tests {
             &uncompressed_timestamps,
             &uncompressed_values,
             error_bound,
-            &test_util::get_compressed_schema(),
+            &test_util::compressed_schema(),
         )
         .unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
@@ -595,7 +595,7 @@ mod tests {
             &uncompressed_timestamps,
             &uncompressed_values,
             error_bound,
-            &test_util::get_compressed_schema(),
+            &test_util::compressed_schema(),
         )
         .unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
@@ -779,9 +779,9 @@ mod tests {
 
 #[cfg(test)]
 /// Separate module for utility functions
-pub mod test_util{
-    use rand::{Rng, thread_rng};
+pub mod test_util {
     use rand::distributions::Uniform;
+    use rand::{thread_rng, Rng};
 
     /// Function for generating constant/random/linear/random-linear test data with the [ThreadRng](rand::rngs::thread::ThreadRng) randomizer.
     ///

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -397,8 +397,8 @@ impl CompressedSegmentBatchBuilder {
 mod tests {
     use super::*;
 
-    use datafusion::arrow::array::UInt8Array;
     use crate::compression::test_util::{generate_data, generate_timestamps};
+    use datafusion::arrow::array::UInt8Array;
 
     use crate::metadata::test_util;
     use crate::models;
@@ -798,7 +798,6 @@ pub mod test_util {
         let mut values: Vec<f32> = vec![];
 
         match (linear, random) {
-
             // Generates almost linear data.
             (true, true) => {
                 let mut random_linear = vec![];
@@ -831,10 +830,9 @@ pub mod test_util {
                 values.append(&mut random);
             }
 
-            // Generates randomly selected constant data.
+            // Generates constant data.
             (false, false) => {
-                let mut constant =
-                    vec![10.0; length as usize];
+                let mut constant = vec![10.0; length as usize];
                 values.append(&mut constant);
             }
         }

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -778,29 +778,15 @@ mod tests {
 }
 
 #[cfg(test)]
-/// Separate module for utility functions
+/// Separate module for utility functions.
 pub mod test_util {
     use rand::distributions::Uniform;
     use rand::{thread_rng, Rng};
 
-    /// Function for generating constant/random/linear/random-linear test data with the [ThreadRng](rand::rngs::thread::ThreadRng) randomizer.
-    ///
-    /// # Arguments
-    ///
-    /// * `length` - Indicates how many data-points should be generated.
-    /// * `linear` - Indicates if the data should be linear.
-    /// * `random` - Indicates if the data should be randomized.
-    /// * `min_step` - Indicates the minimum change that should be applied from one data point to the next when randomizing data. Have to be set if `random` is set to `true`.
-    /// * `max_step` - Indicates the maximum change that should be applied from one data point to the next when randomizing data. Have to be set if `random` is set to `true`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let constant_data = generate_data(100, false, false, None, None);
-    /// let random_data = generate_data(100, false, true, Some(10.0), Some(20.0));
-    /// let linear_data = generate_data(100, true, false, None, None);
-    /// let random_linear = generate_data(100, true, true, Some(9.0), Some(11.0));
-    /// ```
+    /// Generate constant/random/linear/almost-linear test data with the [ThreadRng](rand::rngs::thread::ThreadRng) randomizer.
+    /// Select the length and type of data to be generated using the parameters `length`, `linear` and `random`. If `random` is set to true, select
+    /// the maximum and minimum change that should be applied from one data point to the next using the `min_step` and `max_step` parameters.
+    /// Returns the generated data as a [`Vec`].
     pub fn generate_data(
         length: u16,
         linear: bool,
@@ -812,6 +798,8 @@ pub mod test_util {
         let mut values: Vec<f32> = vec![];
 
         match (linear, random) {
+
+            // Generates almost linear data.
             (true, true) => {
                 let mut random_linear = vec![];
                 let mut previous_value: f32 = 0.0;
@@ -824,11 +812,15 @@ pub mod test_util {
                 }
                 values.append(&mut random_linear);
             }
+
+            // Generates linear data.
             (true, false) => {
                 let mut linear =
                     Vec::from_iter((10..(length + 1) * 10).step_by(10).map(|v| v as f32));
                 values.append(&mut linear);
             }
+
+            // Generates randomized data.
             (false, true) => {
                 let mut random = vec![];
                 for _ in 0..length {
@@ -838,9 +830,11 @@ pub mod test_util {
                 }
                 values.append(&mut random);
             }
+
+            // Generates randomly selected constant data.
             (false, false) => {
                 let mut constant =
-                    vec![randomizer.sample(Uniform::from(0.0..f32::MAX)); length as usize];
+                    vec![10.0; length as usize];
                 values.append(&mut constant);
             }
         }
@@ -848,19 +842,9 @@ pub mod test_util {
         values
     }
 
-    /// Function for generating regular/irregular timestamps with the [ThreadRng](rand::rngs::thread::ThreadRng) randomizer.
-    ///
-    /// # Arguments
-    ///
-    /// * `length` - Indicates how many timestamps should be generated.
-    /// * `irregular` - Indicates if the timestamps should be regular or irregular.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let regular_timestamps = generate_timestamps(100, false);
-    /// let irregular_timestamps = generate_timestamps(100, true);
-    /// ```
+    /// Generate regular/irregular timestamps with the [ThreadRng](rand::rngs::thread::ThreadRng) randomizer.
+    /// Select the length and type of timestamps to be generated using the parameters `length` and `irregular`.
+    /// Returns the generated timestamps as a [`Vec`].
     pub fn generate_timestamps(length: usize, irregular: bool) -> Vec<i64> {
         let mut randomizer = thread_rng();
         let mut timestamps = vec![];

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -425,8 +425,8 @@ mod tests {
 
     #[test]
     fn test_try_compress_regular_constant_time_series() {
-        let values = generate_test_data(100,  false, false, None, None);
-        let timestamps = Vec::from_iter((100..(values.len() + 1) as i64 * 100).step_by(100));
+        let values = generate_data(100, false, false, None, None);
+        let timestamps = generate_timestamps(values.len(), false);
         let (uncompressed_timestamps, uncompressed_values) =
             create_uncompressed_time_series(&timestamps, &values);
         let error_bound = ErrorBound::try_new(0.0).unwrap();
@@ -448,22 +448,31 @@ mod tests {
 
     #[test]
     fn test_try_compress_irregular_constant_time_series(){
-        let mut randomizer = thread_rng();
-        let mut timestamps: Vec<i64> = vec![];
-        let mut previous_timestamp: i64 = 0;
-        for _ in 0..10 {
-            let next_timestamp =
-                (randomizer.sample(Uniform::from(10..100))) + previous_timestamp;
-            timestamps.push(next_timestamp);
-            previous_timestamp = next_timestamp;
-        }
+        let values = generate_data(100, false, false, None, None);
+        let timestamps = generate_timestamps(values.len(), true);
+        let (uncompressed_timestamps, uncompressed_values) =
+            create_uncompressed_time_series(&timestamps, &values);
+        let error_bound = ErrorBound::try_new(0.0).unwrap();
+
+        let compressed_record_batch = try_compress(
+            &uncompressed_timestamps,
+            &uncompressed_values,
+            error_bound,
+            &test_util::get_compressed_schema(),
+        )
+            .unwrap();
+        assert_compressed_record_batch_with_segments_from_regular_time_series(
+            &uncompressed_timestamps,
+            &compressed_record_batch,
+            &[models::PMC_MEAN_ID],
+        )
     }
 
     #[test]
     fn test_try_compress_regular_almost_constant_time_series() {
         let values =
-            generate_test_data(100, false, true, Some(9.8), Some(10.2));
-        let timestamps = Vec::from_iter((100..(values.len() + 1) as i64 * 100).step_by(100));
+            generate_data(100, false, true, Some(9.8), Some(10.2));
+        let timestamps = generate_timestamps(values.len(), false);
         let (uncompressed_timestamps, uncompressed_values) =
             create_uncompressed_time_series(&timestamps, &values);
         let error_bound = ErrorBound::try_new(5.0).unwrap();
@@ -484,9 +493,40 @@ mod tests {
     }
 
     #[test]
+    fn test_try_compress_irregular_almost_constant_time_series() {
+        let mut randomizer = thread_rng();
+        let values =
+            generate_data(100, false, true, Some(9.8), Some(10.2));
+        let mut timestamps: Vec<i64> = vec![];
+        let mut previous_timestamp: i64 = 0;
+        for _ in 0..values.len() {
+            let next_timestamp =
+                (randomizer.sample(Uniform::from(10..100))) + previous_timestamp;
+            timestamps.push(next_timestamp);
+            previous_timestamp = next_timestamp;
+        }
+        let (uncompressed_timestamps, uncompressed_values) =
+            create_uncompressed_time_series(&timestamps, &values);
+        let error_bound = ErrorBound::try_new(5.0).unwrap();
+
+        let compressed_record_batch = try_compress(
+            &uncompressed_timestamps,
+            &uncompressed_values,
+            error_bound,
+            &test_util::get_compressed_schema(),
+        )
+            .unwrap();
+        assert_compressed_record_batch_with_segments_from_regular_time_series(
+            &uncompressed_timestamps,
+            &compressed_record_batch,
+            &[models::PMC_MEAN_ID],
+        )
+    }
+
+    #[test]
     fn test_try_compress_regular_linear_time_series() {
-        let values = generate_test_data(100, true, false, None, None);
-        let timestamps = Vec::from_iter((100..(values.len() + 1) as i64 * 100).step_by(100));
+        let values = generate_data(100, true, false, None, None);
+        let timestamps = generate_timestamps(values.len(), false);
         let (uncompressed_timestamps, uncompressed_values) =
             create_uncompressed_time_series(&timestamps, &values);
         let error_bound = ErrorBound::try_new(0.0).unwrap();
@@ -509,7 +549,7 @@ mod tests {
     #[test]
     fn test_try_compress_regular_almost_linear_time_series() {
         let values =
-            generate_test_data(100,  true, true, Some(9.0), Some(11.0));
+            generate_data(100, true, true, Some(9.0), Some(11.0));
         let timestamps = Vec::from_iter((100..(values.len() + 1) as i64 * 100).step_by(100));
         let (uncompressed_timestamps, uncompressed_values) =
             create_uncompressed_time_series(&timestamps, &values);
@@ -533,7 +573,7 @@ mod tests {
     #[test]
     fn test_try_compress_regular_random_time_series() {
         let values =
-            generate_test_data(50, false, true, Some(0.0), Some(f32::MAX));
+            generate_data(50, false, true, Some(0.0), Some(f32::MAX));
         let timestamps = Vec::from_iter((100..(values.len() + 1) as i64 * 100).step_by(100));
         let (uncompressed_timestamps, uncompressed_values) =
             create_uncompressed_time_series(&timestamps, &values);
@@ -556,9 +596,9 @@ mod tests {
 
     #[test]
     fn test_try_compress_regular_random_linear_constant_time_series() {
-        let mut constant = generate_test_data(50, false, false, None, None);
-        let mut linear = generate_test_data(50, true, false, None, None);
-        let mut random = generate_test_data(50, false, true, Some(0.0), Some(f32::MAX));
+        let mut constant = generate_data(50, false, false, None, None);
+        let mut linear = generate_data(50, true, false, None, None);
+        let mut random = generate_data(50, false, true, Some(0.0), Some(f32::MAX));
 
         let mut values = vec![];
         values.append(&mut random);
@@ -585,7 +625,7 @@ mod tests {
         )
     }
 
-    fn generate_test_data(
+    fn generate_data(
         length: u16,
         linear_values: bool,
         random_values: bool,
@@ -639,6 +679,25 @@ mod tests {
         }
 
         values
+    }
+
+    fn generate_timestamps(length: usize, irregular: bool) -> Vec<i64>{
+        let mut randomizer = thread_rng();
+        let mut timestamps = vec![];
+        if irregular{
+            let mut previous_timestamp: i64 = 0;
+            for _ in 0..length {
+                let next_timestamp =
+                    (randomizer.sample(Uniform::from(10..100))) + previous_timestamp;
+                timestamps.push(next_timestamp);
+                previous_timestamp = next_timestamp;
+            }
+        }
+        else {
+            timestamps = Vec::from_iter((100..(length + 1) as i64 * 100).step_by(100));
+        }
+
+        timestamps
     }
 
     fn create_uncompressed_time_series(

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -400,7 +400,6 @@ mod tests {
     use datafusion::arrow::array::UInt8Array;
     use rand::distributions::Uniform;
     use rand::{thread_rng, Rng};
-    use rand::rngs::ThreadRng;
 
     use crate::metadata::test_util;
     use crate::models;
@@ -447,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_constant_time_series(){
+    fn test_try_compress_irregular_constant_time_series() {
         let values = generate_data(100, false, false, None, None);
         let timestamps = generate_timestamps(values.len(), true);
         let (uncompressed_timestamps, uncompressed_values) =
@@ -460,7 +459,7 @@ mod tests {
             error_bound,
             &test_util::get_compressed_schema(),
         )
-            .unwrap();
+        .unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
             &uncompressed_timestamps,
             &compressed_record_batch,
@@ -470,8 +469,7 @@ mod tests {
 
     #[test]
     fn test_try_compress_regular_almost_constant_time_series() {
-        let values =
-            generate_data(100, false, true, Some(9.8), Some(10.2));
+        let values = generate_data(100, false, true, Some(9.8), Some(10.2));
         let timestamps = generate_timestamps(values.len(), false);
         let (uncompressed_timestamps, uncompressed_values) =
             create_uncompressed_time_series(&timestamps, &values);
@@ -494,8 +492,7 @@ mod tests {
 
     #[test]
     fn test_try_compress_irregular_almost_constant_time_series() {
-        let values =
-            generate_data(100, false, true, Some(9.8), Some(10.2));
+        let values = generate_data(100, false, true, Some(9.8), Some(10.2));
         let timestamps = generate_timestamps(values.len(), true);
         let (uncompressed_timestamps, uncompressed_values) =
             create_uncompressed_time_series(&timestamps, &values);
@@ -507,7 +504,7 @@ mod tests {
             error_bound,
             &test_util::get_compressed_schema(),
         )
-            .unwrap();
+        .unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
             &uncompressed_timestamps,
             &compressed_record_batch,
@@ -540,8 +537,7 @@ mod tests {
 
     #[test]
     fn test_try_compress_regular_almost_linear_time_series() {
-        let values =
-            generate_data(100, true, true, Some(9.0), Some(11.0));
+        let values = generate_data(100, true, true, Some(9.0), Some(11.0));
         let timestamps = generate_timestamps(values.len(), false);
         let (uncompressed_timestamps, uncompressed_values) =
             create_uncompressed_time_series(&timestamps, &values);
@@ -564,8 +560,7 @@ mod tests {
 
     #[test]
     fn test_try_compress_regular_random_time_series() {
-        let values =
-            generate_data(50, false, true, Some(0.0), Some(f32::MAX));
+        let values = generate_data(50, false, true, Some(0.0), Some(f32::MAX));
         let timestamps = generate_timestamps(values.len(), false);
         let (uncompressed_timestamps, uncompressed_values) =
             create_uncompressed_time_series(&timestamps, &values);
@@ -588,8 +583,7 @@ mod tests {
 
     #[test]
     fn test_try_compress_irregular_random_time_series() {
-        let values =
-            generate_data(50, false, true, Some(0.0), Some(f32::MAX));
+        let values = generate_data(50, false, true, Some(0.0), Some(f32::MAX));
         let timestamps = generate_timestamps(values.len(), true);
         let (uncompressed_timestamps, uncompressed_values) =
             create_uncompressed_time_series(&timestamps, &values);
@@ -601,7 +595,7 @@ mod tests {
             error_bound,
             &test_util::get_compressed_schema(),
         )
-            .unwrap();
+        .unwrap();
         assert_compressed_record_batch_with_segments_from_regular_time_series(
             &uncompressed_timestamps,
             &compressed_record_batch,
@@ -652,9 +646,7 @@ mod tests {
 
         if random_values {
             if min_step == None || max_step == None {
-                panic!(
-                    "min_step and max_step need to be entered if random_values is true."
-                )
+                panic!("min_step and max_step need to be entered if random_values is true.")
             } else if min_step > max_step {
                 panic!("min_step cannot be lower than the max_step.")
             }
@@ -688,7 +680,8 @@ mod tests {
                 values.append(&mut random);
             }
             (false, false) => {
-                let mut constant = vec![randomizer.sample(Uniform::from(0.0..f32::MAX)); length as usize];
+                let mut constant =
+                    vec![randomizer.sample(Uniform::from(0.0..f32::MAX)); length as usize];
                 values.append(&mut constant);
             }
         }
@@ -696,10 +689,10 @@ mod tests {
         values
     }
 
-    fn generate_timestamps(length: usize, irregular: bool) -> Vec<i64>{
+    fn generate_timestamps(length: usize, irregular: bool) -> Vec<i64> {
         let mut randomizer = thread_rng();
         let mut timestamps = vec![];
-        if irregular{
+        if irregular {
             let mut previous_timestamp: i64 = 0;
             for _ in 0..length {
                 let next_timestamp =
@@ -707,8 +700,7 @@ mod tests {
                 timestamps.push(next_timestamp);
                 previous_timestamp = next_timestamp;
             }
-        }
-        else {
+        } else {
             timestamps = Vec::from_iter((100..(length + 1) as i64 * 100).step_by(100));
         }
 

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -454,6 +454,7 @@ pub(crate) mod tests {
         let error_bound = ErrorBound::try_new(0.0).unwrap();
 
         let compressed_record_batch = try_compress(
+            1,
             &uncompressed_timestamps,
             &uncompressed_values,
             error_bound,
@@ -499,6 +500,7 @@ pub(crate) mod tests {
         let error_bound = ErrorBound::try_new(5.0).unwrap();
 
         let compressed_record_batch = try_compress(
+            1,
             &uncompressed_timestamps,
             &uncompressed_values,
             error_bound,
@@ -590,6 +592,7 @@ pub(crate) mod tests {
         let error_bound = ErrorBound::try_new(0.0).unwrap();
 
         let compressed_record_batch = try_compress(
+            1,
             &uncompressed_timestamps,
             &uncompressed_values,
             error_bound,

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -840,11 +840,11 @@ pub mod test_util {
     }
 
     /// Generate constant/random/linear/almost-linear test values with the
-    /// [ThreadRng](rand::rngs::thread::ThreadRng) randomizer. Select the length using `length` and type of
-    /// values to be generated using [`StructureOfValues`]. If `Random` is selected, min_step and max_step
-    /// is the range of values which can be generated. If `AlmostLinear` is selected, `min_step`
-    /// and `max_step` is the maximum and minimum change that should be applied from one value to the next.
-    /// Returns the generated values as a [`Vec`].
+    /// [ThreadRng](rand::rngs::thread::ThreadRng) randomizer. Select the amount of values to be generated
+    /// using `length` and type of values to be generated using [`StructureOfValues`]. If `Random` is
+    /// selected, `min` and `max` is the range of values which can be generated. If `AlmostLinear` is
+    /// selected, `min` and `max` is the maximum and minimum change that should be applied from one value
+    /// to the next. Returns the generated values as a [`Vec`].
     pub fn generate_values(
         length: usize,
         data_type: StructureOfValues,
@@ -886,7 +886,7 @@ pub mod test_util {
 
             // Generates constant data.
             StructureOfValues::Constant => {
-                let mut constant = vec![10.0; length as usize];
+                let mut constant = vec![50.0; length as usize];
                 values.append(&mut constant);
             }
         }

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -394,7 +394,7 @@ impl CompressedSegmentBatchBuilder {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     use datafusion::arrow::array::UInt8Array;
@@ -634,17 +634,35 @@ mod tests {
         )
     }
 
-    fn generate_data(
+    /// Function for generating constant/random/linear/random-linear test data with the [ThreadRng](rand::rngs::thread::ThreadRng) randomizer.
+    ///
+    /// # Arguments
+    ///
+    /// * `length` - An unsigned integer that denotes how many data-points should be generated.
+    /// * `linear` - A boolean that denotes if the data should be linear.
+    /// * `random` - A boolean that denotes if the data should be randomized.
+    /// * `min_step` - Denotes the minimum change that should be applied from one data point to the next when randomizing data. Only used if `random` is set to `true`.
+    /// * `max_step` - Denotes the maximum change that should be applied from one data point to the next when randomizing data. Only used if `random` is set to `true`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let constant_data = generate_data(100, false, false, None, None);
+    /// let random_data = generate_data(100, false, true, Some(10.0), Some(20.0));
+    /// let linear_data = generate_data(100, true, false, None, None);
+    /// let random_linear = generate_data(100, true, true, Some(9.0), Some(11.0));
+    /// ```
+    pub fn generate_data(
         length: u16,
-        linear_values: bool,
-        random_values: bool,
+        linear: bool,
+        random: bool,
         min_step: Option<f32>,
         max_step: Option<f32>,
     ) -> Vec<f32> {
         let mut randomizer = thread_rng();
         let mut values: Vec<f32> = vec![];
 
-        if random_values {
+        if random {
             if min_step == None || max_step == None {
                 panic!("min_step and max_step need to be entered if random_values is true.")
             } else if min_step > max_step {
@@ -652,7 +670,7 @@ mod tests {
             }
         }
 
-        match (linear_values, random_values) {
+        match (linear, random) {
             (true, true) => {
                 let mut random_linear = vec![];
                 let mut previous_value: f32 = 0.0;
@@ -689,14 +707,27 @@ mod tests {
         values
     }
 
-    fn generate_timestamps(length: usize, irregular: bool) -> Vec<i64> {
+    /// Function for generating regular/irregular timestamps with the [ThreadRng](rand::rngs::thread::ThreadRng) randomizer.
+    ///
+    /// # Arguments
+    ///
+    /// * `length` - An unsigned integer that denotes how many timestamps should be generated.
+    /// * `irregular` - A boolean that denotes if the timestamps should be regular or irregular.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let regular_timestamps = generate_timestamps(100, false);
+    /// let irregular_timestamps = generate_timestamps(100, true);
+    /// ```
+    pub fn generate_timestamps(length: usize, irregular: bool) -> Vec<i64> {
         let mut randomizer = thread_rng();
         let mut timestamps = vec![];
         if irregular {
             let mut previous_timestamp: i64 = 0;
             for _ in 0..length {
                 let next_timestamp =
-                    (randomizer.sample(Uniform::from(10..15))) + previous_timestamp;
+                    (randomizer.sample(Uniform::from(10..100))) + previous_timestamp;
                 timestamps.push(next_timestamp);
                 previous_timestamp = next_timestamp;
             }

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -305,10 +305,10 @@ fn equal_or_nan(v1: f64, v2: f64) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compression::tests::{generate_data, generate_timestamps};
     use datafusion::from_slice::FromSlice;
     use proptest::num;
     use proptest::{prop_assert, prop_assume, proptest};
-    use crate::compression::tests::{generate_data, generate_timestamps};
 
     use crate::types::TimestampArray;
 
@@ -398,18 +398,23 @@ mod tests {
 
     #[test]
     fn test_selected_model_new() {
-        let uncompressed_timestamps_long = TimestampArray::from_slice(generate_timestamps(100, false));
-        let uncompressed_timestamps_short = TimestampArray::from_slice(generate_timestamps(25, false));
-        let uncompressed_values_long = ValueArray::from(generate_data(100, false, false, None, None));
-        let uncompressed_values_short = ValueArray::from(generate_data(25, false, false, None, None));
+        let uncompressed_timestamps_long =
+            TimestampArray::from_slice(generate_timestamps(100, false));
+        let uncompressed_timestamps_short =
+            TimestampArray::from_slice(generate_timestamps(25, false));
+        let uncompressed_values_long =
+            ValueArray::from(generate_data(100, false, false, None, None));
+        let uncompressed_values_short =
+            ValueArray::from(generate_data(25, false, false, None, None));
 
-        let selected_model_long = create_selected_model(&uncompressed_timestamps_long, &uncompressed_values_long);
-        let selected_model_short = create_selected_model(&uncompressed_timestamps_short, &uncompressed_values_short);
+        let selected_model_long =
+            create_selected_model(&uncompressed_timestamps_long, &uncompressed_values_long);
+        let selected_model_short =
+            create_selected_model(&uncompressed_timestamps_short, &uncompressed_values_short);
 
         assert_eq!(PMC_MEAN_ID, selected_model_long.model_type_id);
         assert_eq!(PMC_MEAN_ID, selected_model_short.model_type_id);
     }
-
 
     fn create_selected_model(
         uncompressed_timestamps: &TimestampArray,

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -305,7 +305,7 @@ fn equal_or_nan(v1: f64, v2: f64) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compression::tests::{generate_data, generate_timestamps};
+    use crate::compression::test_util::{generate_data, generate_timestamps};
     use datafusion::from_slice::FromSlice;
     use proptest::num;
     use proptest::{prop_assert, prop_assume, proptest};
@@ -397,7 +397,7 @@ mod tests {
     }
 
     #[test]
-    fn test_selected_model_new() {
+    fn test_new_selected_model_selects_the_best_model() {
         let uncompressed_timestamps_long =
             TimestampArray::from_slice(generate_timestamps(100, false));
         let uncompressed_timestamps_short =

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -29,7 +29,6 @@ pub mod timestamps;
 use std::cmp::{Ordering, PartialOrd};
 use std::mem;
 
-
 use crate::errors::ModelarDbError;
 use crate::models::{gorilla::Gorilla, pmc_mean::PMCMean, swing::Swing};
 use crate::types::{
@@ -397,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_selected_model_selects_the_best_model() {
+    fn test_model_with_fewest_bytes_is_selected() {
         let uncompressed_timestamps_long =
             TimestampArray::from_slice(generate_timestamps(100, false));
         let uncompressed_timestamps_short =

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -403,56 +403,26 @@ mod tests {
 
     /// This test ensures that the model with the fewest amount of bytes is selected.
     #[test]
-    fn test_model_with_fewest_bytes_is_selected_pmc_mean() {
-        let values_1 = ValueArray::from(compression_test_util::generate_values(
-            5,
-            StructureOfValues::Random,
-            Some(-1.0),
-            Some(1.0),
+    fn test_model_with_fewest_bytes_is_selected() {
+        let values: Vec<f32> =
+            compression_test_util::generate_values(25, StructureOfValues::Constant, None, None)
+                .into_iter()
+                .chain(compression_test_util::generate_values(
+                    25,
+                    StructureOfValues::Random,
+                    Some(0.0),
+                    Some(100.0),
+                ))
+                .collect();
+        let timestamps = TimestampArray::from_slice(compression_test_util::generate_timestamps(
+            values.len(),
+            false,
         ));
-        let timestamps_1 =
-            TimestampArray::from_slice(compression_test_util::generate_timestamps(5, false));
-        let values_2 = ValueArray::from(compression_test_util::generate_values(
-            50,
-            StructureOfValues::Random,
-            Some(-1.0),
-            Some(1.0),
-        ));
-        let timestamps_2 =
-            TimestampArray::from_slice(compression_test_util::generate_timestamps(50, false));
+        let value_array = ValueArray::from(values);
 
-        let selected_model_1 = create_selected_model(&timestamps_1, &values_1, 10.0);
-        let selected_model_2 = create_selected_model(&timestamps_2, &values_2, 10.0);
+        let selected_model = create_selected_model(&timestamps, &value_array, 10.0);
 
-        assert_eq!(selected_model_1.model_type_id, PMC_MEAN_ID);
-        assert_eq!(selected_model_2.model_type_id, PMC_MEAN_ID);
-    }
-
-    /// This test ensures that the model with the fewest amount of bytes is selected.
-    #[test]
-    fn test_model_with_fewest_bytes_is_selected_swing() {
-        let values_1 = ValueArray::from(compression_test_util::generate_values(
-            5,
-            StructureOfValues::Linear,
-            None,
-            None,
-        ));
-        let timestamps_1 =
-            TimestampArray::from_slice(compression_test_util::generate_timestamps(5, false));
-        let values_2 = ValueArray::from(compression_test_util::generate_values(
-            50,
-            StructureOfValues::Linear,
-            None,
-            None,
-        ));
-        let timestamps_2 =
-            TimestampArray::from_slice(compression_test_util::generate_timestamps(50, false));
-
-        let selected_model_1 = create_selected_model(&timestamps_1, &values_1, 0.0);
-        let selected_model_2 = create_selected_model(&timestamps_2, &values_2, 0.0);
-
-        assert_eq!(selected_model_1.model_type_id, SWING_ID);
-        assert_eq!(selected_model_2.model_type_id, SWING_ID);
+        assert_eq!(selected_model.model_type_id, PMC_MEAN_ID);
     }
 
     fn create_selected_model(

--- a/server/src/models/mod.rs
+++ b/server/src/models/mod.rs
@@ -29,6 +29,7 @@ pub mod timestamps;
 use std::cmp::{Ordering, PartialOrd};
 use std::mem;
 
+
 use crate::errors::ModelarDbError;
 use crate::models::{gorilla::Gorilla, pmc_mean::PMCMean, swing::Swing};
 use crate::types::{
@@ -307,6 +308,7 @@ mod tests {
     use datafusion::from_slice::FromSlice;
     use proptest::num;
     use proptest::{prop_assert, prop_assume, proptest};
+    use crate::compression::tests::{generate_data, generate_timestamps};
 
     use crate::types::TimestampArray;
 
@@ -393,6 +395,21 @@ mod tests {
         assert_eq!(73.0, selected_model.max_value);
         assert_eq!(10, selected_model.values.len());
     }
+
+    #[test]
+    fn test_selected_model_new() {
+        let uncompressed_timestamps_long = TimestampArray::from_slice(generate_timestamps(100, false));
+        let uncompressed_timestamps_short = TimestampArray::from_slice(generate_timestamps(25, false));
+        let uncompressed_values_long = ValueArray::from(generate_data(100, false, false, None, None));
+        let uncompressed_values_short = ValueArray::from(generate_data(25, false, false, None, None));
+
+        let selected_model_long = create_selected_model(&uncompressed_timestamps_long, &uncompressed_values_long);
+        let selected_model_short = create_selected_model(&uncompressed_timestamps_short, &uncompressed_values_short);
+
+        assert_eq!(PMC_MEAN_ID, selected_model_long.model_type_id);
+        assert_eq!(PMC_MEAN_ID, selected_model_short.model_type_id);
+    }
+
 
     fn create_selected_model(
         uncompressed_timestamps: &TimestampArray,

--- a/server/tests/integration_test.rs
+++ b/server/tests/integration_test.rs
@@ -743,6 +743,7 @@ fn stop_modelardbd(mut flight_server: Child) {
     let mut system = System::new_all();
 
     while let Some(_process) = system.process(Pid::from_u32(flight_server.id())) {
+        system.refresh_all();
         flight_server
             .kill()
             .expect(&*format!("Could not kill process {}.", flight_server.id()));

--- a/server/tests/integration_test.rs
+++ b/server/tests/integration_test.rs
@@ -455,7 +455,7 @@ fn start_modelardbd(path: &Path) -> Child {
 
     // The thread needs to sleep to ensure that the server has properly started before sending
     // streams to it.
-    thread::sleep(Duration::from_secs(2));
+    thread::sleep(Duration::from_secs(5));
 
     return process;
 }


### PR DESCRIPTION
This pull request adds a generator for generating random test data and randomized irregular timestamps, new tests for testing irregular time series during compression, and a test to ensure that the selected model has the least amount of bytes. Additional fixes for the macOS and Windows testing environments have also been added to (hopefully) ensure that GitHub checks do not fail again on these platforms. 