### PR TITLE
Resolve issues with ingestion and processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,6 +1827,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tracing",
  "tracing-subscriber",
@@ -3065,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/crates/modelardb_common/src/macros.rs
+++ b/crates/modelardb_common/src/macros.rs
@@ -16,8 +16,21 @@
 /// Extract an [`array`](arrow::array::Array) from a
 /// [`RecordBatch`](arrow::record_batch::RecordBatch) and cast it to the specified type:
 ///
-/// ``` ignore
-/// let array = modelardb_common::array!(record_batch, 0, UInt8Array);
+/// ```
+/// # use std::sync::Arc;
+/// #
+/// # use arrow::record_batch::RecordBatch;
+/// # use modelardb_common::schemas::UNCOMPRESSED_SCHEMA;
+/// # use modelardb_common::types::{Timestamp, TimestampArray, Value, ValueArray};
+/// #
+/// # let record_batch = RecordBatch::try_new(
+/// #     UNCOMPRESSED_SCHEMA.0.clone(),
+/// #     vec![
+/// #         Arc::new(TimestampArray::from(Vec::<Timestamp>::new())),
+/// #         Arc::new(ValueArray::from(Vec::<Value>::new())),
+/// #     ],
+/// # ).unwrap();
+/// let array = modelardb_common::array!(record_batch, 0, TimestampArray);
 /// ```
 ///
 /// # Panics
