### PR TITLE
Now possible to change the server port with an environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "modelardb_common",
  "modelardb_compression",
  "object_store",
+ "once_cell",
  "parquet",
  "proptest",
  "ringbuf",

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Note that the server uses `9999` as the default port. The port can be changed by
 environment variable:
 
 ```shell
-PORT=9998
+MODELARDBD_PORT=9998
 ```
 
 ### Execute SQL

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ To run `modelardbd` in cloud mode simply replace `edge` with `cloud` as shown be
 modelardbd cloud path_to_local_data_folder s3://bucket-name
 ```
 
+Note that the server uses `9999` as the default port. The port can be changed by specifying a different port with an
+environment variable:
+
+```shell
+PORT=9998
+```
+
 ### Execute SQL
 ModelarDB includes a command-line client in the form of `modelardb`. To interactively execute SQL statements against a local instance of `modelardbd` through a REPL, simply run `modelardb`:
 

--- a/crates/modelardb_server/Cargo.toml
+++ b/crates/modelardb_server/Cargo.toml
@@ -32,6 +32,7 @@ futures = "0.3.27"
 modelardb_common = { path = "../modelardb_common" }
 modelardb_compression = { path = "../modelardb_compression" }
 object_store = { version = "0.5.5", features = ["aws", "azure"] }
+once_cell = "1.17.1"
 parquet = { version = "34.0.0", features = ["object_store"] }
 ringbuf = "0.3.2"
 rusqlite = { version = "0.29.0", features = ["bundled"] }

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -42,8 +42,8 @@ use crate::storage::StorageEngine;
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
-/// The port of the Apache Arrow Flight Server. If the `PORT` environment variable is not set, 9999 is used.
-pub static PORT: Lazy<u16> = Lazy::new(|| match env::var("PORT") {
+/// The port of the Apache Arrow Flight Server. If the environment variable is not set, 9999 is used.
+pub static PORT: Lazy<u16> = Lazy::new(|| match env::var("MODELARDBD_PORT") {
     Ok(port) => port.parse().unwrap(),
     Err(_) => 9999,
 });

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -877,7 +877,8 @@ mod tests {
     /// Return a full path to the file with `file_name`.
     fn format_path(file_name: &str) -> String {
         format!(
-            "{COMPRESSED_DATA_FOLDER}/{TABLE_NAME}/{COLUMN_INDEX}/{file_name}_{TEST_UUID}_{PORT}.parquet",
+            "{COMPRESSED_DATA_FOLDER}/{TABLE_NAME}/{COLUMN_INDEX}/{file_name}_{TEST_UUID}_{}.parquet",
+            *PORT
         )
     }
 

--- a/crates/modelardb_server/src/storage/data_transfer.rs
+++ b/crates/modelardb_server/src/storage/data_transfer.rs
@@ -477,7 +477,8 @@ mod tests {
 
         // The transferred file should have a time range file name that matches the compressed data.
         let target_path = target.path().join(format!(
-            "{COMPRESSED_DATA_FOLDER}/{TABLE_NAME}/{COLUMN_INDEX}/0_5_5.2_34.2_{TEST_UUID}_{PORT}.parquet",
+            "{COMPRESSED_DATA_FOLDER}/{TABLE_NAME}/{COLUMN_INDEX}/0_5_5.2_34.2_{TEST_UUID}_{}.parquet",
+            *PORT
         ));
         assert!(target_path.exists());
 


### PR DESCRIPTION
This PR includes changes to make it possible to change the server port using an environment variable. `9999` is still used as the default port but it is now possible to overwrite this default with a custom port. 