### PR TITLE
Support other ports than 9999 in the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,16 @@ ModelarDB includes a command-line client in the form of `modelardb`. To interact
 modelardb
 ```
 
-If `modelardbd` is not running on the same host, the host `modelardb` should connect to must be specified. `modelardbd`'s Apache Arrow Flight interface accept requests on port `9999` so it is not necessary to specify a port:
+If `modelardbd` is not running on the same host, the host `modelardb` should connect to must be specified. `modelardbd`'s Apache Arrow Flight interface accept requests on port `9999` by default so it is generally not necessary to specify a port:
 
 ```shell
 modelardb 10.0.0.37
+```
+
+However, if `modelardbd` has been configured to use another port using the environment variable `MODELARDBD_PORT`, the same port must also be passed to the client:
+
+```shell
+modelardb 10.0.0.37:9998
 ```
 
 `modelardb` can also execute SQL statements from a file passed as a command-line argument:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ ModelarDB includes a command-line client in the form of `modelardb`. To interact
 modelardb
 ```
 
-If `modelardbd` is not running on the same host, the host `modelardb` should connect to must be specified. `modelardbd`'s Apache Arrow Flight interface accept requests on port `9999` by default so it is generally not necessary to specify a port:
+If `modelardbd` is not running on the same host, the host `modelardb` should connect to must be specified. `modelardbd`'s Apache Arrow Flight interface accepts requests on port `9999` by default so it is generally not necessary to specify a port:
 
 ```shell
 modelardb 10.0.0.37

--- a/README.md
+++ b/README.md
@@ -225,14 +225,14 @@ used for purposes such as logging, where multiple crates provide similar functio
 
 ## Docker
 An environment that includes a local [MinIO](https://min.io/) instance and an edge node using the [MinIO](https://min.io/)
-instance as the remote object store, can be set up using [Docker](https://docs.docker.com/). Note that since 
+instance as the remote object store, can be set up using [Docker](https://docs.docker.com/). Note that since
 [Rust](https://www.rust-lang.org/) is a compiled language and a more dynamic `modelardbd` configuration might be needed,
-it is not recommended to use the [Docker](https://docs.docker.com/) environment during active development of `modelardbd`. 
+it is not recommended to use the [Docker](https://docs.docker.com/) environment during active development of `modelardbd`.
 It is however ideal to use during more static deployments or when developing components that utilize `modelardbd`.
 
-Downloading [Docker Desktop](https://docs.docker.com/desktop/) is recommended to make maintenance of the created 
-containers easier. Once [Docker](https://docs.docker.com/) is set up, the [MinIO](https://min.io/) instance can be 
-created by running the services defined in [docker-compose-minio.yml](docker-compose-minio.yml). The services can 
+Downloading [Docker Desktop](https://docs.docker.com/desktop/) is recommended to make maintenance of the created
+containers easier. Once [Docker](https://docs.docker.com/) is set up, the [MinIO](https://min.io/) instance can be
+created by running the services defined in [docker-compose-minio.yml](docker-compose-minio.yml). The services can
 be built and started using the command:
 
 ```shell
@@ -240,15 +240,15 @@ docker-compose -p modelardata-minio -f docker-compose-minio.yml up
 ```
 
 After the [MinIO](https://min.io/) service is created, a [MinIO](https://min.io/) client is created to initialize
-the development bucket `modelardata`, if it does not already exist. [MinIO](https://min.io/) can be administered through 
+the development bucket `modelardata`, if it does not already exist. [MinIO](https://min.io/) can be administered through
 its [web interface](http://localhost:9001). The default username and password, `minioadmin`, can be used to log in.
-A separate compose file is used for [MinIO](https://min.io/) so an existing [MinIO](https://min.io/) instance can be 
+A separate compose file is used for [MinIO](https://min.io/) so an existing [MinIO](https://min.io/) instance can be
 used when `modelardbd` is deployed using [Docker](https://docker.com/), if necessary.
 
 Similarly, the `modelardbd` instance can be built and started using the command:
 
 ```shell
-docker-compose -p modelardbd up              
+docker-compose -p modelardbd up
 ```
 
 The instance can then be accessed using the Apache Arrow Flight interface at `grpc://127.0.0.1:9999`.

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -96,7 +96,7 @@ fn main() -> Result<(), String> {
 
 /// Parse the command line arguments in `args` and return a triple with the host of the server to
 /// connect to, the port to connect to, and the file containing the queries to execute on the
-/// server. If one of these command line arguments is not provided it is replaced with [`None`]."
+/// server. If one of these command line arguments is not provided it is replaced with [`None`].
 fn parse_command_line_arguments(mut args: Args) -> (Option<String>, Option<u16>, Option<String>) {
     // Drop the path of the executable.
     args.next();
@@ -118,7 +118,7 @@ fn parse_command_line_arguments(mut args: Args) -> (Option<String>, Option<u16>,
             port = Some(
                 host_and_port[1]
                     .parse()
-                    .map_err(|_| "for host:port port must be from 1 to 65535.")
+                    .map_err(|_| "port must be between 1 and 65535.")
                     .unwrap(),
             );
         } else {

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -46,7 +46,7 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 pub static PORT: Lazy<u16> = Lazy::new(|| match env::var("MODELARDBD_PORT") {
     Ok(port) => port
         .parse()
-        .map_err(|_| "MODELARDBD_PORT must be a port from 1 to 65535 if set")
+        .map_err(|_| "MODELARDBD_PORT must be between 1 and 65535.")
         .unwrap(),
     Err(_) => 9999,
 });

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -44,7 +44,10 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
 /// The port of the Apache Arrow Flight Server. If the environment variable is not set, 9999 is used.
 pub static PORT: Lazy<u16> = Lazy::new(|| match env::var("MODELARDBD_PORT") {
-    Ok(port) => port.parse().unwrap(),
+    Ok(port) => port
+        .parse()
+        .map_err(|_| "MODELARDBD_PORT must be a port from 1 to 65535 if set")
+        .unwrap(),
     Err(_) => 9999,
 });
 


### PR DESCRIPTION
This PR adds support for other ports than 9999 to the client by allowing a non-default port to be specified using the syntax `host:port`.