### PR TITLE
Evaluate PMC-Mean and Swing before Gorilla

### DIFF
--- a/crates/modelardb_common/src/schemas.rs
+++ b/crates/modelardb_common/src/schemas.rs
@@ -50,8 +50,9 @@ pub static COMPRESSED_SCHEMA: Lazy<CompressedSchema> = Lazy::new(|| {
     ])))
 });
 
-/// Size of the metadata required for a compressed segment. Meaning that the size of `timestamps`
-/// and `values` are not included as they are binary and thus depends on which model is selected.
+/// Minimum size of the metadata required for a compressed segment. Meaning that the sizes of
+/// `timestamps` and `values` are not included as they are [`DataType::Binary`] and thus their size
+/// depend on which model is selected to represent the values for that compressed segment.
 pub static COMPRESSED_METADATA_SIZE_IN_BYTES: Lazy<usize> = Lazy::new(|| {
     COMPRESSED_SCHEMA
         .0

--- a/crates/modelardb_common/src/schemas.rs
+++ b/crates/modelardb_common/src/schemas.rs
@@ -50,6 +50,17 @@ pub static COMPRESSED_SCHEMA: Lazy<CompressedSchema> = Lazy::new(|| {
     ])))
 });
 
+/// Size of the metadata required for a compressed segment. Meaning that the size of `timestamps`
+/// and `values` are not included as they are binary and thus depends which model is selected.
+pub static COMPRESSED_METADATA_SIZE_IN_BYTES: Lazy<usize> = Lazy::new(|| {
+    COMPRESSED_SCHEMA
+        .0
+        .fields()
+        .iter()
+        .map(|field| field.data_type().primitive_width().unwrap_or(0))
+        .sum()
+});
+
 /// [`RecordBatch`](arrow::record_batch::RecordBatch) [`Schema`](arrow::datatypes::Schema) used for
 /// internally collected metrics.
 pub static METRIC_SCHEMA: Lazy<MetricSchema> = Lazy::new(|| {

--- a/crates/modelardb_common/src/schemas.rs
+++ b/crates/modelardb_common/src/schemas.rs
@@ -51,7 +51,7 @@ pub static COMPRESSED_SCHEMA: Lazy<CompressedSchema> = Lazy::new(|| {
 });
 
 /// Size of the metadata required for a compressed segment. Meaning that the size of `timestamps`
-/// and `values` are not included as they are binary and thus depends which model is selected.
+/// and `values` are not included as they are binary and thus depends on which model is selected.
 pub static COMPRESSED_METADATA_SIZE_IN_BYTES: Lazy<usize> = Lazy::new(|| {
     COMPRESSED_SCHEMA
         .0

--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -58,7 +58,7 @@ pub fn try_compress(
     }
 
     // Enough memory for end_index compressed segments are allocated to never require reallocation
-    // as one compressed segments is created per data point in the absolute worst case.
+    // as one compressed segment is created per data point in the absolute worst case.
     let end_index = uncompressed_timestamps.len();
     let mut compressed_record_batch_builder = CompressedSegmentBatchBuilder::new(end_index);
 
@@ -81,7 +81,7 @@ pub fn try_compress(
         // The selected model is only stored as part of a compressed segment if it uses less storage
         // space per value than the uncompressed values it represents.
         if selected_model.bytes_per_value <= models::VALUE_SIZE_IN_BYTES as f32 {
-            // Compress residual data points with gorilla and store them in a compressed segments.
+            // Compress residual data points with Gorilla and store them in a compressed segment.
             if residual_start_index != current_index {
                 compress_and_store_residual_value_range(
                     univariate_id,
@@ -93,7 +93,7 @@ pub fn try_compress(
                 )
             }
 
-            // Store the selected model and the corresponding timestamps in a compressed segments.
+            // Store the selected model and the corresponding timestamps in a compressed segment.
             store_selected_model_in_batch_builder(
                 univariate_id,
                 current_index,
@@ -102,17 +102,17 @@ pub fn try_compress(
                 &mut compressed_record_batch_builder,
             );
 
-            // Update the indexes to specify that all data points until now has been compressed.
+            // Update the indices to specify that all data points until now has been compressed.
             current_index = selected_model.end_index + 1;
             residual_start_index = current_index;
         } else {
             // The potentially lossy models could not efficiently encode the sub-sequence starting
-            // at current_index, the residual values will instead be compressed using gorilla.
+            // at current_index, the residual values will instead be compressed using Gorilla.
             current_index += 1;
         }
     }
 
-    // Compress the last residual data points with gorilla and store them in a compressed segment.
+    // Compress the last residual data points with Gorilla and store them in a compressed segment.
     if residual_start_index != current_index {
         compress_and_store_residual_value_range(
             univariate_id,
@@ -392,9 +392,8 @@ impl CompressedModelBuilder {
         self.pmc_mean_could_fit_all || self.swing_could_fit_all
     }
 
-    /// Return the model that requires the smallest number of bits per value if used for a segment.
+    /// Return the model that requires the fewest number of bytes per value.
     fn finish(self) -> SelectedModel {
-        // The model that uses the fewest number of bytes per value is selected.
         SelectedModel::new(self.start_index, self.pmc_mean, self.swing)
     }
 }

--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -32,15 +32,7 @@ use modelardb_common::types::{
     Timestamp, TimestampArray, TimestampBuilder, Value, ValueArray, ValueBuilder,
 };
 
-use crate::models::{
-    gorilla::Gorilla, pmc_mean::PMCMean, swing::Swing, timestamps, ErrorBound, SelectedModel,
-};
-
-// TODO: use Gorilla as a fallback to remove GORILLA_MAXIMUM_LENGTH.
-/// Maximum number of data points that models of type Gorilla can represent per
-/// compressed segment. As models of type Gorilla use lossless compression they
-/// will never exceed the user-defined error bounds.
-pub const GORILLA_MAXIMUM_LENGTH: usize = 50;
+use crate::models::{pmc_mean::PMCMean, swing::Swing, timestamps, ErrorBound, SelectedModel};
 
 /// Compress `uncompressed_timestamps` using a start time, end time, and a sampling interval if
 /// regular and delta-of-deltas followed by a variable length binary encoding if irregular.
@@ -48,44 +40,145 @@ pub const GORILLA_MAXIMUM_LENGTH: usize = 50;
 /// Assumes `uncompressed_timestamps` and `uncompressed_values` are sorted according to
 /// `uncompressed_timestamps`. Returns [`CompressionError`](ModelarDbError::CompressionError) if
 /// `uncompressed_timestamps` and `uncompressed_values` have different lengths, otherwise the
-///  resulting compressed segments are returned as a [`RecordBatch`] with the [`COMPRESSED_SCHEMA`]
-///  schema.
+/// resulting compressed segments are returned as a [`RecordBatch`] with the [`COMPRESSED_SCHEMA`]
+/// schema.
 pub fn try_compress(
     univariate_id: u64,
     uncompressed_timestamps: &TimestampArray,
     uncompressed_values: &ValueArray,
     error_bound: ErrorBound,
 ) -> Result<RecordBatch, ModelarDbError> {
-    // The uncompressed data must be passed as arrays instead of a RecordBatch
-    // as a TimestampArray and a ValueArray is the only supported input.
-    // However, as a result it is necessary to verify they have the same length.
+    // The uncompressed data must be passed as arrays instead of a RecordBatch as a TimestampArray
+    // and a ValueArray is the only supported input. However, as a result it is necessary to verify
+    // they have the same length.
     if uncompressed_timestamps.len() != uncompressed_values.len() {
         return Err(ModelarDbError::CompressionError(
             "Uncompressed timestamps and uncompressed values have different lengths.".to_owned(),
         ));
     }
 
-    // Enough memory for end_index elements are allocated to never require
-    // reallocation as one model is created per data point in the worst case.
+    // Enough memory for end_index compressed segments are allocated to never require reallocation
+    // as one compressed segments is created per data point in the absolute worst case.
     let end_index = uncompressed_timestamps.len();
     let mut compressed_record_batch_builder = CompressedSegmentBatchBuilder::new(end_index);
 
     // Compress the uncompressed timestamps and uncompressed values.
     let mut current_index = 0;
+    let mut residual_start_index = 0;
     while current_index < end_index {
-        // Create a compressed segment that represents the data points from
-        // current_index to index within error_bound where index <= end_index.
-        let compressed_segment_builder = CompressedSegmentBuilder::new(
-            univariate_id,
+        // Propose a model that represents the values from current_index to index within error_bound
+        // where index <= end_index.
+        let compressed_model_builder = CompressedModelBuilder::new(
             current_index,
             end_index,
             uncompressed_timestamps,
             uncompressed_values,
             error_bound,
         );
-        current_index = compressed_segment_builder.finish(&mut compressed_record_batch_builder);
+
+        let selected_model = compressed_model_builder.finish();
+
+        // The selected model is only stored as part of a compressed segment if it uses less storage
+        // space per value than the uncompressed values it represents.
+        if selected_model.bytes_per_value <= models::VALUE_SIZE_IN_BYTES as f32 {
+            // Compress residual data points with gorilla and store them in a compressed segments.
+            if residual_start_index != current_index {
+                compress_and_store_residual_value_range(
+                    univariate_id,
+                    residual_start_index,
+                    current_index - 1,
+                    uncompressed_timestamps,
+                    uncompressed_values,
+                    &mut compressed_record_batch_builder,
+                )
+            }
+
+            // Store the selected model and the corresponding timestamps in a compressed segments.
+            store_selected_model_in_batch_builder(
+                univariate_id,
+                current_index,
+                &selected_model,
+                uncompressed_timestamps,
+                &mut compressed_record_batch_builder,
+            );
+
+            // Update the indexes to specify that all data points until now has been compressed.
+            current_index = selected_model.end_index + 1;
+            residual_start_index = current_index;
+        } else {
+            // The potentially lossy models could not efficiently encode the sub-sequence starting
+            // at current_index, the residual values will instead be compressed using gorilla.
+            current_index += 1;
+        }
     }
+
+    // Compress the last residual data points with gorilla and store them in a compressed segment.
+    if residual_start_index != current_index {
+        compress_and_store_residual_value_range(
+            univariate_id,
+            residual_start_index,
+            current_index - 1,
+            uncompressed_timestamps,
+            uncompressed_values,
+            &mut compressed_record_batch_builder,
+        )
+    }
+
     Ok(compressed_record_batch_builder.finish())
+}
+
+/// For the time series with `univariate_id`, compress the values from `start_index` to `end_index`
+/// in `uncompressed_values` using [`Gorilla`] and store the resulting model with the corresponding
+/// timestamps from `uncompressed_timestamps` as a segment in `compressed_record_batch_builder`.
+fn compress_and_store_residual_value_range(
+    univariate_id: u64,
+    start_index: usize,
+    end_index: usize,
+    uncompressed_timestamps: &TimestampArray,
+    uncompressed_values: &ValueArray,
+    compressed_record_batch_builder: &mut CompressedSegmentBatchBuilder,
+) {
+    let selected_model =
+        models::compress_residual_value_range(start_index, end_index, uncompressed_values);
+
+    store_selected_model_in_batch_builder(
+        univariate_id,
+        start_index,
+        &selected_model,
+        uncompressed_timestamps,
+        compressed_record_batch_builder,
+    );
+}
+
+/// Store the `selected_model` which represents values from the time series with `univariate_id`
+/// from `start_index to `end_index` as part of a segment in `compressed_record_batch_builder`.
+fn store_selected_model_in_batch_builder(
+    univariate_id: u64,
+    start_index: usize,
+    selected_model: &SelectedModel,
+    uncompressed_timestamps: &TimestampArray,
+    compressed_record_batch_builder: &mut CompressedSegmentBatchBuilder,
+) {
+    // Add timestamps and error.
+    let end_index = selected_model.end_index;
+    let start_time = uncompressed_timestamps.value(start_index);
+    let end_time = uncompressed_timestamps.value(end_index);
+    let timestamps = timestamps::compress_residual_timestamps(
+        &uncompressed_timestamps.values()[start_index..=end_index],
+    );
+    let error = f32::NAN; // TODO: compute and store the actual error.
+
+    compressed_record_batch_builder.append_compressed_segment(
+        univariate_id,
+        selected_model.model_type_id,
+        start_time,
+        end_time,
+        &timestamps,
+        selected_model.min_value,
+        selected_model.max_value,
+        &selected_model.values,
+        error,
+    );
 }
 
 /// Merge segments in `compressed_segments` that:
@@ -230,61 +323,43 @@ fn can_models_be_merged(
     )
 }
 
-/// A compressed segment being built from an uncompressed segment using the model types in
-/// [`models`]. Each of the model types is used to fit models to the data points, and then the
-/// model that uses the fewest number of bytes per value is selected.
-struct CompressedSegmentBuilder<'a> {
-    /// The id of the time series from which the compressed segment is created.
-    univariate_id: u64,
-    /// The regular timestamps of the uncompressed segment the compressed
-    /// segment is being built from.
-    uncompressed_timestamps: &'a TimestampArray,
-    /// The values of the uncompressed segment the compressed segment is being
-    /// built from.
-    uncompressed_values: &'a ValueArray,
-    /// Index of the first data point in `uncompressed_timestamps` and
-    /// `uncompressed_values` the compressed segment represents.
+/// A compressed model being built from an uncompressed segment using the potentially lossy model
+/// types in [`models`]. Each of the potentially lossy model types is used to fit models to the data
+/// points, and then the model that uses the fewest number of bytes per value is selected.
+struct CompressedModelBuilder {
+    /// Index of the first data point in `uncompressed_timestamps` and `uncompressed_values` the
+    /// compressed model represents values for.
     start_index: usize,
-    /// Constant function that currently represents the values in
-    /// `uncompressed_values` from `start_index` to `start_index` +
-    /// `pmc_mean.length`.
+    /// Constant function that currently represents the values in `uncompressed_values` from
+    /// `start_index` to `start_index` + `pmc_mean.length`.
     pmc_mean: PMCMean,
-    /// Indicates if `pmc_mean` could represent all values in
-    /// `uncompressed_values` from `start_index` to `current_index` in `new()`.
+    /// Indicates if `pmc_mean` could represent all values in `uncompressed_values` from
+    /// `start_index` to `current_index` in `new()`.
     pmc_mean_could_fit_all: bool,
-    /// Linear function that represents the values in `uncompressed_values` from
-    /// `start_index` to `start_index` + `swing.length`.
+    /// Linear function that represents the values in `uncompressed_values` from `start_index` to
+    /// `start_index` + `swing.length`.
     swing: Swing,
-    /// Indicates if `swing` could represent all values in `uncompressed_values`
-    /// from `start_index` to `current_index` in `new()`.
+    /// Indicates if `swing` could represent all values in `uncompressed_values` from `start_index`
+    /// to `current_index` in `new()`.
     swing_could_fit_all: bool,
-    /// Values in `uncompressed_values` from `start_index` to `start_index` +
-    /// `gorilla.length` compressed using lossless compression.
-    gorilla: Gorilla,
 }
 
-impl<'a> CompressedSegmentBuilder<'a> {
-    /// Create a compressed segment that represents the regular timestamps in
-    /// `uncompressed_timestamps` and the values in `uncompressed_values` from
+impl CompressedModelBuilder {
+    /// Create a compressed model that represents the values in `uncompressed_values` from
     /// `start_index` to index within `error_bound` where index <= `end_index`.
     fn new(
-        univariate_id: u64,
         start_index: usize,
         end_index: usize,
-        uncompressed_timestamps: &'a TimestampArray,
-        uncompressed_values: &'a ValueArray,
+        uncompressed_timestamps: &TimestampArray,
+        uncompressed_values: &ValueArray,
         error_bound: ErrorBound,
     ) -> Self {
         let mut compressed_segment_builder = Self {
-            univariate_id,
-            uncompressed_timestamps,
-            uncompressed_values,
             start_index,
             pmc_mean: PMCMean::new(error_bound),
             pmc_mean_could_fit_all: true,
             swing: Swing::new(error_bound),
             swing_could_fit_all: true,
-            gorilla: Gorilla::new(),
         };
 
         let mut current_index = start_index;
@@ -309,60 +384,18 @@ impl<'a> CompressedSegmentBuilder<'a> {
 
         self.swing_could_fit_all =
             self.swing_could_fit_all && self.swing.fit_data_point(timestamp, value);
-
-        // Gorilla uses lossless compression and cannot exceed the error bound.
-        if self.gorilla.length < GORILLA_MAXIMUM_LENGTH {
-            self.gorilla.compress_value(value);
-        }
     }
 
     /// Return [`true`] if any of the current models can represent additional
     /// values, otherwise [`false`].
     fn can_fit_more(&self) -> bool {
-        self.pmc_mean_could_fit_all
-            || self.swing_could_fit_all
-            || self.gorilla.length < GORILLA_MAXIMUM_LENGTH
+        self.pmc_mean_could_fit_all || self.swing_could_fit_all
     }
 
-    /// Store the model that requires the smallest number of bits per value in
-    /// `compressed_record_batch_builder`. Returns the index of the first value
-    /// in `uncompressed_values` the selected model could not represent.
-    fn finish(self, compressed_record_batch_builder: &mut CompressedSegmentBatchBuilder) -> usize {
+    /// Return the model that requires the smallest number of bits per value if used for a segment.
+    fn finish(self) -> SelectedModel {
         // The model that uses the fewest number of bytes per value is selected.
-        let SelectedModel {
-            model_type_id,
-            end_index,
-            min_value,
-            max_value,
-            values,
-        } = SelectedModel::new(
-            self.start_index,
-            self.pmc_mean,
-            self.swing,
-            self.gorilla,
-            self.uncompressed_values,
-        );
-
-        // Add timestamps and error.
-        let start_time = self.uncompressed_timestamps.value(self.start_index);
-        let end_time = self.uncompressed_timestamps.value(end_index);
-        let timestamps = timestamps::compress_residual_timestamps(
-            &self.uncompressed_timestamps.values()[self.start_index..=end_index],
-        );
-        let error = f32::NAN; // TODO: compute and store the actual error.
-
-        compressed_record_batch_builder.append_compressed_segment(
-            self.univariate_id,
-            model_type_id,
-            start_time,
-            end_time,
-            &timestamps,
-            min_value,
-            max_value,
-            &values,
-            error,
-        );
-        end_index + 1
+        SelectedModel::new(self.start_index, self.pmc_mean, self.swing)
     }
 }
 

--- a/crates/modelardb_compression/src/models/gorilla.rs
+++ b/crates/modelardb_compression/src/models/gorilla.rs
@@ -121,7 +121,7 @@ impl Gorilla {
     /// Return the number of bytes currently used per data point on average.
     pub fn bytes_per_value(&self) -> f32 {
         // Gorilla does not use metadata for encoding values, only the data in compressed_values.
-        (COMPRESSED_METADATA_SIZE_IN_BYTES.to_owned() as f32 + self.compressed_values.len() as f32)
+        (COMPRESSED_METADATA_SIZE_IN_BYTES.to_owned() + self.compressed_values.len()) as f32
             / self.length as f32
     }
 

--- a/crates/modelardb_compression/src/models/gorilla.rs
+++ b/crates/modelardb_compression/src/models/gorilla.rs
@@ -22,6 +22,7 @@
 //!
 //! [Gorilla paper]: https://www.vldb.org/pvldb/vol8/p1816-teller.pdf
 
+use modelardb_common::schemas::COMPRESSED_METADATA_SIZE_IN_BYTES;
 use modelardb_common::types::{Timestamp, UnivariateId, UnivariateIdBuilder, Value, ValueBuilder};
 
 use crate::models;
@@ -119,7 +120,9 @@ impl Gorilla {
 
     /// Return the number of bytes currently used per data point on average.
     pub fn bytes_per_value(&self) -> f32 {
-        self.compressed_values.len() as f32 / self.length as f32
+        // Gorilla does not use metadata for encoding values, only the data in compressed_values.
+        (COMPRESSED_METADATA_SIZE_IN_BYTES.to_owned() as f32 + self.compressed_values.len() as f32)
+            / self.length as f32
     }
 
     /// Return the values compressed using XOR and a variable length binary

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -441,7 +441,7 @@ mod tests {
         SelectedModel::new(0, pmc_mean, swing)
     }
 
-    // Tests for compress_residual_value_range()
+    // Tests for compress_residual_value_range().
     #[test]
     fn test_compress_all_residual_value_range() {
         let uncompressed_values = ValueArray::from(vec![73.0, 37.0, 37.0, 37.0, 73.0]);

--- a/crates/modelardb_compression/src/models/pmc_mean.rs
+++ b/crates/modelardb_compression/src/models/pmc_mean.rs
@@ -82,7 +82,8 @@ impl PMCMean {
 
     /// Return the number of bytes the current model uses per data point on average.
     pub fn bytes_per_value(&self) -> f32 {
-        // No data is needed for PMC-Mean as the value can be read from min_value or max_value.
+        // No additional data is needed for PMC-Mean as the value can be read from min_value or
+        // max_value which is already stored as part of the metadata in the compressed segments.
         COMPRESSED_METADATA_SIZE_IN_BYTES.to_owned() as f32 / self.length as f32
     }
 

--- a/crates/modelardb_compression/src/models/pmc_mean.rs
+++ b/crates/modelardb_compression/src/models/pmc_mean.rs
@@ -20,6 +20,7 @@
 //! [Poor Man’s Compression paper]: https://ieeexplore.ieee.org/document/1260811
 //! [ModelarDB paper]: https://www.vldb.org/pvldb/vol11/p1688-jensen.pdf
 
+use modelardb_common::schemas::COMPRESSED_METADATA_SIZE_IN_BYTES;
 use modelardb_common::types::{Timestamp, UnivariateId, UnivariateIdBuilder, Value, ValueBuilder};
 
 use crate::models;
@@ -81,7 +82,8 @@ impl PMCMean {
 
     /// Return the number of bytes the current model uses per data point on average.
     pub fn bytes_per_value(&self) -> f32 {
-        models::VALUE_SIZE_IN_BYTES as f32 / self.length as f32
+        // No data is needed for PMC-Mean as the value can be read from min_value or max_value.
+        COMPRESSED_METADATA_SIZE_IN_BYTES.to_owned() as f32 / self.length as f32
     }
 
     /// Return the current model. For a model of type PMC-Mean, its coefficient

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -544,16 +544,17 @@ mod tests {
 
     #[test]
     fn test_can_reconstruct_sequence_of_linear_increasing_values_within_error_bound_zero() {
-        test_can_reconstruct_sequence_of_linear_values_within_error_bound_zero(vec![
-            42.0, 84.0, 126.0, 168.0, 210.0,
-        ])
+        test_can_reconstruct_sequence_of_linear_values_within_error_bound_zero(
+            (42..=4200).step_by(42).map(|value| value as f32).collect(),
+        )
     }
 
     #[test]
     fn test_can_reconstruct_sequence_of_linear_decreasing_values_within_error_bound_zero() {
-        test_can_reconstruct_sequence_of_linear_values_within_error_bound_zero(vec![
-            210.0, 168.0, 126.0, 84.0, 42.0,
-        ])
+        let mut values: Vec<Value> = (42..=4200).step_by(42).map(|value| value as f32).collect();
+        values.reverse();
+
+        test_can_reconstruct_sequence_of_linear_values_within_error_bound_zero(values);
     }
 
     fn test_can_reconstruct_sequence_of_linear_values_within_error_bound_zero(values: Vec<Value>) {

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -23,6 +23,7 @@
 //! [Swing and Slide paper]: https://dl.acm.org/doi/10.14778/1687627.1687645
 //! [ModelarDB paper]: https://www.vldb.org/pvldb/vol11/p1688-jensen.pdf
 
+use modelardb_common::schemas::COMPRESSED_METADATA_SIZE_IN_BYTES;
 use modelardb_common::types::{Timestamp, UnivariateId, UnivariateIdBuilder, Value, ValueBuilder};
 
 use crate::models::ErrorBound;
@@ -186,7 +187,8 @@ impl Swing {
 
     /// Return the number of bytes the current model uses per data point on average.
     pub fn bytes_per_value(&self) -> f32 {
-        (2.0 * models::VALUE_SIZE_IN_BYTES as f32) / self.length as f32
+        // One additional byte is needed for Swing to store if it is increasing or decreasing.
+        (COMPRESSED_METADATA_SIZE_IN_BYTES.to_owned() as f32 + 1.0) / self.length as f32
     }
 
     /// Return the current model. For a model of type Swing, the first and last

--- a/crates/modelardb_compression_python/tests/__init__.py
+++ b/crates/modelardb_compression_python/tests/__init__.py
@@ -37,11 +37,11 @@ class ModelarDBCompressionPythonTest(unittest.TestCase):
         self.assertEqual(
             time_series.column(0).to_pylist(), decompressed.column(1).to_pylist()
         )
-        self.assertEqual(5 * [10.239999771118164], decompressed.column(2).to_pylist())
+        self.assertEqual(50 * [10.25], decompressed.column(2).to_pylist())
 
     def __get_time_series(self):
-        timestamps = pyarrow.array([100, 200, 300, 400, 500], pyarrow.timestamp("ms"))
-        values = pyarrow.array([10.2, 10.3, 10.2, 10.3, 10.2], pyarrow.float32())
+        timestamps = pyarrow.array(range(100, 5100, 100), pyarrow.timestamp("ms"))
+        values = pyarrow.array(25 * [10.2, 10.3], pyarrow.float32())
         return RecordBatch.from_arrays(
             [timestamps, values], names=["timestamps", "values"]
         )


### PR DESCRIPTION
This PR modifies the compression in two ways. First, the size of the metadata is now included when computing the number of bytes per value a model requires, e.g., a single segment of length eight is better than two segments of length four due to the metadata. Second, Gorilla is no longer evaluated alongside PMC-Mean and Swing, instead it is used as a fallback when neither PMC-Mean nor Swing can create models that efficiently encode a sub-sequence of values. Another benefit of only using Gorilla for values is that PMC-Mean and Swing cannot compress, is that the length bound is no longer needed. Preliminary results indicates that this reduces the amount of storage required by 5-25% by using PMC-Mean and Swing for more values and decreases ingestion speed by 0-10% .