### PR TITLE
Collect internal statistics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,6 +1782,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand",
+ "ringbuf",
  "rusqlite",
  "serial_test",
  "snmalloc-rs",
@@ -2453,6 +2454,15 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ringbuf"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ca10b9c9e53ac855a2d6953bce34cef6edbac32c4b13047a4d59d67299420a"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,6 +19,7 @@ snmalloc-rs = "0.3.3"
 sqlparser = "0.27.0"
 tokio = { version = "1.22.0", features = ["rt-multi-thread", "signal"] }
 tonic = "0.8.3"
+ringbuf = "0.3.2"
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same values.
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,12 +14,12 @@ futures = "0.3.25"
 object_store = { version = "0.5.1", features = ["aws"] }
 parking_lot = "0.12.1"
 rand = "0.8.5"
+ringbuf = "0.3.2"
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 snmalloc-rs = "0.3.3"
 sqlparser = "0.27.0"
 tokio = { version = "1.22.0", features = ["rt-multi-thread", "signal"] }
 tonic = "0.8.3"
-ringbuf = "0.3.2"
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same values.
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }

--- a/server/src/metadata/mod.rs
+++ b/server/src/metadata/mod.rs
@@ -115,7 +115,7 @@ impl MetadataManager {
         let value_field = Field::new("item", DataType::UInt32, true);
 
         let metric_schema = MetricSchema(Arc::new(Schema::new(vec![
-            Field::new("log", DataType::Utf8, false),
+            Field::new("metric", DataType::Utf8, false),
             Field::new(
                 "timestamps",
                 DataType::List(Box::new(timestamp_field)),

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -487,14 +487,14 @@ impl FlightService for FlightServiceHandler {
     /// normal table, and `CREATE MODEL TABLE table_name(...` which creates a model table.
     /// * `FlushMemory`: Flush all data that is currently in memory to disk. This flushes both
     /// uncompressed and compressed data in the storage engine to disk.
-    /// * `FlushEdge`: An extension of the `FlushMemory` action that both flushes all data that is
+    /// * `FlushEdge`: An extension of the `FlushMemory` action that first flushes all data that is
     /// currently in memory to disk and then flushes all compressed data on disk to the remote
     /// object store. Note that data is only transferred to the remote object store if one was
     /// provided when starting the server.
     /// * `CollectMetrics`: Collect internal metrics describing the amount of used memory for
     /// uncompressed and compressed data, used disk space, and ingested data points over time.
     /// Note that the metrics are cleared when collected, meaning that only the metrics
-    /// recorded since the last call to `CollectMetrics` is returned.
+    /// recorded since the last call to `CollectMetrics` are returned.
     async fn do_action(
         &self,
         request: Request<Action>,

--- a/server/src/remote.rs
+++ b/server/src/remote.rs
@@ -485,15 +485,16 @@ impl FlightService for FlightServiceHandler {
     /// * `CommandStatementUpdate`: Execute a SQL query containing a command that does not
     /// return a result. These commands can be `CREATE TABLE table_name(...` which creates a
     /// normal table, and `CREATE MODEL TABLE table_name(...` which creates a model table.
-    /// * `FlushMemory`: Flush all data that is currently in memory to disk. This flushes both
-    /// uncompressed and compressed data in the storage engine to disk.
+    /// * `FlushMemory`: Flush all data that is currently in memory to disk. This compresses the
+    /// uncompressed data currently in memory and then flushes all compressed data in the storage
+    /// engine to disk.
     /// * `FlushEdge`: An extension of the `FlushMemory` action that first flushes all data that is
     /// currently in memory to disk and then flushes all compressed data on disk to the remote
     /// object store. Note that data is only transferred to the remote object store if one was
     /// provided when starting the server.
-    /// * `CollectMetrics`: Collect internal metrics describing the amount of used memory for
-    /// uncompressed and compressed data, used disk space, and ingested data points over time.
-    /// Note that the metrics are cleared when collected, meaning that only the metrics
+    /// * `CollectMetrics`: Collect internal metrics describing the amount of memory used for
+    /// uncompressed and compressed data, disk space used, and the number of data points ingested
+    /// over time. Note that the metrics are cleared when collected, thus only the metrics
     /// recorded since the last call to `CollectMetrics` are returned.
     async fn do_action(
         &self,

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -55,7 +55,7 @@ pub(super) struct CompressedDataManager {
     compressed_remaining_memory_in_bytes: isize,
     /// Reference to the schema for compressed data buffers.
     compressed_schema: CompressedSchema,
-    /// Log of the used compressed memory, updated every time the used memory changes.
+    /// Log of the used compressed memory in bytes, updated every time the used memory changes.
     compressed_used_memory: (TimestampBuilder, UInt32Builder),
 }
 

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -153,7 +153,9 @@ impl CompressedDataManager {
             segment_size
         };
 
-        self.compressed_remaining_memory_in_bytes -= segments_size as isize;
+        self.set_compressed_remaining_memory_in_bytes(
+            self.compressed_remaining_memory_in_bytes - segments_size as isize
+        );
 
         // If the reserved memory limit is exceeded, save compressed data to disk.
         if self.compressed_remaining_memory_in_bytes < 0 {
@@ -296,7 +298,9 @@ impl CompressedDataManager {
 
         let file_path = compressed_data_buffer
             .save_to_apache_parquet(folder_path.as_path(), &self.compressed_schema)?;
-        self.compressed_remaining_memory_in_bytes += compressed_data_buffer.size_in_bytes as isize;
+        self.set_compressed_remaining_memory_in_bytes(
+            self.compressed_remaining_memory_in_bytes + compressed_data_buffer.size_in_bytes as isize
+        );
 
         debug!(
             "Saved {} bytes of compressed data to disk. Remaining reserved bytes: {}.",

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -34,7 +34,7 @@ use tracing::{debug, info};
 use crate::errors::ModelarDbError;
 use crate::storage::compressed_data_buffer::CompressedDataBuffer;
 use crate::storage::data_transfer::DataTransfer;
-use crate::storage::{StorageEngine, COMPRESSED_DATA_FOLDER, Log};
+use crate::storage::{StorageEngine, COMPRESSED_DATA_FOLDER, Metric};
 use crate::types::{CompressedSchema, Timestamp, Value};
 
 /// Stores data points compressed as models in memory to batch compressed data before saving it to
@@ -55,11 +55,11 @@ pub(super) struct CompressedDataManager {
     compressed_remaining_memory_in_bytes: isize,
     /// Reference to the schema for compressed data buffers.
     compressed_schema: CompressedSchema,
-    /// Log of the used compressed memory in bytes, updated every time the used memory changes.
-    pub(super) used_compressed_memory_log: Log,
-    /// Log of the total used disk space in bytes, updated every time a new compressed file is
+    /// Metric for the used compressed memory in bytes, updated every time the used memory changes.
+    pub(super) used_compressed_memory_metric: Metric,
+    /// Metric for the total used disk space in bytes, updated every time a new compressed file is
     /// saved to disk.
-    pub used_disk_space_log: Arc<RwLock<Log>>,
+    pub used_disk_space_metric: Arc<RwLock<Metric>>,
 }
 
 impl CompressedDataManager {
@@ -70,7 +70,7 @@ impl CompressedDataManager {
         local_data_folder: PathBuf,
         compressed_reserved_memory_in_bytes: usize,
         compressed_schema: CompressedSchema,
-        used_disk_space_log: Arc<RwLock<Log>>,
+        used_disk_space_metric: Arc<RwLock<Metric>>,
     ) -> Result<Self, IOError> {
         // Ensure the folder required by the compressed data manager exists.
         fs::create_dir_all(local_data_folder.join(COMPRESSED_DATA_FOLDER))?;
@@ -82,8 +82,8 @@ impl CompressedDataManager {
             compressed_queue: VecDeque::new(),
             compressed_remaining_memory_in_bytes: compressed_reserved_memory_in_bytes as isize,
             compressed_schema,
-            used_compressed_memory_log: Log::new(),
-            used_disk_space_log,
+            used_compressed_memory_metric: Metric::new(),
+            used_disk_space_metric,
         })
     }
 
@@ -158,9 +158,9 @@ impl CompressedDataManager {
             segment_size
         };
 
-        // Update the remaining memory for compressed data and log the change.
+        // Update the remaining memory for compressed data and record the change.
         self.compressed_remaining_memory_in_bytes -= segments_size as isize;
-        self.used_compressed_memory_log.add_entry(segments_size as isize, true);
+        self.used_compressed_memory_metric.append(segments_size as isize, true);
 
         // If the reserved memory limit is exceeded, save compressed data to disk.
         if self.compressed_remaining_memory_in_bytes < 0 {
@@ -304,14 +304,14 @@ impl CompressedDataManager {
         let file_path = compressed_data_buffer
             .save_to_apache_parquet(folder_path.as_path(), &self.compressed_schema)?;
 
-        // Update the remaining memory for compressed data and log the change.
+        // Update the remaining memory for compressed data and record the change.
         let freed_memory = compressed_data_buffer.size_in_bytes as isize;
         self.compressed_remaining_memory_in_bytes += freed_memory;
-        self.used_compressed_memory_log.add_entry(-freed_memory, true);
+        self.used_compressed_memory_metric.append(-freed_memory, true);
 
-        // Log the change to the used disk space.
+        // Record the change to the used disk space.
         let file_size = file_path.metadata()?.len() as isize;
-        self.used_disk_space_log.write().await.add_entry(file_size, true);
+        self.used_disk_space_metric.write().await.append(file_size, true);
 
         debug!(
             "Saved {} bytes of compressed data to disk. Remaining reserved bytes: {}.",
@@ -544,7 +544,7 @@ mod tests {
             .unwrap();
 
         assert!(reserved_memory > data_manager.compressed_remaining_memory_in_bytes);
-        assert_eq!(data_manager.used_compressed_memory_log.values.len(), 1);
+        assert_eq!(data_manager.used_compressed_memory_metric.values.len(), 1);
     }
 
     #[tokio::test]
@@ -565,8 +565,8 @@ mod tests {
             .unwrap();
 
         assert!(-1 < data_manager.compressed_remaining_memory_in_bytes);
-        assert_eq!(data_manager.used_compressed_memory_log.values.len(), 2);
-        assert_eq!(data_manager.used_disk_space_log.read().await.values.len(), 1);
+        assert_eq!(data_manager.used_compressed_memory_metric.values.len(), 2);
+        assert_eq!(data_manager.used_disk_space_metric.read().await.values.len(), 1);
     }
 
     /// Create a [`CompressedDataManager`] with a folder that is deleted once the test is finished.
@@ -582,7 +582,7 @@ mod tests {
                 local_data_folder,
                 metadata_manager.compressed_reserved_memory_in_bytes,
                 metadata_manager.compressed_schema(),
-                Arc::new(RwLock::new(Log::new())),
+                Arc::new(RwLock::new(Metric::new())),
             )
             .unwrap(),
         )

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -566,6 +566,7 @@ mod tests {
 
         assert!(-1 < data_manager.compressed_remaining_memory_in_bytes);
         assert_eq!(data_manager.used_compressed_memory_log.values.len(), 2);
+        assert_eq!(data_manager.used_disk_space_log.read().await.values.len(), 1);
     }
 
     /// Create a [`CompressedDataManager`] with a folder that is deleted once the test is finished.

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -407,10 +407,10 @@ fn is_compressed_file_within_time_and_value_range(
 mod tests {
     use super::*;
     use std::path::Path;
-    use datafusion::arrow::array::ArrayBuilder;
 
     use datafusion::arrow::compute;
     use object_store::local::LocalFileSystem;
+    use ringbuf::Rb;
     use tempfile::{self, TempDir};
 
     use crate::array;

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -578,6 +578,7 @@ mod tests {
                 local_data_folder,
                 metadata_manager.compressed_reserved_memory_in_bytes,
                 metadata_manager.compressed_schema(),
+                Arc::new(RwLock::new(Log::new())),
             )
             .unwrap(),
         )

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -34,7 +34,7 @@ use tracing::{debug, info};
 use crate::errors::ModelarDbError;
 use crate::storage::compressed_data_buffer::CompressedDataBuffer;
 use crate::storage::data_transfer::DataTransfer;
-use crate::storage::{StorageEngine, COMPRESSED_DATA_FOLDER};
+use crate::storage::{StorageEngine, COMPRESSED_DATA_FOLDER, create_log_entry};
 use crate::types::{CompressedSchema, Timestamp, TimestampBuilder, Value};
 
 /// Stores data points compressed as models in memory to batch compressed data before saving it to
@@ -314,6 +314,20 @@ impl CompressedDataManager {
         }
 
         Ok(())
+    }
+
+    /// Setter for the `compressed_remaining_memory_in_bytes` field to ensure the total used
+    /// memory log is updated when the remaining memory is updated.
+    fn set_compressed_remaining_memory_in_bytes(&mut self, value: isize) {
+        let (timestamp, new_value) = create_log_entry(
+            self.compressed_used_memory.1.values_slice(),
+            self.compressed_remaining_memory_in_bytes - value,
+        );
+
+        self.compressed_used_memory.0.append_value(timestamp);
+        self.compressed_used_memory.1.append_value(new_value);
+
+        self.compressed_remaining_memory_in_bytes = value;
     }
 }
 

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -55,7 +55,7 @@ pub(super) struct CompressedDataManager {
     /// Reference to the schema for compressed data buffers.
     compressed_schema: CompressedSchema,
     /// Log of the used compressed memory in bytes, updated every time the used memory changes.
-    used_compressed_memory_log: Log,
+    pub(super) used_compressed_memory_log: Log,
 }
 
 impl CompressedDataManager {

--- a/server/src/storage/compressed_data_manager.rs
+++ b/server/src/storage/compressed_data_manager.rs
@@ -407,6 +407,7 @@ fn is_compressed_file_within_time_and_value_range(
 mod tests {
     use super::*;
     use std::path::Path;
+    use datafusion::arrow::array::ArrayBuilder;
 
     use datafusion::arrow::compute;
     use object_store::local::LocalFileSystem;
@@ -543,6 +544,7 @@ mod tests {
             .unwrap();
 
         assert!(reserved_memory > data_manager.compressed_remaining_memory_in_bytes);
+        assert_eq!(data_manager.used_compressed_memory_log.values.len(), 1);
     }
 
     #[tokio::test]
@@ -563,6 +565,7 @@ mod tests {
             .unwrap();
 
         assert!(-1 < data_manager.compressed_remaining_memory_in_bytes);
+        assert_eq!(data_manager.used_compressed_memory_log.values.len(), 2);
     }
 
     /// Create a [`CompressedDataManager`] with a folder that is deleted once the test is finished.

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -262,7 +262,7 @@ impl DataTransfer {
     /// calculated based on the previous value.
     fn log_used_disk_space(&mut self, value_change: isize) {
         self.used_disk_space.0.append_value(create_timestamp());
-        
+
         let last_value = self.used_disk_space.1.values_slice().last().unwrap_or(&0);
         self.used_disk_space.1.append_value((*last_value as isize + value_change) as u32);
     }

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -33,7 +33,7 @@ use tokio::sync::RwLock;
 use tonic::codegen::Bytes;
 use tracing::debug;
 
-use crate::storage::{self, StorageEngine, COMPRESSED_DATA_FOLDER, Log};
+use crate::storage::{self, StorageEngine, COMPRESSED_DATA_FOLDER, Metric};
 
 // TODO: Make the transfer batch size in bytes part of the user-configurable settings.
 // TODO: When the storage engine is changed to use object store for everything, receive
@@ -56,8 +56,8 @@ pub struct DataTransfer {
     /// The number of bytes that is required before transferring a batch of data to the remote
     /// object store.
     transfer_batch_size_in_bytes: usize,
-    /// Log of the total used disk space in bytes, updated when data is transferred.
-    pub used_disk_space_log: Arc<RwLock<Log>>,
+    /// Metric for the total used disk space in bytes, updated when data is transferred.
+    pub used_disk_space_metric: Arc<RwLock<Metric>>,
 }
 
 impl DataTransfer {
@@ -68,7 +68,7 @@ impl DataTransfer {
         local_data_folder_path: PathBuf,
         remote_data_folder_object_store: Arc<dyn ObjectStore>,
         transfer_batch_size_in_bytes: usize,
-        used_disk_space_log: Arc<RwLock<Log>>,
+        used_disk_space_metric: Arc<RwLock<Metric>>,
     ) -> Result<Self, IOError> {
         let local_fs = LocalFileSystem::new_with_prefix(local_data_folder_path.clone())?;
         let local_data_folder_object_store = Arc::new(local_fs);
@@ -96,12 +96,12 @@ impl DataTransfer {
             remote_data_folder_object_store,
             compressed_files: compressed_files.clone(),
             transfer_batch_size_in_bytes,
-            used_disk_space_log
+            used_disk_space_metric
         };
 
-        // Log the initial used disk space.
+        // Record the initial used disk space.
         let initial_disk_space: usize = compressed_files.values().into_iter().sum();
-        data_transfer.used_disk_space_log.write().await.add_entry(initial_disk_space as isize, true);
+        data_transfer.used_disk_space_metric.write().await.append(initial_disk_space as isize, true);
 
         // Check if data should be transferred immediately.
         for (table_name, size_in_bytes) in compressed_files.iter() {
@@ -229,7 +229,7 @@ impl DataTransfer {
         // Delete the transferred files from the in-memory tracking of compressed files.
         let transferred_bytes: usize = read_object_metas.iter().map(|meta| meta.size).sum();
         *self.compressed_files.get_mut(table_name).unwrap() -= transferred_bytes;
-        self.used_disk_space_log.write().await.add_entry(-(transferred_bytes as isize), true);
+        self.used_disk_space_metric.write().await.append(-(transferred_bytes as isize), true);
 
         debug!(
             "Transferred {} bytes of compressed data to path '{}' in remote object store.",
@@ -323,7 +323,7 @@ mod tests {
             COMPRESSED_FILE_SIZE * 2
         );
 
-        assert_eq!(data_transfer.used_disk_space_log.read().await.values.len(), 1);
+        assert_eq!(data_transfer.used_disk_space_metric.read().await.values.len(), 1);
     }
 
     #[tokio::test]
@@ -489,7 +489,7 @@ mod tests {
             0 as usize
         );
 
-        assert_eq!(data_transfer.used_disk_space_log.read().await.values.len(), 2);
+        assert_eq!(data_transfer.used_disk_space_metric.read().await.values.len(), 2);
     }
 
     /// Set up a data folder with a table folder that has a single compressed file in it. Return the
@@ -524,7 +524,7 @@ mod tests {
             local_data_folder_path.to_path_buf(),
             remote_data_folder_object_store,
             COMPRESSED_FILE_SIZE * 3 - 1,
-            Arc::new(RwLock::new(Log::new())),
+            Arc::new(RwLock::new(Metric::new())),
         )
         .await
         .unwrap();

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -23,7 +23,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use bytes::BufMut;
-use datafusion::arrow::array::UInt32Builder;
 use datafusion::arrow::compute;
 use datafusion::parquet::errors::ParquetError;
 use futures::StreamExt;
@@ -33,8 +32,7 @@ use object_store::ObjectStore;
 use tonic::codegen::Bytes;
 use tracing::debug;
 
-use crate::storage::{self, StorageEngine, COMPRESSED_DATA_FOLDER, create_timestamp};
-use crate::types::TimestampBuilder;
+use crate::storage::{self, StorageEngine, COMPRESSED_DATA_FOLDER, StatisticLog};
 
 // TODO: Make the transfer batch size in bytes part of the user-configurable settings.
 // TODO: When the storage engine is changed to use object store for everything, receive
@@ -59,7 +57,7 @@ pub struct DataTransfer {
     transfer_batch_size_in_bytes: usize,
     /// Log of the total used disk space in bytes, updated every time a new compressed file is
     /// added and when data is transferred.
-    used_disk_space: (TimestampBuilder, UInt32Builder),
+    used_disk_space: StatisticLog,
 }
 
 impl DataTransfer {
@@ -97,12 +95,12 @@ impl DataTransfer {
             remote_data_folder_object_store,
             compressed_files: compressed_files.clone(),
             transfer_batch_size_in_bytes,
-            used_disk_space: (TimestampBuilder::new(), UInt32Builder::new()),
+            used_disk_space: StatisticLog::new(),
         };
 
         // Log the initial used disk space.
         let initial_disk_space: usize = compressed_files.values().into_iter().sum();
-        data_transfer.log_used_disk_space(initial_disk_space as isize);
+        data_transfer.used_disk_space.add_entry(initial_disk_space as isize, true);
 
         // Check if data should be transferred immediately.
         for (table_name, size_in_bytes) in compressed_files.iter() {
@@ -132,7 +130,7 @@ impl DataTransfer {
             self.compressed_files.insert(table_name.to_owned(), 0);
         }
         *self.compressed_files.get_mut(table_name).unwrap() += file_size;
-        self.log_used_disk_space(file_size as isize);
+        self.used_disk_space.add_entry(file_size as isize, true);
 
         // If the combined size of the files is larger than the batch size, transfer the data to the
         // remote object store.
@@ -231,7 +229,7 @@ impl DataTransfer {
         // Delete the transferred files from the in-memory tracking of compressed files.
         let transferred_bytes: usize = read_object_metas.iter().map(|meta| meta.size).sum();
         *self.compressed_files.get_mut(table_name).unwrap() -= transferred_bytes;
-        self.log_used_disk_space(-(transferred_bytes as isize));
+        self.used_disk_space.add_entry(-(transferred_bytes as isize), true);
 
         debug!(
             "Transferred {} bytes of compressed data to path '{}' in remote object store.",
@@ -256,15 +254,6 @@ impl DataTransfer {
             }
         }
         None
-    }
-
-    /// Add an entry to the used disk space log with the current timestamp and a new value
-    /// calculated based on the previous value.
-    fn log_used_disk_space(&mut self, value_change: isize) {
-        self.used_disk_space.0.append_value(create_timestamp());
-
-        let last_value = self.used_disk_space.1.values_slice().last().unwrap_or(&0);
-        self.used_disk_space.1.append_value((*last_value as isize + value_change) as u32);
     }
 }
 

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -489,6 +489,8 @@ mod tests {
             0 as usize
         );
 
+        // The used disk space log should have an entry for when the data transfer component is
+        // created and for when the transferred files are deleted from disk.
         assert_eq!(data_transfer.used_disk_space_metric.read().await.values.len(), 2);
     }
 

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -261,8 +261,8 @@ impl DataTransfer {
 mod tests {
     use super::*;
     use std::fs;
-    use datafusion::arrow::array::ArrayBuilder;
 
+    use ringbuf::Rb;
     use tempfile::{self, TempDir};
 
     use crate::storage::test_util;

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -519,6 +519,7 @@ mod tests {
             local_data_folder_path.to_path_buf(),
             remote_data_folder_object_store,
             COMPRESSED_FILE_SIZE * 3 - 1,
+            Arc::new(RwLock::new(Log::new())),
         )
         .await
         .unwrap();

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -57,7 +57,7 @@ pub struct DataTransfer {
     transfer_batch_size_in_bytes: usize,
     /// Log of the total used disk space in bytes, updated every time a new compressed file is
     /// added and when data is transferred.
-    used_disk_space_log: Log,
+    pub used_disk_space_log: Log,
 }
 
 impl DataTransfer {

--- a/server/src/storage/data_transfer.rs
+++ b/server/src/storage/data_transfer.rs
@@ -261,6 +261,7 @@ impl DataTransfer {
 mod tests {
     use super::*;
     use std::fs;
+    use datafusion::arrow::array::ArrayBuilder;
 
     use tempfile::{self, TempDir};
 
@@ -321,6 +322,8 @@ mod tests {
             *data_transfer.compressed_files.get(TABLE_NAME).unwrap(),
             COMPRESSED_FILE_SIZE * 2
         );
+
+        assert_eq!(data_transfer.used_disk_space_log.read().await.values.len(), 1);
     }
 
     #[tokio::test]
@@ -485,6 +488,8 @@ mod tests {
             *data_transfer.compressed_files.get(TABLE_NAME).unwrap(),
             0 as usize
         );
+
+        assert_eq!(data_transfer.used_disk_space_log.read().await.values.len(), 2);
     }
 
     /// Set up a data folder with a table folder that has a single compressed file in it. Return the

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -361,6 +361,8 @@ pub struct Log {
     timestamps: TimestampBuilder,
     /// Builder consisting of values.
     values: UInt32Builder,
+    /// Since the values builder is cleared when the log is finished, the last value is saved separately.
+    last_value: isize,
 }
 
 impl Log {
@@ -368,6 +370,7 @@ impl Log {
         Self {
             timestamps: TimestampBuilder::new(),
             values: UInt32Builder::new(),
+            last_value: 0,
         }
     }
 
@@ -380,12 +383,12 @@ impl Log {
 
         let mut new_value = value;
         if based_on_last {
-            let last_value = self.values.values_slice().last().unwrap_or(&0);
-            new_value = *last_value as isize + value;
+            new_value = self.last_value + value;
         }
 
         self.timestamps.append_value(timestamp);
         self.values.append_value(new_value as u32);
+        self.last_value = new_value;
     }
 
     /// Finish and reset the internal builders and return the finished Apache Arrow arrays.

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -399,14 +399,6 @@ pub(self) fn create_time_and_value_range_file_name(batch: &RecordBatch) -> Strin
     )
 }
 
-/// Return the current milliseconds since the Unix epoch.
-pub(self) fn create_timestamp() -> Timestamp {
-    // unwrap() is safe since the Unix epoch is always earlier than now.
-    let since_the_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-
-    return since_the_epoch.as_millis() as Timestamp;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -266,29 +266,29 @@ impl StorageEngine {
     }
 
     /// Collect and return the metrics of used uncompressed/compressed memory, used disk space, and ingested
-    /// data points over time. The metrics are returned in tuples with the format (metric_name, (timestamps, values)).
-    pub async fn collect_metrics(&mut self) -> Vec<(String, (TimestampArray, UInt32Array))> {
+    /// data points over time. The metrics are returned in tuples with the format (metric_type, (timestamps, values)).
+    pub async fn collect_metrics(&mut self) -> Vec<(MetricType, (TimestampArray, UInt32Array))> {
         vec![
             (
-                MetricType::UsedUncompressedMemory.to_string(),
+                MetricType::UsedUncompressedMemory,
                 self.uncompressed_data_manager
                     .used_uncompressed_memory_metric
                     .finish(),
             ),
             (
-                MetricType::UsedCompressedMemory.to_string(),
+                MetricType::UsedCompressedMemory,
                 self.compressed_data_manager
                     .used_compressed_memory_metric
                     .finish(),
             ),
             (
-                MetricType::IngestedDataPoints.to_string(),
+                MetricType::IngestedDataPoints,
                 self.uncompressed_data_manager
                     .ingested_data_points_metric
                     .finish(),
             ),
             (
-                MetricType::UsedDiskSpace.to_string(),
+                MetricType::UsedDiskSpace,
                 self.compressed_data_manager
                     .used_disk_space_metric
                     .write()
@@ -359,7 +359,7 @@ impl StorageEngine {
 }
 
 /// The different types of metrics that are collected in the storage engine.
-enum MetricType {
+pub enum MetricType {
     UsedUncompressedMemory,
     UsedCompressedMemory,
     IngestedDataPoints,
@@ -384,7 +384,7 @@ pub struct Metric {
     /// Builder consisting of values.
     values: UInt32Builder,
     /// Last saved metric value, used to support updating the metric based on a change to the last
-    /// value instead of with a direct new value. Since the values builder is cleared when the metric
+    /// value instead of simply storing the new value. Since the values builder is cleared when the metric
     /// is finished, the last value is saved separately.
     last_value: isize,
 }

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -32,6 +32,7 @@ use std::io::{Error as IOError, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use datafusion::arrow::array::UInt32Builder;
 
 use datafusion::arrow::compute::kernels::aggregate;
 use datafusion::arrow::datatypes::SchemaRef;
@@ -55,7 +56,7 @@ use crate::storage::compressed_data_manager::CompressedDataManager;
 use crate::storage::data_transfer::DataTransfer;
 use crate::storage::uncompressed_data_buffer::UncompressedDataBuffer;
 use crate::storage::uncompressed_data_manager::UncompressedDataManager;
-use crate::types::{Timestamp, TimestampArray, Value, ValueArray};
+use crate::types::{Timestamp, TimestampArray, TimestampBuilder, Value, ValueArray};
 
 /// The folder storing uncompressed data in the data folders.
 pub const UNCOMPRESSED_DATA_FOLDER: &str = "uncompressed";
@@ -311,6 +312,23 @@ impl StorageEngine {
             bytes == APACHE_PARQUET_FILE_SIGNATURE
         } else {
             false
+        }
+    }
+}
+
+/// Log used to record changes in specific attributes in the storage engine.
+struct StatisticLog {
+    /// Builder consisting of millisecond precision timestamps.
+    timestamps: TimestampBuilder,
+    /// Builder consisting of values.
+    values: UInt32Builder,
+}
+
+impl StatisticLog {
+    fn new() -> Self {
+        Self {
+            timestamps: TimestampBuilder::new(),
+            values: UInt32Builder::new(),
         }
     }
 }

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -317,14 +317,14 @@ impl StorageEngine {
 }
 
 /// Log used to record changes in specific attributes in the storage engine.
-struct StatisticLog {
+struct Log {
     /// Builder consisting of millisecond precision timestamps.
     timestamps: TimestampBuilder,
     /// Builder consisting of values.
     values: UInt32Builder,
 }
 
-impl StatisticLog {
+impl Log {
     fn new() -> Self {
         Self {
             timestamps: TimestampBuilder::new(),

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -28,6 +28,7 @@ mod uncompressed_data_manager;
 
 use datafusion::arrow::array::{UInt32Array, UInt32Builder};
 use std::ffi::OsStr;
+use std::fmt;
 use std::fs::File;
 use std::io::{Error as IOError, Write};
 use std::path::{Path, PathBuf};
@@ -365,13 +366,13 @@ enum MetricType {
     UsedDiskSpace,
 }
 
-impl MetricType {
-    fn to_string(&self) -> String {
+impl fmt::Display for MetricType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::UsedUncompressedMemory => "used_uncompressed_memory".to_string(),
-            Self::UsedCompressedMemory => "used_compressed_memory".to_string(),
-            Self::IngestedDataPoints => "ingested_data_bytes".to_string(),
-            Self::UsedDiskSpace => "used_disk_space".to_string(),
+            Self::UsedUncompressedMemory => write!(f, "used_uncompressed_memory"),
+            Self::UsedCompressedMemory => write!(f, "used_compressed_memory"),
+            Self::IngestedDataPoints => write!(f, "ingested_data_bytes"),
+            Self::UsedDiskSpace => write!(f, "used_disk_space"),
         }
     }
 }

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -32,7 +32,6 @@ use std::io::{Error as IOError, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use datafusion::arrow::array::UInt32Builder;
 
 use datafusion::arrow::compute::kernels::aggregate;
 use datafusion::arrow::datatypes::SchemaRef;
@@ -56,7 +55,7 @@ use crate::storage::compressed_data_manager::CompressedDataManager;
 use crate::storage::data_transfer::DataTransfer;
 use crate::storage::uncompressed_data_buffer::UncompressedDataBuffer;
 use crate::storage::uncompressed_data_manager::UncompressedDataManager;
-use crate::types::{Timestamp, TimestampArray, TimestampBuilder, Value, ValueArray};
+use crate::types::{Timestamp, TimestampArray, Value, ValueArray};
 
 /// The folder storing uncompressed data in the data folders.
 pub const UNCOMPRESSED_DATA_FOLDER: &str = "uncompressed";
@@ -362,19 +361,15 @@ pub(self) fn create_time_and_value_range_file_name(batch: &RecordBatch) -> Strin
 
 /// Create and add an entry to the logs used to create internal statistics. The timestamp is in
 /// milliseconds and the value is calculated based on the last log entry and the new value change.
-pub(self) fn create_log_entry(
-    mut current_logs: (TimestampBuilder, UInt32Builder),
-    value_change: isize,
-) {
+pub(self) fn create_log_entry(values: &[u32], value_change: isize) -> (Timestamp, u32) {
     // unwrap() is safe since the Unix epoch is always earlier than now.
     let since_the_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
     let timestamp = since_the_epoch.as_millis() as Timestamp;
 
-    let last_value = current_logs.1.values_slice().last().unwrap_or(&0);
+    let last_value = values.last().unwrap_or(&0);
     let new_value = (*last_value as isize + value_change) as u32;
 
-    current_logs.0.append_value(timestamp);
-    current_logs.1.append_value(new_value);
+    (timestamp, new_value)
 }
 
 #[cfg(test)]

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -424,10 +424,10 @@ impl Metric {
 
     /// Finish and reset the internal ring buffers and return the timestamps and values as Apache Arrow arrays.
     fn finish(&mut self) -> (TimestampArray, UInt32Array) {
-        let timestamps = self.timestamps.pop_iter().collect::<Vec<Timestamp>>();
-        let values = self.values.pop_iter().collect::<Vec<u32>>();
+        let timestamps = TimestampArray::from_iter_values(self.timestamps.pop_iter());
+        let values = UInt32Array::from_iter_values(self.values.pop_iter());
 
-        (TimestampArray::from(timestamps), UInt32Array::from(values))
+        (timestamps, values)
     }
 }
 

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -269,25 +269,25 @@ impl StorageEngine {
     pub async fn collect_metrics(&mut self) -> Vec<(String, (TimestampArray, UInt32Array))> {
         vec![
             (
-                "used_uncompressed_memory".to_owned(),
+                MetricType::UsedUncompressedMemory.to_string(),
                 self.uncompressed_data_manager
                     .used_uncompressed_memory_metric
                     .finish(),
             ),
             (
-                "used_compressed_memory".to_owned(),
+                MetricType::UsedCompressedMemory.to_string(),
                 self.compressed_data_manager
                     .used_compressed_memory_metric
                     .finish(),
             ),
             (
-                "ingested_data_points".to_owned(),
+                MetricType::IngestedDataPoints.to_string(),
                 self.uncompressed_data_manager
                     .ingested_data_points_metric
                     .finish(),
             ),
             (
-                "used_disk_space".to_owned(),
+                MetricType::UsedDiskSpace.to_string(),
                 self.compressed_data_manager
                     .used_disk_space_metric
                     .write()
@@ -353,6 +353,25 @@ impl StorageEngine {
             bytes == APACHE_PARQUET_FILE_SIGNATURE
         } else {
             false
+        }
+    }
+}
+
+/// The different types of metrics that are collected in the storage engine.
+enum MetricType {
+    UsedUncompressedMemory,
+    UsedCompressedMemory,
+    IngestedDataPoints,
+    UsedDiskSpace,
+}
+
+impl MetricType {
+    fn to_string(&self) -> String {
+        match self {
+            Self::UsedUncompressedMemory => "used_uncompressed_memory".to_string(),
+            Self::UsedCompressedMemory => "used_compressed_memory".to_string(),
+            Self::IngestedDataPoints => "ingested_data_bytes".to_string(),
+            Self::UsedDiskSpace => "used_disk_space".to_string(),
         }
     }
 }

--- a/server/src/storage/mod.rs
+++ b/server/src/storage/mod.rs
@@ -359,17 +359,12 @@ pub(self) fn create_time_and_value_range_file_name(batch: &RecordBatch) -> Strin
     )
 }
 
-/// Create and add an entry to the logs used to create internal statistics. The timestamp is in
-/// milliseconds and the value is calculated based on the last log entry and the new value change.
-pub(self) fn create_log_entry(values: &[u32], value_change: isize) -> (Timestamp, u32) {
+/// Return the current milliseconds since the Unix epoch.
+pub(self) fn create_timestamp() -> Timestamp {
     // unwrap() is safe since the Unix epoch is always earlier than now.
     let since_the_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-    let timestamp = since_the_epoch.as_millis() as Timestamp;
 
-    let last_value = values.last().unwrap_or(&0);
-    let new_value = (*last_value as isize + value_change) as u32;
-
-    (timestamp, new_value)
+    return since_the_epoch.as_millis() as Timestamp;
 }
 
 #[cfg(test)]

--- a/server/src/storage/uncompressed_data_buffer.rs
+++ b/server/src/storage/uncompressed_data_buffer.rs
@@ -440,7 +440,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(uncompressed_on_disk_buffer.disk_size(), 691)
+        assert_eq!(uncompressed_on_disk_buffer.disk_size(), 675)
     }
 
     #[tokio::test]

--- a/server/src/storage/uncompressed_data_buffer.rs
+++ b/server/src/storage/uncompressed_data_buffer.rs
@@ -57,6 +57,9 @@ pub trait UncompressedDataBuffer: fmt::Debug + Sync + Send {
     /// Return the total amount of memory used by the buffer.
     fn memory_size(&self) -> usize;
 
+    /// Return the total amount of disk space used by the buffer.
+    fn disk_size(&self) -> usize;
+
     /// Since both [`UncompressedInMemoryDataBuffers`](UncompressedInMemoryDataBuffer) and
     /// [`UncompressedOnDiskDataBuffers`](UncompressedOnDiskDataBuffer) are present in the queue,
     /// both structs need to implement spilling to Apache Parquet, with already spilled segments
@@ -168,6 +171,11 @@ impl UncompressedDataBuffer for UncompressedInMemoryDataBuffer {
         UncompressedInMemoryDataBuffer::memory_size()
     }
 
+    /// Since the data is not kept on disk, return 0.
+    fn disk_size(&self) -> usize {
+        0
+    }
+
     /// Spill the in-memory [`UncompressedInMemoryDataBuffer`] to an Apache Parquet file and return
     /// the [`UncompressedOnDiskDataBuffer`] when finished.
     async fn spill_to_apache_parquet(
@@ -273,6 +281,12 @@ impl UncompressedDataBuffer for UncompressedOnDiskDataBuffer {
         0
     }
 
+    /// Return the total size of the Apache Parquet file containing the uncompressed data buffer.
+    fn disk_size(&self) -> usize {
+        // unwrap() is safe since the path is created internally.
+        self.file_path.metadata().unwrap().len() as usize
+    }
+
     /// Since the buffer has already been spilled, return [`IOError`].
     async fn spill_to_apache_parquet(
         &mut self,
@@ -306,6 +320,13 @@ mod tests {
             + (uncompressed_buffer.values.capacity() * mem::size_of::<Value>());
 
         assert_eq!(UncompressedInMemoryDataBuffer::memory_size(), expected)
+    }
+
+    #[test]
+    fn test_get_in_memory_data_buffer_disk_size() {
+        let uncompressed_buffer = UncompressedInMemoryDataBuffer::new(1);
+
+        assert_eq!(uncompressed_buffer.disk_size(), 0);
     }
 
     #[test]
@@ -405,6 +426,21 @@ mod tests {
         };
 
         assert_eq!(uncompressed_buffer.memory_size(), 0)
+    }
+
+    #[tokio::test]
+    async fn test_get_on_disk_data_buffer_disk_size() {
+        let mut uncompressed_in_memory_buffer = UncompressedInMemoryDataBuffer::new(1);
+        let capacity = uncompressed_in_memory_buffer.capacity();
+        insert_data_points(capacity, &mut uncompressed_in_memory_buffer);
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let uncompressed_on_disk_buffer = uncompressed_in_memory_buffer
+            .spill_to_apache_parquet(temp_dir.path(), &test_util::uncompressed_schema())
+            .await
+            .unwrap();
+
+        assert_eq!(uncompressed_on_disk_buffer.disk_size(), 898)
     }
 
     #[tokio::test]

--- a/server/src/storage/uncompressed_data_buffer.rs
+++ b/server/src/storage/uncompressed_data_buffer.rs
@@ -440,7 +440,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(uncompressed_on_disk_buffer.disk_size(), 828)
+        assert_eq!(uncompressed_on_disk_buffer.disk_size(), 691)
     }
 
     #[tokio::test]

--- a/server/src/storage/uncompressed_data_buffer.rs
+++ b/server/src/storage/uncompressed_data_buffer.rs
@@ -440,7 +440,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(uncompressed_on_disk_buffer.disk_size(), 898)
+        assert_eq!(uncompressed_on_disk_buffer.disk_size(), 828)
     }
 
     #[tokio::test]

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -60,9 +60,9 @@ pub(super) struct UncompressedDataManager {
     /// If this is true, compress finished buffers directly instead of queueing them.
     compress_directly: bool,
     /// Log of the used uncompressed memory in bytes, updated every time the used memory changes.
-    used_uncompressed_memory_log: Log,
+    pub(super) used_uncompressed_memory_log: Log,
     /// Log of the amount of ingested data points, updated every time a new batch of data is ingested.
-    ingested_data_points_log: Log,
+    pub(super) ingested_data_points_log: Log,
 }
 
 impl UncompressedDataManager {

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -409,7 +409,7 @@ impl UncompressedDataManager {
             .last()
             .unwrap_or(&0);
         let value_change = self.uncompressed_remaining_memory_in_bytes as isize - value as isize;
-        self.uncompressed_used_memory.1.append_value((last_value as isize - value_change) as u32);
+        self.uncompressed_used_memory.1.append_value((*last_value as isize - value_change) as u32);
 
         self.uncompressed_remaining_memory_in_bytes = value;
     }

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -759,6 +759,10 @@ mod tests {
         );
 
         assert_eq!(data_manager.used_uncompressed_memory_metric.values.len(), 3);
+
+        // The used disk space metric should have an entry for when the uncompressed data manager is
+        // created, an entry for when the data buffer is spilled to disk, and an entry for when the
+        // finished data buffer is popped.
         assert_eq!(data_manager.used_disk_space_metric.read().await.values.len(), 3);
     }
 

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -440,9 +440,9 @@ mod tests {
     use super::*;
     use std::path::Path;
     use std::sync::Arc;
-    use datafusion::arrow::array::ArrayBuilder;
 
     use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
+    use ringbuf::Rb;
     use tempfile;
 
     use crate::metadata::{test_util, MetadataManager};

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -486,7 +486,9 @@ mod tests {
         assert_eq!(
             data_manager.active_uncompressed_data_buffers.keys().len(),
             2
-        )
+        );
+
+        assert_eq!(data_manager.ingested_data_points_log.values.len(), 1);
     }
 
     #[tokio::test]
@@ -507,7 +509,9 @@ mod tests {
         assert_eq!(
             data_manager.active_uncompressed_data_buffers.keys().len(),
             4
-        )
+        );
+
+        assert_eq!(data_manager.ingested_data_points_log.values.len(), 1);
     }
 
     /// Create a record batch with data that resembles uncompressed data with a single tag and two
@@ -568,7 +572,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_can_insert_message_into_existing_uncompressed_data_buffer() {
+    async fn test_can_insert_data_point_into_existing_uncompressed_data_buffer() {
         let temp_dir = tempfile::tempdir().unwrap();
         let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
         insert_data_points(2, &mut data_manager, UNIVARIATE_ID).await;

--- a/server/src/storage/uncompressed_data_manager.rs
+++ b/server/src/storage/uncompressed_data_manager.rs
@@ -20,9 +20,11 @@ use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::io::{Error as IOError, ErrorKind as IOErrorKind};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, StringArray};
 use datafusion::arrow::record_batch::RecordBatch;
+use tokio::sync::RwLock;
 use tracing::debug;
 
 use crate::metadata::model_table_metadata::ModelTableMetadata;
@@ -63,6 +65,8 @@ pub(super) struct UncompressedDataManager {
     pub(super) used_uncompressed_memory_log: Log,
     /// Log of the amount of ingested data points, updated every time a new batch of data is ingested.
     pub(super) ingested_data_points_log: Log,
+    /// Log of the total used disk space in bytes, updated every time uncompressed data is spilled.
+    pub used_disk_space_log: Arc<RwLock<Log>>,
 }
 
 impl UncompressedDataManager {
@@ -70,12 +74,13 @@ impl UncompressedDataManager {
     /// `local_data_folder` and an [`UncompressedOnDiskDataBuffer`] can be initialized for all
     /// Apache Parquet files containing uncompressed data points in `local_data_store`, otherwise
     /// [`IOError`] is returned.
-    pub(super) fn try_new(
+    pub(super) async fn try_new(
         local_data_folder: PathBuf,
         uncompressed_reserved_memory_in_bytes: usize,
         uncompressed_schema: UncompressedSchema,
         compressed_schema: CompressedSchema,
         compress_directly: bool,
+        used_disk_space_log: Arc<RwLock<Log>>,
     ) -> Result<Self, IOError> {
         // Ensure the folder required by the uncompressed data manager exists.
         let local_uncompressed_data_folder = local_data_folder.join(UNCOMPRESSED_DATA_FOLDER);
@@ -101,6 +106,16 @@ impl UncompressedDataManager {
             }
         }
 
+        // Log the used disk space of the uncompressed data buffers currently on disk.
+        let initial_disk_space: usize = finished_data_buffers
+            .iter()
+            .map(|buffer| buffer.disk_size())
+            .sum();
+        used_disk_space_log
+            .write()
+            .await
+            .add_entry(initial_disk_space as isize, true);
+
         Ok(Self {
             local_data_folder,
             active_uncompressed_data_buffers: HashMap::new(),
@@ -111,6 +126,7 @@ impl UncompressedDataManager {
             compress_directly,
             used_uncompressed_memory_log: Log::new(),
             ingested_data_points_log: Log::new(),
+            used_disk_space_log,
         })
     }
 
@@ -134,7 +150,8 @@ impl UncompressedDataManager {
         );
 
         // Log the amount of ingested data points.
-        self.ingested_data_points_log.add_entry(data_points.num_rows() as isize, false);
+        self.ingested_data_points_log
+            .add_entry(data_points.num_rows() as isize, false);
 
         // Prepare the timestamp column for iteration.
         let timestamp_index = model_table.timestamp_column_index;
@@ -297,7 +314,8 @@ impl UncompressedDataManager {
 
             let used_memory = UncompressedInMemoryDataBuffer::memory_size();
             self.uncompressed_remaining_memory_in_bytes -= used_memory;
-            self.used_uncompressed_memory_log.add_entry(used_memory as isize, true);
+            self.used_uncompressed_memory_log
+                .add_entry(used_memory as isize, true);
 
             debug!(
                 "Created buffer for {}. Remaining reserved bytes: {}.",
@@ -315,12 +333,19 @@ impl UncompressedDataManager {
     /// Remove the oldest finished [`UncompressedDataBuffer`] from the queue and return it. Returns
     /// [`None`] if there are no finished [`UncompressedDataBuffers`](UncompressedDataBuffer) in the
     /// queue.
-    pub(super) fn finished_data_buffer(&mut self) -> Option<Box<dyn UncompressedDataBuffer>> {
+    pub(super) async fn finished_data_buffer(&mut self) -> Option<Box<dyn UncompressedDataBuffer>> {
         if let Some(uncompressed_data_buffer) = self.finished_uncompressed_data_buffers.pop_front()
         {
             // Add the memory size of the removed buffer back to the remaining bytes and log the change.
             self.uncompressed_remaining_memory_in_bytes += uncompressed_data_buffer.memory_size();
-            self.used_uncompressed_memory_log.add_entry(-(uncompressed_data_buffer.memory_size() as isize), true);
+            self.used_uncompressed_memory_log
+                .add_entry(-(uncompressed_data_buffer.memory_size() as isize), true);
+
+            // Since the buffer was potentially on disk, log the potential change to the used disk space.
+            self.used_disk_space_log
+                .write()
+                .await
+                .add_entry(-(uncompressed_data_buffer.disk_size() as isize), true);
 
             Some(uncompressed_data_buffer)
         } else {
@@ -339,7 +364,8 @@ impl UncompressedDataManager {
         // Add the size of the segment back to the remaining reserved bytes and log the change.
         let freed_memory = UncompressedInMemoryDataBuffer::memory_size();
         self.uncompressed_remaining_memory_in_bytes += freed_memory;
-        self.used_uncompressed_memory_log.add_entry(-(freed_memory as isize), true);
+        self.used_uncompressed_memory_log
+            .add_entry(-(freed_memory as isize), true);
 
         // unwrap() is safe to use since the error bound is not negative, infinite, or NAN.
         let error_bound = ErrorBound::try_new(0.0).unwrap();
@@ -384,7 +410,14 @@ impl UncompressedDataManager {
                 // Add the size of the in-memory data buffer back to the remaining reserved bytes.
                 let freed_memory = UncompressedInMemoryDataBuffer::memory_size();
                 self.uncompressed_remaining_memory_in_bytes += freed_memory;
-                self.used_uncompressed_memory_log.add_entry(-(freed_memory as isize), true);
+                self.used_uncompressed_memory_log
+                    .add_entry(-(freed_memory as isize), true);
+
+                // Log the used disk space of the spilled finished buffer.
+                self.used_disk_space_log
+                    .write()
+                    .await
+                    .add_entry(uncompressed_on_disk_data_buffer.disk_size() as isize, true);
 
                 debug!(
                     "Spilled '{:?}'. Remaining reserved bytes: {}.",
@@ -430,14 +463,14 @@ mod tests {
             .unwrap();
 
         // The uncompressed data buffer should be referenced by the uncompressed data manager.
-        let (_metadata_manager, data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, data_manager) = create_managers(temp_dir.path()).await;
         assert_eq!(data_manager.finished_uncompressed_data_buffers.len(), 1)
     }
 
     #[tokio::test]
     async fn test_can_insert_record_batch() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (mut metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (mut metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
 
         let (model_table_metadata, data) = uncompressed_data(1);
         metadata_manager
@@ -458,7 +491,7 @@ mod tests {
     #[tokio::test]
     async fn test_can_insert_record_batch_with_multiple_data_points() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (mut metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (mut metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
 
         let (model_table_metadata, data) = uncompressed_data(2);
         metadata_manager
@@ -517,7 +550,7 @@ mod tests {
     #[tokio::test]
     async fn test_can_insert_data_point_into_new_uncompressed_data_buffer() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
         insert_data_points(1, &mut data_manager, UNIVARIATE_ID).await;
 
         assert!(data_manager
@@ -536,7 +569,7 @@ mod tests {
     #[tokio::test]
     async fn test_can_insert_message_into_existing_uncompressed_data_buffer() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
         insert_data_points(2, &mut data_manager, UNIVARIATE_ID).await;
 
         assert!(data_manager
@@ -555,7 +588,7 @@ mod tests {
     #[tokio::test]
     async fn test_can_get_finished_uncompressed_data_buffer_when_finished() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
         insert_data_points(
             UNCOMPRESSED_DATA_BUFFER_CAPACITY,
             &mut data_manager,
@@ -563,13 +596,13 @@ mod tests {
         )
         .await;
 
-        assert!(data_manager.finished_data_buffer().is_some());
+        assert!(data_manager.finished_data_buffer().await.is_some());
     }
 
     #[tokio::test]
     async fn test_can_get_multiple_finished_uncompressed_data_buffers_when_multiple_finished() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
         insert_data_points(
             UNCOMPRESSED_DATA_BUFFER_CAPACITY * 2,
             &mut data_manager,
@@ -577,22 +610,22 @@ mod tests {
         )
         .await;
 
-        assert!(data_manager.finished_data_buffer().is_some());
-        assert!(data_manager.finished_data_buffer().is_some());
+        assert!(data_manager.finished_data_buffer().await.is_some());
+        assert!(data_manager.finished_data_buffer().await.is_some());
     }
 
-    #[test]
-    fn test_cannot_get_finished_uncompressed_data_buffers_when_none_are_finished() {
+    #[tokio::test]
+    async fn test_cannot_get_finished_uncompressed_data_buffers_when_none_are_finished() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
 
-        assert!(data_manager.finished_data_buffer().is_none());
+        assert!(data_manager.finished_data_buffer().await.is_none());
     }
 
     #[tokio::test]
     async fn test_spill_first_uncompressed_data_buffer_to_disk_if_out_of_memory() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
         let reserved_memory = data_manager.uncompressed_remaining_memory_in_bytes;
 
         // Insert messages into the storage engine until a buffer is spilled to Apache Parquet.
@@ -618,7 +651,7 @@ mod tests {
     #[tokio::test]
     async fn test_ignore_already_spilled_uncompressed_data_buffer_when_spilling() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
         insert_data_points(
             UNCOMPRESSED_DATA_BUFFER_CAPACITY * 2,
             &mut data_manager,
@@ -648,7 +681,7 @@ mod tests {
     #[tokio::test]
     async fn test_remaining_memory_incremented_when_spilling_finished_uncompressed_data_buffer() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
 
         insert_data_points(
             UNCOMPRESSED_DATA_BUFFER_CAPACITY,
@@ -665,7 +698,7 @@ mod tests {
     #[tokio::test]
     async fn test_remaining_memory_decremented_when_creating_new_uncompressed_data_buffer() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
         let reserved_memory = data_manager.uncompressed_remaining_memory_in_bytes;
 
         insert_data_points(1, &mut data_manager, UNIVARIATE_ID).await;
@@ -676,7 +709,7 @@ mod tests {
     #[tokio::test]
     async fn test_remaining_memory_incremented_when_popping_in_memory() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
         insert_data_points(
             UNCOMPRESSED_DATA_BUFFER_CAPACITY,
             &mut data_manager,
@@ -685,7 +718,7 @@ mod tests {
         .await;
 
         let remaining_memory = data_manager.uncompressed_remaining_memory_in_bytes.clone();
-        data_manager.finished_data_buffer();
+        data_manager.finished_data_buffer().await;
 
         assert!(remaining_memory < data_manager.uncompressed_remaining_memory_in_bytes);
     }
@@ -693,7 +726,7 @@ mod tests {
     #[tokio::test]
     async fn test_remaining_memory_not_incremented_when_popping_spilled() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
         insert_data_points(
             UNCOMPRESSED_DATA_BUFFER_CAPACITY,
             &mut data_manager,
@@ -706,7 +739,7 @@ mod tests {
 
         // Since the UncompressedOnDiskDataBuffer is not in memory, the remaining memory should not
         // increase when popped.
-        data_manager.finished_data_buffer();
+        data_manager.finished_data_buffer().await;
 
         assert_eq!(
             remaining_memory,
@@ -718,7 +751,7 @@ mod tests {
     #[should_panic(expected = "Not enough reserved memory for the necessary uncompressed buffers.")]
     async fn test_panic_if_not_enough_reserved_memory() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path());
+        let (_metadata_manager, mut data_manager) = create_managers(temp_dir.path()).await;
         let reserved_memory = data_manager.uncompressed_remaining_memory_in_bytes;
 
         // If there is enough reserved memory to hold n builders, we need to create n + 1 to panic.
@@ -744,7 +777,7 @@ mod tests {
 
     /// Create an [`UncompressedDataManager`] with a folder that is deleted once the test is
     /// finished.
-    fn create_managers(path: &Path) -> (MetadataManager, UncompressedDataManager) {
+    async fn create_managers(path: &Path) -> (MetadataManager, UncompressedDataManager) {
         let metadata_manager = test_util::test_metadata_manager(path);
 
         let local_data_folder = metadata_manager.local_data_folder();
@@ -755,7 +788,9 @@ mod tests {
             metadata_manager.uncompressed_schema(),
             metadata_manager.compressed_schema(),
             false,
+            Arc::new(RwLock::new(Log::new())),
         )
+        .await
         .unwrap();
 
         (metadata_manager, uncompressed_data_manager)

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -51,9 +51,12 @@ pub mod tests {
 pub type ValueBuilder = datafusion::arrow::array::PrimitiveBuilder<ArrowValue>;
 pub type ValueArray = datafusion::arrow::array::PrimitiveArray<ArrowValue>;
 
-// Types used for the schema of uncompressed and compressed data.
+// Types used for the schema of uncompressed data, compressed data, and metrics.
 #[derive(Clone)]
 pub struct UncompressedSchema(pub datafusion::arrow::datatypes::SchemaRef);
 
 #[derive(Clone)]
 pub struct CompressedSchema(pub datafusion::arrow::datatypes::SchemaRef);
+
+#[derive(Clone)]
+pub struct MetricSchema(pub datafusion::arrow::datatypes::SchemaRef);


### PR DESCRIPTION
This PR includes changes to the storage engine and API to support collecting internal statistics and retrieving them through the Arrow Flight API. Data on the used compressed and uncompressed memory is recorded every time the remaining reserved memory is changed. When uncompressed data is spilled to disk or when compressed files are saved to disk, the used disk space is recorded. Finally, every time a batch of data points is ingested, the number of data points are recorded.