@@ -38,7 +51,28 @@ macro_rules! array {
 /// from a [`RecordBatch`](arrow::record_batch::RecordBatch), cast them to the required type, and
 /// assign the resulting arrays to the specified variables:
 ///
-/// ``` ignore
+/// ```
+/// # use std::sync::Arc;
+/// #
+/// # use arrow::array::{BinaryArray, Float32Array, UInt64Array, UInt8Array};
+/// # use arrow::record_batch::RecordBatch;
+/// # use modelardb_common::schemas::COMPRESSED_SCHEMA;
+/// # use modelardb_common::types::{Timestamp, TimestampArray, Value, ValueArray};
+/// #
+/// # let record_batch = RecordBatch::try_new(
+/// #     COMPRESSED_SCHEMA.0.clone(),
+/// #     vec![
+/// #         Arc::new(UInt64Array::from(Vec::<u64>::new())),
+/// #         Arc::new(UInt8Array::from(Vec::<u8>::new())),
+/// #         Arc::new(TimestampArray::from(Vec::<Timestamp>::new())),
+/// #         Arc::new(TimestampArray::from(Vec::<Timestamp>::new())),
+/// #         Arc::new(BinaryArray::from(Vec::<&[u8]>::new())),
+/// #         Arc::new(ValueArray::from(Vec::<Value>::new())),
+/// #         Arc::new(ValueArray::from(Vec::<Value>::new())),
+/// #         Arc::new(BinaryArray::from(Vec::<&[u8]>::new())),
+/// #         Arc::new(Float32Array::from(Vec::<f32>::new())),
+/// #     ],
+/// # ).unwrap();
 /// modelardb_common::arrays!(record_batch, univariate_ids, model_type_ids, start_times, end_times,
 /// timestamps, min_values, max_values, values, errors);
 /// ```

--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -90,87 +90,143 @@ pub fn try_compress(
     Ok(compressed_record_batch_builder.finish(compressed_schema))
 }
 
-/// Merges the segments in `compressed_segments` that contain equivalent models.
-/// Assumes that the segments in `compressed_segments` are all from the same
-/// time series and that the segments are all sorted according to time.
-#[allow(dead_code)]
+/// Merge the segments in `compressed_segments` which are from the same time series, contains
+/// equivalent models, and can be merged without creating overlapping segments. Assumes that the
+/// segments for the time series and time range `compressed_segments` has segments for are all in
+/// `compressed_segments`.
 pub fn merge_segments(compressed_segments: RecordBatch) -> RecordBatch {
-    // TODO: merge segments with none equivalent models.
-
     // Extract the columns from the RecordBatch.
-    let univariate_ids = modelardb_common::array!(compressed_segments, 0, UInt64Array);
-    let model_type_ids = modelardb_common::array!(compressed_segments, 1, UInt8Array);
-    let start_times = modelardb_common::array!(compressed_segments, 2, TimestampArray);
-    let end_times = modelardb_common::array!(compressed_segments, 3, TimestampArray);
-    let timestamps = modelardb_common::array!(compressed_segments, 4, BinaryArray);
-    let min_values = modelardb_common::array!(compressed_segments, 5, ValueArray);
-    let max_values = modelardb_common::array!(compressed_segments, 6, ValueArray);
-    let values = modelardb_common::array!(compressed_segments, 7, BinaryArray);
-    let errors = modelardb_common::array!(compressed_segments, 8, Float32Array);
+    modelardb_common::arrays!(
+        compressed_segments,
+        univariate_ids,
+        model_type_ids,
+        start_times,
+        end_times,
+        timestamps,
+        min_values,
+        max_values,
+        values,
+        errors
+    );
 
-    // For each segment, check if it can be merged with another segment.
+    // For each segment, check if it can be merged with another adjacent segment.
     let num_rows = compressed_segments.num_rows();
-    let mut compressed_segments_to_merge = HashMap::with_capacity(num_rows);
+    let mut can_segments_be_merged = false;
+    let mut univariate_id_to_previous_index = HashMap::new();
+    let mut indexes_to_merge_per_univaraite_id = HashMap::new();
 
-    for index in 0..num_rows {
-        // f32 are converted to u32 with the same bitwise representation as f32
-        // and f64 does not implement std::hash::Hash and thus cannot be hashed.
-        let model = (
-            model_type_ids.value(index),
-            values.value(index),
-            min_values.value(index).to_bits(),
-            max_values.value(index).to_bits(),
-        );
+    for current_index in 0..num_rows {
+        let univariate_id = univariate_ids.value(current_index);
+        let previous_index = *univariate_id_to_previous_index
+            .get(&univariate_id)
+            .unwrap_or(&current_index);
 
-        // Lookup the entry in the HashMap for model, create an empty Vec if an
-        // entry for model did not exist, and append index to the entry's Vec.
-        compressed_segments_to_merge
-            .entry(model)
-            .or_insert_with(Vec::new)
-            .push(index);
+        if can_models_be_merged(
+            previous_index,
+            current_index,
+            univariate_ids,
+            model_type_ids,
+            min_values,
+            max_values,
+            values,
+        ) {
+            indexes_to_merge_per_univaraite_id
+                .entry(univariate_id)
+                .or_insert_with(Vec::new)
+                .push(Some(current_index));
+
+            can_segments_be_merged = previous_index != current_index;
+        } else {
+            // unwrap() is safe as a segment is guaranteed to match itself.
+            let indexes_to_merge = indexes_to_merge_per_univaraite_id
+                .get_mut(&univariate_id)
+                .unwrap();
+            indexes_to_merge.push(None);
+            indexes_to_merge.push(Some(current_index));
+        }
+
+        univariate_id_to_previous_index.insert(univariate_id, current_index);
     }
 
     // If none of the segments can be merged return the original compressed
     // segments, otherwise return the smaller set of merged compressed segments.
-    if compressed_segments_to_merge.len() < num_rows {
+    if can_segments_be_merged {
         let mut merged_compressed_segments = CompressedSegmentBatchBuilder::new(num_rows);
-        for (_, indices) in compressed_segments_to_merge {
-            // Merge timestamps.
-            let mut timestamp_builder = TimestampBuilder::new();
-            for index in &indices {
-                let start_time = start_times.value(*index);
-                let end_time = end_times.value(*index);
-                let timestamps = timestamps.value(*index);
-                timestamps::decompress_all_timestamps(
-                    start_time,
-                    end_time,
-                    timestamps,
-                    &mut timestamp_builder,
-                );
-            }
-            let timestamps = timestamp_builder.finish();
-            let compressed_timestamps =
-                timestamps::compress_residual_timestamps(timestamps.values());
+        let mut index_of_last_segment = 0;
 
-            // Merge segments. The first segment's model is used for the merged
-            // segment as all of the segments contain the exact same model.
-            let index = indices[0];
-            merged_compressed_segments.append_compressed_segment(
-                univariate_ids.value(index),
-                model_type_ids.value(index),
-                timestamps.value(0),
-                timestamps.value(timestamps.len() - 1),
-                &compressed_timestamps,
-                min_values.value(index),
-                max_values.value(index),
-                values.value(index),
-                errors.value(index),
-            );
+        let mut timestamp_builder = TimestampBuilder::new();
+        for (_, mut indexes_to_merge) in indexes_to_merge_per_univaraite_id {
+            indexes_to_merge.push(None);
+            for maybe_index in indexes_to_merge {
+                if let Some(index) = maybe_index {
+                    // Merge timestamps.
+                    let start_time = start_times.value(index);
+                    let end_time = end_times.value(index);
+                    let timestamps = timestamps.value(index);
+
+                    timestamps::decompress_all_timestamps(
+                        start_time,
+                        end_time,
+                        timestamps,
+                        &mut timestamp_builder,
+                    );
+
+                    index_of_last_segment = index;
+                } else {
+                    let timestamps = timestamp_builder.finish();
+                    let compressed_timestamps =
+                        timestamps::compress_residual_timestamps(timestamps.values());
+
+                    // Merge segments. The first segment's model is used for the merged
+                    // segment as all of the segments contain the exact same model.
+                    merged_compressed_segments.append_compressed_segment(
+                        univariate_ids.value(index_of_last_segment),
+                        model_type_ids.value(index_of_last_segment),
+                        timestamps.value(0),
+                        timestamps.value(timestamps.len() - 1),
+                        &compressed_timestamps,
+                        min_values.value(index_of_last_segment),
+                        max_values.value(index_of_last_segment),
+                        values.value(index_of_last_segment),
+                        errors.value(index_of_last_segment),
+                    );
+                }
+            }
         }
         merged_compressed_segments.finish(&CompressedSchema(compressed_segments.schema()))
     } else {
         compressed_segments
     }
+}
+
+/// Return [`true`] if the models at `previous_index` and `current_index` represent values from the
+/// same time series, are of the same type, and are equivalent, otherwise [`false`]. Assumes the
+/// arrays are the same length and that `previous_index` and `current_index` only access values in
+/// the arrays.
+fn can_models_be_merged(
+    previous_index: usize,
+    current_index: usize,
+    univariate_ids: &UInt64Array,
+    model_type_ids: &UInt8Array,
+    min_values: &ValueArray,
+    max_values: &ValueArray,
+    values: &BinaryArray,
+) -> bool {
+    // f32 are converted to u32 with the same bitwise representation as f32
+    // and f64 does not implement std::hash::Hash and thus cannot be hashed.
+    (
+        univariate_ids.value(previous_index),
+        model_type_ids.value(previous_index),
+        min_values.value(previous_index).to_bits(),
+        max_values.value(previous_index).to_bits(),
+        values.value(previous_index),
+    ) == (
+        univariate_ids.value(current_index),
+        model_type_ids.value(current_index),
+        min_values.value(current_index).to_bits(),
+        max_values.value(current_index).to_bits(),
+        values.value(current_index),
+    )
 }
 
 /// A compressed segment being built from an uncompressed segment using the
@@ -716,7 +772,7 @@ mod tests {
         // Add a mix of different segments that can be merged into two segments.
         let mut compressed_record_batch_builder = CompressedSegmentBatchBuilder::new(10);
 
-        for start_time in (100..2000).step_by(400) {
+        for start_time in (100..2100).step_by(400) {
             compressed_record_batch_builder.append_compressed_segment(
                 univariate_id,
                 model_type_id,
@@ -728,7 +784,9 @@ mod tests {
                 values,
                 0.0,
             );
+        }
 
+        for start_time in (2500..4500).step_by(400) {
             compressed_record_batch_builder.append_compressed_segment(
                 univariate_id,
                 model_type_id + 1,
@@ -795,10 +853,89 @@ mod tests {
         assert_eq!(0.0, errors.value(positive));
         assert_eq!(10.0, errors.value(negative));
     }
+
+    // Tests for can_models_be_merged().
+    #[test]
+    fn test_models_can_be_merged() {
+        assert!(can_models_be_merged(
+            0,
+            1,
+            &UInt64Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([1, 1]),
+            &ValueArray::from_iter_values([1.0, 1.0]),
+            &ValueArray::from_iter_values([2.0, 2.0]),
+            &BinaryArray::from_iter_values([[1], [1]])
+        ))
+    }
+
+    #[test]
+    fn test_models_with_different_uids_cannot_be_merged() {
+        assert!(!can_models_be_merged(
+            0,
+            1,
+            &UInt64Array::from_iter_values([1, 2]),
+            &UInt8Array::from_iter_values([1, 1]),
+            &ValueArray::from_iter_values([1.0, 1.0]),
+            &ValueArray::from_iter_values([2.0, 2.0]),
+            &BinaryArray::from_iter_values([[1], [1]])
+        ))
+    }
+
+    #[test]
+    fn test_models_with_different_model_types_cannot_be_merged() {
+        assert!(!can_models_be_merged(
+            0,
+            1,
+            &UInt64Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([1, 2]),
+            &ValueArray::from_iter_values([1.0, 1.0]),
+            &ValueArray::from_iter_values([2.0, 2.0]),
+            &BinaryArray::from_iter_values([[1], [1]])
+        ))
+    }
+
+    #[test]
+    fn test_models_with_different_min_values_cannot_be_merged() {
+        assert!(!can_models_be_merged(
+            0,
+            1,
+            &UInt64Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([1, 1]),
+            &ValueArray::from_iter_values([1.0, 2.0]),
+            &ValueArray::from_iter_values([2.0, 2.0]),
+            &BinaryArray::from_iter_values([[1], [1]])
+        ))
+    }
+
+    #[test]
+    fn test_models_with_different_max_values_cannot_be_merged() {
+        assert!(!can_models_be_merged(
+            0,
+            1,
+            &UInt64Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([1, 1]),
+            &ValueArray::from_iter_values([1.0, 1.0]),
+            &ValueArray::from_iter_values([2.0, 3.0]),
+            &BinaryArray::from_iter_values([[1], [1]])
+        ))
+    }
+
+    #[test]
+    fn test_models_with_different_values_cannot_be_merged() {
+        assert!(!can_models_be_merged(
+            0,
+            1,
+            &UInt64Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([1, 1]),
+            &ValueArray::from_iter_values([1.0, 1.0]),
+            &ValueArray::from_iter_values([2.0, 2.0]),
+            &BinaryArray::from_iter_values([[1], [2]])
+        ))
+    }
 }
 
-#[cfg(test)]
 /// Separate module for utility functions.
+#[cfg(test)]
 pub mod test_util {
     use rand::distributions::Uniform;
     use rand::{thread_rng, Rng};
@@ -809,7 +946,6 @@ pub mod test_util {
         Linear,
         AlmostLinear,
     }
-
     /// Generate constant/random/linear/almost-linear test values with the
     /// [ThreadRng](rand::rngs::thread::ThreadRng) randomizer. The amount of values to be generated
     /// will match `timestamps` and their structure will match [`StructureOfValues`]. If `Random` is

--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -92,10 +92,11 @@ pub fn try_compress(
 
 /// Merge segments in `compressed_segments` that:
 /// * Are from same time series.
-/// * Contains completely equivalent models.
+/// * Contain the exact same models.
 /// * Are consecutive in terms of time.
-/// Assumes that if the sequence of consecutive segments A B C exists for a time series and A C is
-/// in `compressed_segments` then B is also in `compressed_segments`.
+/// Assumes that if the consecutive segments A, B, and C exists for a time series and the segments A
+/// and C are in `compressed_segments` then B is also in `compressed_segments`. If only A and C are
+/// in `compressed_segments` a segment that overlaps with B will be created if A and C are merged.
 pub fn merge_segments(compressed_segments: RecordBatch) -> RecordBatch {
     // Extract the columns from the RecordBatch.
     modelardb_common::arrays!(

--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -94,7 +94,7 @@ pub fn try_compress(
 /// * Are from same time series.
 /// * Contain the exact same models.
 /// * Are consecutive in terms of time.
-/// Assumes that if the consecutive segments A, B, and C exists for a time series and the segments A
+/// Assumes that if the consecutive segments A, B, and C exist for a time series and the segments A
 /// and C are in `compressed_segments` then B is also in `compressed_segments`. If only A and C are
 /// in `compressed_segments` a segment that overlaps with B will be created if A and C are merged.
 pub fn merge_segments(compressed_segments: RecordBatch) -> RecordBatch {

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -305,7 +305,6 @@ mod tests {
     use super::*;
 
     use arrow::array::{BinaryArray, Float32Array, UInt64Array, UInt8Array};
-    use modelardb_common::schemas::COMPRESSED_SCHEMA;
     use modelardb_common::types::{TimestampArray, TimestampBuilder, ValueArray, ValueBuilder};
     use proptest::num::f32 as ProptestValue;
     use proptest::strategy::Strategy;
@@ -563,8 +562,7 @@ mod tests {
             (START_TIME..end_time).step_by(SAMPLING_INTERVAL as usize),
         );
         let values = ValueArray::from_iter_values(values);
-        let segments =
-            crate::try_compress(1, &timestamps, &values, error_bound, &COMPRESSED_SCHEMA).unwrap();
+        let segments = crate::try_compress(1, &timestamps, &values, error_bound).unwrap();
 
         // Extract the individual columns from the record batch.
         modelardb_common::arrays!(

--- a/crates/modelardb_compression_python/src/lib.rs
+++ b/crates/modelardb_compression_python/src/lib.rs
@@ -69,14 +69,9 @@ fn compress<'a>(
     let values = modelardb_common::array!(uncompressed, 1, ValueArray);
 
     // unwrap() is safe as the timestamps and values are guaranteed to be the same length.
-    let compressed = modelardb_compression::try_compress(
-        univariate_id,
-        timestamps,
-        values,
-        error_bound,
-        &COMPRESSED_SCHEMA,
-    )
-    .unwrap();
+    let compressed =
+        modelardb_compression::try_compress(univariate_id, timestamps, values, error_bound)
+            .unwrap();
 
     // Convert and return the finished compressed PyArrow record batch.
     convert::rust_record_batch_to_python(compressed, python)

--- a/crates/modelardb_server/Cargo.toml
+++ b/crates/modelardb_server/Cargo.toml
@@ -38,6 +38,7 @@ rusqlite = { version = "0.28.0", features = ["bundled"] }
 snmalloc-rs = "0.3.3"
 sqlparser = "0.30.0"
 tokio = { version = "1.25.0", features = ["rt-multi-thread", "signal"] }
+tokio-stream = "0.1.12"
 tonic = "0.8.3"
 uuid = "1.3.0"
 

--- a/crates/modelardb_server/src/metadata/model_table_metadata.rs
+++ b/crates/modelardb_server/src/metadata/model_table_metadata.rs
@@ -35,7 +35,7 @@ pub struct ModelTableMetadata {
     pub timestamp_column_index: usize,
     /// Indices of the tag columns in the schema.
     pub tag_column_indices: Vec<usize>,
-    /// Error bound of the field columns in the schema.
+    /// Error bound of the columns in the schema.
     pub error_bounds: Vec<ErrorBound>,
 }
 
@@ -45,7 +45,7 @@ impl ModelTableMetadata {
     /// * The timestamp or tag column indices does not match `schema`.
     /// * The types of the fields are not correct.
     /// * The timestamp column index is in the tag column indices.
-    /// * The number of error bounds does not match the number of fields.
+    /// * The number of error bounds does not match the number of columns.
     /// * There are duplicates in the tag column indices.
     /// * There are more than 1024 columns.
     /// * There are no field columns.
@@ -125,10 +125,10 @@ impl ModelTableMetadata {
             }
         }
 
-        // If an error bound is not defined for each field, return an error.
-        if field_column_indices.len() != error_bounds.len() {
+        // If an error bound is not defined for each column, return an error.
+        if schema.fields().len() != error_bounds.len() {
             return Err(ModelarDbError::ConfigurationError(
-                "An error bound must be defined for each field column.".to_owned(),
+                "An error bound must be defined for each column.".to_owned(),
             ));
         }
 
@@ -322,6 +322,10 @@ mod test {
                 Field::new("temperature", ArrowValue::DATA_TYPE, false),
             ]),
             vec![
+                ErrorBound::try_new(0.0).unwrap(),
+                ErrorBound::try_new(0.0).unwrap(),
+                ErrorBound::try_new(0.0).unwrap(),
+                ErrorBound::try_new(0.0).unwrap(),
                 ErrorBound::try_new(0.0).unwrap(),
                 ErrorBound::try_new(0.0).unwrap(),
                 ErrorBound::try_new(0.0).unwrap(),

--- a/crates/modelardb_server/src/query/grid_exec.rs
+++ b/crates/modelardb_server/src/query/grid_exec.rs
@@ -319,6 +319,9 @@ impl GridStream {
         } else {
             current_batch
         };
+
+        // As a new batch have been created the offset into this batch must be set to zero.
+        self.current_batch_offset = 0;
     }
 }
 

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -88,7 +88,7 @@ pub fn start_apache_arrow_flight_server(
 
 /// Read [`RecordBatches`](RecordBatch) from `query_result_stream` and send them one at a time to
 /// [`FlightService`] using `sender`. Returns [`Status`] with the code [`tonic::Code::Internal`] if
-/// the result cannot be send through `sender`.
+/// the result cannot be sent through `sender`.
 async fn send_query_result(
     df_schema: DFSchema,
     mut query_result_stream: SendableRecordBatchStream,
@@ -484,7 +484,7 @@ impl FlightService for FlightServiceHandler {
         let (sender, receiver) = mpsc::channel(2);
 
         task::spawn(async move {
-            // Errors cannot be send to the client if there is an error with the channel, if such an
+            // Errors cannot be sent to the client if there is an error with the channel, if such an
             // error occurs it is logged using error!(). Simply calling await! on the JoinHandle
             // returned by task::spawn is also not an option as it waits until send_query_result()
             // returns and thus creates a deadlock since the results are never read from receiver.

--- a/crates/modelardb_server/src/storage/data_transfer.rs
+++ b/crates/modelardb_server/src/storage/data_transfer.rs
@@ -247,7 +247,7 @@ mod tests {
 
     const TABLE_NAME: &str = "table";
     const COLUMN_INDEX: u16 = 5;
-    const COMPRESSED_FILE_SIZE: usize = 2147;
+    const COMPRESSED_FILE_SIZE: usize = 2126;
 
     // Tests for path_is_compressed_file().
     #[test]
@@ -480,11 +480,11 @@ mod tests {
         ));
         assert!(target_path.exists());
 
-        // The file should have 3 * number_of_files rows since each compressed file has 3 rows.
+        // The file should have three rows since the rows in the compressed files are merged.
         let batch = StorageEngine::read_batch_from_apache_parquet_file(target_path.as_path())
             .await
             .unwrap();
-        assert_eq!(batch.num_rows(), 3 * paths.len());
+        assert_eq!(batch.num_rows(), 3);
 
         assert_eq!(
             *data_transfer

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -420,10 +420,10 @@ impl StorageEngine {
             record_batches.push(record_batch);
         }
 
-        // Merge the record batches into a single combined and merged record batch.
+        // Merge the record batches into a single concatenated and merged record batch.
         let schema = record_batches[0].schema();
-        let combined = compute::concat_batches(&schema, &record_batches)?;
-        let merged = modelardb_compression::merge_segments(combined);
+        let concatenated = compute::concat_batches(&schema, &record_batches)?;
+        let merged = modelardb_compression::merge_segments(concatenated);
 
         // Compute the name of the output file based on data in merged.
         let file_name = create_time_and_value_range_file_name(&merged);
@@ -435,7 +435,7 @@ impl StorageEngine {
             SortingColumn::new(2, false, false),
         ]);
 
-        // Write the combined and merged record batch to the output location.
+        // Write the concatenated and merged record batch to the output location.
         let mut buf = vec![].writer();
         let mut apache_arrow_writer =
             create_apache_arrow_writer(&mut buf, schema, sorting_columns)?;

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -125,8 +125,7 @@ impl StorageEngine {
         // Create the uncompressed data manager.
         let uncompressed_data_manager = UncompressedDataManager::try_new(
             local_data_folder.clone(),
-            metadata_manager.clone(),
-            metadata_manager.uncompressed_reserved_memory_in_bytes,
+            &metadata_manager,
             compress_directly,
             used_disk_space_metric.clone(),
         )

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -378,20 +378,16 @@ impl UncompressedDataManager {
         let uncompressed_values = modelardb_common::array!(data_points, 1, ValueArray);
 
         // unwrap() is safe to use since uncompressed_timestamps and uncompressed_values have the same length.
-        modelardb_compression::try_compress(
+        let compressed_segments = modelardb_compression::try_compress(
             univariate_id,
             uncompressed_timestamps,
             uncompressed_values,
             error_bound,
             &self.compressed_schema,
         )
-        .unwrap()
+        .unwrap();
 
-        // TODO: integrate merge_segments with query processing.
-        // Currently segment merging is disabled as the query pipeline assumes compressed segments
-        // are sorted and never overlapping. That compressed segments are never overlapping can be
-        // broken by merge_segments if the segments A B C for a univariate time series becomes AC B.
-        // compression::merge_segments(compressed_segments)
+        modelardb_compression::merge_segments(compressed_segments)
     }
 
     /// Spill the first [`UncompressedInMemoryDataBuffer`] in the queue of

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -369,7 +369,7 @@ impl UncompressedDataManager {
         self.used_uncompressed_memory_metric
             .append(-(freed_memory as isize), true);
 
-        // unwrap() is safe to use since get_record_batch() can only fail for spilled buffers.
+        // unwrap() is safe to use since record_batch() can only fail for spilled buffers.
         let data_points = in_memory_data_buffer.record_batch().await.unwrap();
         let uncompressed_timestamps = modelardb_common::array!(data_points, 0, TimestampArray);
         let uncompressed_values = modelardb_common::array!(data_points, 1, ValueArray);


### PR DESCRIPTION
This PR resolves a set of issues with the current ingestion and query processing pipeline. Specifically it:

- Makes [`merge_segments()`](https://github.com/ModelarData/ModelarDB-RS/blob/f6d7b0ee0c6991b87b0044f5112e18d7dbe04417/crates/modelardb_compression/src/lib.rs#L97) compatible with the  query processing pipeline by only merging segments that are from the same time series and adjacent in time.
- Fixes an issue with queries returning an incorrect number of data points for a model table due to an offset not being reset correctly.
- Makes the query processing pipeline compatible with  [`DataTransfer`](https://github.com/ModelarData/ModelarDB-RS/blob/f6d7b0ee0c6991b87b0044f5112e18d7dbe04417/crates/modelardb_server/src/storage/data_transfer.rs#L44) by not assuming each column of a model table contains the same number of values since the columns are not transferred atomically.
- Makes [`insert_data_points()`](https://github.com/ModelarData/ModelarDB-RS/blob/f6d7b0ee0c6991b87b0044f5112e18d7dbe04417/crates/modelardb_server/src/storage/uncompressed_data_manager.rs#L134) copy the column's error bound from the tables [`ModelTableMetadata`](https://github.com/ModelarData/ModelarDB-RS/blob/f6d7b0ee0c6991b87b0044f5112e18d7dbe04417/crates/modelardb_server/src/storage/uncompressed_data_buffer.rs#L45) to each [`UncompressedDataBuffer`](https://github.com/ModelarData/ModelarDB-RS/blob/f6d7b0ee0c6991b87b0044f5112e18d7dbe04417/crates/modelardb_server/src/storage/uncompressed_data_buffer.rs#L45) so it can be efficiently retrieved when the buffer is compressed without having to [read it from the metadata database](https://github.com/ModelarData/ModelarDB-RS/blob/f6d7b0ee0c6991b87b0044f5112e18d7dbe04417/crates/modelardb_server/src/metadata/mod.rs#L260).
- Adds testing of the macros.
- Makes [`FlightService::do_get()`](https://github.com/ModelarData/ModelarDB-RS/blob/f6d7b0ee0c6991b87b0044f5112e18d7dbe04417/crates/modelardb_server/src/remote.rs#L456) return the query result in batches instead of as a single batch. By continuously transferring batches to the client during query processing, `modelardbd` need not store the entire result set in memory.