### PR TITLE
Add --all-targets to cargo build, clippy, and test

### DIFF
--- a/.github/workflows/cargo-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/cargo-build-lint-and-test-on-pr-and-push.yml
@@ -27,12 +27,12 @@ jobs:
     - name: Cargo Install
       run: cargo install cargo-machete
     - name: Cargo Build
-      run: cargo build --verbose
+      run: cargo build --verbose --all-targets
     - name: Cargo Clippy
-      run: cargo clippy --verbose
+      run: cargo clippy --verbose --all-targets
     - name: Cargo Doc
       run: cargo doc --verbose
     - name: Cargo Machete --with-metadata
       run: cargo machete --with-metadata
     - name: Cargo Test
-      run: cargo test --verbose
+      run: cargo test --verbose --all-targets

--- a/server/src/compression.rs
+++ b/server/src/compression.rs
@@ -678,8 +678,8 @@ mod tests {
     }
 
     fn create_and_compress_time_series(
-        values: &Vec<f32>,
-        timestamps: &Vec<i64>,
+        values: &[f32],
+        timestamps: &[i64],
         error_bound: f32,
     ) -> (TimestampArray, RecordBatch) {
         let (uncompressed_timestamps, uncompressed_values) =
@@ -707,11 +707,10 @@ mod tests {
         );
 
         let mut total_compressed_length = 0;
-        for segment in 0..expected_model_type_ids.len() {
-            let expected_model_type_id = expected_model_type_ids[segment];
+        for (segment, expected_model_type_id) in expected_model_type_ids.iter().enumerate() {
             let model_type_id =
                 crate::array!(compressed_record_batch, 1, UInt8Array).value(segment);
-            assert_eq!(expected_model_type_id, model_type_id);
+            assert_eq!(*expected_model_type_id, model_type_id);
 
             let start_time =
                 crate::array!(compressed_record_batch, 2, TimestampArray).value(segment);

--- a/server/tests/integration_test.rs
+++ b/server/tests/integration_test.rs
@@ -743,11 +743,10 @@ fn stop_modelardbd(mut flight_server: Child) {
         system.refresh_all();
         flight_server
             .kill()
-            .expect(&format!("Could not kill process {}.", flight_server.id()));
-        flight_server.wait().expect(&format!(
-            "Could not wait for process {}.",
-            flight_server.id()
-        ));
+            .unwrap_or_else(|_| panic!("Could not kill process {}.", flight_server.id()));
+        flight_server
+            .wait()
+            .unwrap_or_else(|_| panic!("Could not wait for process {}.", flight_server.id()));
         system.refresh_all();
     }
 }


### PR DESCRIPTION
This PR add --all-targets to cargo build, clippy, and test to ensure the commands are run for all targets in GitHub Actions.