### PR TITLE
Use optimized settings for ArrowWriter

### DIFF
--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -257,7 +257,7 @@ mod tests {
     use crate::storage::test_util;
 
     const TABLE_NAME: &str = "table";
-    const COMPRESSED_FILE_SIZE: usize = 2922;
+    const COMPRESSED_FILE_SIZE: usize = 2163;
 
     // Tests for path_is_compressed_file().
     #[test]

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -37,7 +37,7 @@ use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
 use datafusion::parquet::arrow::ArrowWriter;
-use datafusion::parquet::basic::Compression;
+use datafusion::parquet::basic::{Compression, Encoding};
 use datafusion::parquet::errors::ParquetError;
 use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
 use futures::StreamExt;
@@ -321,9 +321,11 @@ pub(self) fn create_apache_arrow_writer<W: Write>(
     schema: SchemaRef,
 ) -> Result<ArrowWriter<W>, ParquetError> {
     let props = WriterProperties::builder()
+        .set_encoding(Encoding::PLAIN)
         .set_compression(Compression::ZSTD)
         .set_dictionary_enabled(false)
-        .set_statistics_enabled(EnabledStatistics::Page)
+        .set_statistics_enabled(EnabledStatistics::None)
+        .set_bloom_filter_enabled(false)
         .build();
 
     let writer = ArrowWriter::try_new(writer, schema, Some(props))?;


### PR DESCRIPTION
This PR configures [ArrowWriter](https://docs.rs/parquet/latest/parquet/arrow/arrow_writer/struct.ArrowWriter.html) with the global [WriterProperties](https://docs.rs/parquet/latest/parquet/file/properties/struct.WriterProperties.html) that currently provides the best trade-off between ingestion time, query time, and the amount of storage required according to an extensive search performed by [Evaluate-ModelarDB-Changes](https://github.com/ModelarData/Utilities/tree/main/Evaluate-ModelarDB-Changes) using a 1 GiB real-life data set, a 63 MiB real-life data set, and simple aggregate queries that aggregate the entire ingested data set. The following tables shows the set of nondominated results as computed by this [Python script](https://github.com/matthewjwoodruff/pareto.py). The nondominated results are also available in the following Microsoft Excel spreadsheet: [nondominated_results.xlsx](https://github.com/ModelarData/ModelarDB-RS/files/10369361/nondominated_results.xlsx).

| Changes                                                                                                                                                                                                                                                                                 | Ingestion Time in Seconds | Query Time in Seconds | Data Folder Size in KiB |
| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- | --------------------- | ----------------------- |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)  | 35.6971733570099          | 13.0355319976807      | 719008                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Chunk).set_bloom_filter_enabled(false) | 26.1492829322815          | 15.2288262844086      | 719024                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::SNAPPY).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page).set_bloom_filter_enabled(false)        | 26.3453426361084          | 16.7899332046509      | 517768                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::GZIP).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)          | 51.351035118103           | 32.6221859455109      | 457960                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::BROTLI).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)        | 29.1902270317078          | 52.63414311409        | 459468                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::BROTLI).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Chunk).set_bloom_filter_enabled(false)       | 29.6286566257477          | 52.4277191162109      | 459488                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::BROTLI).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page).set_bloom_filter_enabled(false)        | 35.2686696052551          | 51.8985857963562      | 459500                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::LZ4).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)           | 26.4911239147186          | 16.7138996124268      | 508992                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::LZ4).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Chunk).set_bloom_filter_enabled(false)          | 27.8335614204407          | 13.9875149726868      | 509004                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)          | 27.2469036579132          | 18.5795502662659      | 466792                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page).set_bloom_filter_enabled(false)          | 29.8090989589691          | 18.4886856079102      | 466852                  |

| Changes                                                                                                                                                                                                                                                                                         | Ingestion Time in Seconds | Query Time in Seconds | Data Folder Size in KiB |
| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- | --------------------- | ----------------------- |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(true).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Chunk).set_bloom_filter_enabled(false)          | 6.90566396713257          | 0.710154294967651     | 521596                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::SNAPPY).set_dictionary_enabled(true).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                 | 6.68179845809937          | 0.798011541366577     | 277996                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::GZIP).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                  | 7.22872066497803          | 1.27241182327271      | 261848                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::GZIP).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(true)                   | 5.99495434761047          | 1.21481513977051      | 7929600                 |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::BROTLI).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                | 6.87151741981506          | 2.59978675842285      | 264392                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::BROTLI).set_dictionary_enabled(true).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                 | 6.56363940238953          | 2.89241909980774      | 269600                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::LZ4).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                   | 6.82837867736816          | 0.767329454421997     | 273044                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::LZ4).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Chunk).set_bloom_filter_enabled(false)                  | 6.73955011367798          | 0.718275308609009     | 456212                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                  | 7.95132207870483          | 0.832075357437134     | 265820                  |
| .set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::LZ4_RAW).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)               | 7.98056173324585          | 0.764811754226685     | 273024                  |
| .set_encoding(datafusion::parquet::basic::Encoding::DELTA_LENGTH_BYTE_ARRAY).set_compression(datafusion::parquet::basic::Compression::GZIP).set_dictionary_enabled(true).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false) | 7.22511959075928          | 1.34419274330139      | 267332                  |
| .set_encoding(datafusion::parquet::basic::Encoding::DELTA_LENGTH_BYTE_ARRAY).set_compression(datafusion::parquet::basic::Compression::ZSTD).set_dictionary_enabled(true).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false) | 7.57153820991516          | 0.849146842956543     | 271024                  |
| .set_encoding(datafusion::parquet::basic::Encoding::DELTA_BYTE_ARRAY).set_compression(datafusion::parquet::basic::Compression::ZSTD).set_dictionary_enabled(true).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)        | 6.61281657218933          | 0.867357015609741     | 271024                  |
| .set_encoding(datafusion::parquet::basic::Encoding::DELTA_BYTE_ARRAY).set_compression(datafusion::parquet::basic::Compression::LZ4_RAW).set_dictionary_enabled(true).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)     | 6.15821766853333          | 0.749859571456909     | 278464                  |