### PR TITLE
Support for Azure Blob Storage as initial remote data folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ Then, assuming a bucket named `wind-turbine` has been created through [MinIO's w
 modelardbd edge path_to_local_data_folder s3://wind-turbine
 ```
 
+`modelardbd` also supports using [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/) 
+for the remote object store. To use [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/), 
+set the following environment variables instead:
+
+```shell
+AZURE_STORAGE_ACCOUNT_NAME
+AZURE_STORAGE_ACCESS_KEY
+```
+
+`modelardbd` can then be run in edge mode with transfer of the ingested time series to the 
+[Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/) container `wind-turbine`:
+
+```shell
+modelardbd edge path_to_local_data_folder azureblobstorage://wind-turbine
+```
+
 To run `modelardbd` in cloud mode simply replace `edge` with `cloud` as shown below. Be aware that both a local data folder and an object store are required when `modelardbd` is run in cloud mode.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
 5. Move `modelardbd` and `modelardb` from the `target` directory to any directory.
 
 ## Usage
-`modelardbd` supports two execution modes *edge* and *cloud*. For storage, `modelardbd` uses local storage and an Amazon S3-compatible object store (optional in edge mode). The execution mode dictates where queries are executed. When `modelardbd` is deployed in edge mode it executes queries against local storage and when it is deployed in cloud mode it executes queries against the object store. For both deployment modes, `modelardbd` automatically compresses the ingested time series using multiple different types of models and continuously transfers this compressed representation from local storage to the object store. Be aware that sharing metadata between multiple instances of `modelardbd` is currently under development, thus only the instance of `modelardbd` that ingested a time series can currently query it.
+`modelardbd` supports two execution modes *edge* and *cloud*. For storage, `modelardbd` uses local storage and an Amazon S3-compatible or Azure Blob Storage object store (optional in edge mode). The execution mode dictates where queries are executed. When `modelardbd` is deployed in edge mode it executes queries against local storage and when it is deployed in cloud mode it executes queries against the object store. For both deployment modes, `modelardbd` automatically compresses the ingested time series using multiple different types of models and continuously transfers this compressed representation from local storage to the object store. Be aware that sharing metadata between multiple instances of `modelardbd` is currently under development, thus only the instance of `modelardbd` that ingested a time series can currently query it.
 
 ### Start Server
 To run `modelardbd` in edge mode using only local storage, i.e., without transferring the ingested time series to an object store, simply pass the path to the local folder `modelardbd` should use as its data folder:
@@ -90,8 +90,9 @@ AZURE_STORAGE_ACCOUNT_NAME
 AZURE_STORAGE_ACCESS_KEY
 ```
 
-`modelardbd` can then be run in edge mode with transfer of the ingested time series to the 
-[Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/) container `wind-turbine`:
+Assuming a container named `wind-turbine` already exists, `modelardbd` can then be run in edge mode with transfer of 
+the ingested time series to the [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/) 
+container `wind-turbine`:
 
 ```shell
 modelardbd edge path_to_local_data_folder azureblobstorage://wind-turbine

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -232,18 +232,18 @@ fn argument_to_local_object_store(argument: &str) -> Result<Arc<dyn ObjectStore>
 
 /// Create an [`ObjectStore`] that represents the remote path in `argument`.
 fn argument_to_remote_object_store(argument: &str) -> Result<Arc<dyn ObjectStore>, String> {
-    match &argument[..5] {
-        "s3://" => {
+    match argument.get(..5) {
+        Some("s3://") => {
             let object_store = AmazonS3Builder::from_env()
-                .with_bucket_name(&argument[5..])
+                .with_bucket_name(argument.get(5..).unwrap())
                 .build()
                 .map_err(|error| error.to_string())?;
 
             Ok(Arc::new(object_store))
         }
-        "azureblobstorage://" => {
+        Some("azureblobstorage://") => {
             let object_store = MicrosoftAzureBuilder::from_env()
-                .with_container_name(&argument[5..])
+                .with_container_name(argument.get(19..).unwrap())
                 .build()
                 .map_err(|error| error.to_string())?;
 

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -232,18 +232,18 @@ fn argument_to_local_object_store(argument: &str) -> Result<Arc<dyn ObjectStore>
 
 /// Create an [`ObjectStore`] that represents the remote path in `argument`.
 fn argument_to_remote_object_store(argument: &str) -> Result<Arc<dyn ObjectStore>, String> {
-    match argument.get(..5) {
-        Some("s3://") => {
+    match argument.split_once("://") {
+        Some(("s3", bucket_name)) => {
             let object_store = AmazonS3Builder::from_env()
-                .with_bucket_name(argument.get(5..).unwrap())
+                .with_bucket_name(bucket_name)
                 .build()
                 .map_err(|error| error.to_string())?;
 
             Ok(Arc::new(object_store))
         }
-        Some("azureblobstorage://") => {
+        Some(("azureblobstorage", container_name)) => {
             let object_store = MicrosoftAzureBuilder::from_env()
-                .with_container_name(argument.get(19..).unwrap())
+                .with_container_name(container_name)
                 .build()
                 .map_err(|error| error.to_string())?;
 

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -113,11 +113,14 @@ fn main() -> Result<(), String> {
         Runtime::new().map_err(|error| format!("Unable to create a Tokio Runtime: {error}"))?,
     );
 
-    // Check if a remote data folder was provided and can be accessed. These checks are performed
+    // If a remote data folder was provided, check that it can be accessed. This check is performed
     // after parse_command_line_arguments() as the Tokio Runtime is required.
     if let Some(remote_data_folder) = &data_folders.remote_data_folder {
+        // unwrap() is safe since if there is a remote data folder, there is always third argument.
+        let remote_data_folder_type = arguments.get(2).unwrap().split_once("://").unwrap().0;
+
         runtime.block_on(async {
-            validate_remote_data_folder("s3", remote_data_folder).await
+            validate_remote_data_folder(remote_data_folder_type, remote_data_folder).await
         })?;
     }
 
@@ -278,7 +281,7 @@ async fn validate_remote_data_folder(
                 } else {
                     Err(error.to_string())
                 }
-            },
+            }
             _ => Err(error.to_string()),
         },
     }

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -116,7 +116,7 @@ fn main() -> Result<(), String> {
     // If a remote data folder was provided, check that it can be accessed. This check is performed
     // after parse_command_line_arguments() as the Tokio Runtime is required.
     if let Some(remote_data_folder) = &data_folders.remote_data_folder {
-        // unwrap() is safe since if there is a remote data folder, there is always third argument.
+        // unwrap() is safe since if there is a remote data folder, there is always a third argument.
         let remote_data_folder_type = arguments.get(2).unwrap().split_once("://").unwrap().0;
 
         runtime.block_on(async {

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -77,7 +77,7 @@ impl FromStr for RemoteDataFolderType {
             "s3" => Ok(RemoteDataFolderType::S3),
             "azureblobstorage" => Ok(RemoteDataFolderType::AzureBlobStorage),
             _ => Err(format!(
-                "'{}' is not a valid value for ObjectStoreType.",
+                "'{}' is not a valid value for RemoteDataFolderType.",
                 value
             )),
         }

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -140,11 +140,11 @@ fn main() -> Result<(), String> {
     // after parse_command_line_arguments() as the Tokio Runtime is required.
     if let Some(remote_data_folder) = &data_folders.remote_data_folder {
         // unwrap() is safe since if there is a remote data folder, there is always a valid third argument.
-        let remote_data_folder_type = arguments.get(2).unwrap().split_once("://").unwrap().0;
-        let object_store_type = RemoteDataFolderType::from_str(remote_data_folder_type).unwrap();
+        let object_store_type = arguments.get(2).unwrap().split_once("://").unwrap().0;
+        let remote_data_folder_type = RemoteDataFolderType::from_str(object_store_type).unwrap();
 
         runtime.block_on(async {
-            validate_remote_data_folder(object_store_type, remote_data_folder).await
+            validate_remote_data_folder(remote_data_folder_type, remote_data_folder).await
         })?;
     }
 

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -62,7 +62,7 @@ use crate::metadata::MetadataManager;
 use crate::parser::{self, ValidStatement};
 use crate::query::ModelTable;
 use crate::storage::{StorageEngine, COMPRESSED_DATA_FOLDER};
-use crate::{validate_remote_data_folder, Context, ServerMode};
+use crate::{validate_remote_data_folder, Context, ServerMode, RemoteDataFolderType};
 
 /// Start an Apache Arrow Flight server on 0.0.0.0:`port` that pass `context` to
 /// the methods that process the requests through `FlightServiceHandler`.
@@ -165,7 +165,7 @@ async fn parse_s3_arguments(data: &[u8]) -> Result<Arc<dyn ObjectStore>, Status>
             .map_err(|error| Status::invalid_argument(error.to_string()))?,
     );
 
-    validate_remote_data_folder("s3", &s3)
+    validate_remote_data_folder(RemoteDataFolderType::S3, &s3)
         .await
         .map_err(Status::invalid_argument)?;
 
@@ -190,7 +190,7 @@ async fn parse_azure_blob_storage_arguments(data: &[u8]) -> Result<Arc<dyn Objec
             .map_err(|error| Status::invalid_argument(error.to_string()))?,
     );
 
-    validate_remote_data_folder("azureblobstorage", &azure_blob_storage)
+    validate_remote_data_folder(RemoteDataFolderType::AzureBlobStorage, &azure_blob_storage)
         .await
         .map_err(Status::invalid_argument)?;
 

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -167,7 +167,7 @@ async fn parse_s3_arguments(data: &[u8]) -> Result<Arc<dyn ObjectStore>, Status>
 
     validate_remote_data_folder("s3", &s3)
         .await
-        .map_err(|error| Status::invalid_argument(error.to_string()))?;
+        .map_err(Status::invalid_argument)?;
 
     Ok(s3)
 }
@@ -192,7 +192,7 @@ async fn parse_azure_blob_storage_arguments(data: &[u8]) -> Result<Arc<dyn Objec
 
     validate_remote_data_folder("azureblobstorage", &azure_blob_storage)
         .await
-        .map_err(|error| Status::invalid_argument(error.to_string()))?;
+        .map_err(Status::invalid_argument)?;
 
     Ok(azure_blob_storage)
 }

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -48,7 +48,6 @@ use modelardb_common::schemas::METRIC_SCHEMA;
 use modelardb_common::types::TimestampBuilder;
 use object_store::aws::AmazonS3Builder;
 use object_store::azure::MicrosoftAzureBuilder;
-use object_store::path::Path;
 use object_store::ObjectStore;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc::{self, Sender};
@@ -63,7 +62,7 @@ use crate::metadata::MetadataManager;
 use crate::parser::{self, ValidStatement};
 use crate::query::ModelTable;
 use crate::storage::{StorageEngine, COMPRESSED_DATA_FOLDER};
-use crate::{Context, ServerMode};
+use crate::{validate_remote_data_folder, Context, ServerMode};
 
 /// Start an Apache Arrow Flight server on 0.0.0.0:`port` that pass `context` to
 /// the methods that process the requests through `FlightServiceHandler`.
@@ -154,7 +153,7 @@ async fn parse_s3_arguments(data: &[u8]) -> Result<Arc<dyn ObjectStore>, Status>
     let (access_key_id, offset_data) = extract_argument(offset_data)?;
     let (secret_access_key, _offset_data) = extract_argument(offset_data)?;
 
-    let s3 = Arc::new(
+    let s3: Arc<dyn ObjectStore> = Arc::new(
         AmazonS3Builder::new()
             .with_region("")
             .with_allow_http(true)
@@ -166,11 +165,11 @@ async fn parse_s3_arguments(data: &[u8]) -> Result<Arc<dyn ObjectStore>, Status>
             .map_err(|error| Status::invalid_argument(error.to_string()))?,
     );
 
-    // Check that the connection is valid by attempting to retrieve a file that does not exist.
-    match s3.get(&Path::from("")).await {
-        Ok(_) => Ok(s3),
-        Err(error) => Err(Status::invalid_argument(error.to_string())),
-    }
+    validate_remote_data_folder("s3", &s3)
+        .await
+        .map_err(|error| Status::invalid_argument(error.to_string()))?;
+
+    Ok(s3)
 }
 
 /// Parse the arguments in `data` and return an [`Azure Blob Storage`](object_store::azure::MicrosoftAzure)
@@ -182,7 +181,7 @@ async fn parse_azure_blob_storage_arguments(data: &[u8]) -> Result<Arc<dyn Objec
     let (access_key, offset_data) = extract_argument(offset_data)?;
     let (container_name, _offset_data) = extract_argument(offset_data)?;
 
-    let azure_blob_storage = Arc::new(
+    let azure_blob_storage: Arc<dyn ObjectStore> = Arc::new(
         MicrosoftAzureBuilder::new()
             .with_account(account)
             .with_access_key(access_key)
@@ -191,16 +190,11 @@ async fn parse_azure_blob_storage_arguments(data: &[u8]) -> Result<Arc<dyn Objec
             .map_err(|error| Status::invalid_argument(error.to_string()))?,
     );
 
-    // Check that the connection is valid by attempting to retrieve a file that does not exist.
-    match azure_blob_storage.get(&Path::from("")).await {
-        Ok(_) => Ok(azure_blob_storage),
-        // Note that the same error is returned if the object was not found due to the object not
-        // existing and due to the container not existing.
-        Err(error) => match error {
-            object_store::Error::NotFound { .. } => Ok(azure_blob_storage),
-            _ => Err(Status::invalid_argument(error.to_string())),
-        },
-    }
+    validate_remote_data_folder("azureblobstorage", &azure_blob_storage)
+        .await
+        .map_err(|error| Status::invalid_argument(error.to_string()))?;
+
+    Ok(azure_blob_storage)
 }
 
 /// Assumes `data` is a slice containing one or more arguments with the following format:
@@ -763,7 +757,7 @@ impl FlightService for FlightServiceHandler {
                 // TODO: The query data folder should be updated in the session context.
                 return Err(Status::unimplemented(
                     "Currently not possible to update remote object store on cloud nodes.",
-                ))
+                ));
             }
 
             // If the type of the new remote object store is not "s3" or "azureblobstorage", return an error.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -37,13 +37,13 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
 5. Move `modelardbd` and `modelardb` from the `target` directory to any directory.
 
 ## Usage
-`modelardbd` supports two execution modes, *edge* and *cloud*. For storage, `modelardbd` uses local storage and an Amazon 
-S3-compatible object store (optional in edge mode). The execution mode dictates where queries are executed. When 
-`modelardbd` is deployed in edge mode, it executes queries against local storage and when it is deployed in cloud mode, 
-it executes queries against the object store. For both deployment modes, `modelardbd` automatically compresses the 
-ingested time series using multiple different types of models and continuously transfers this compressed representation 
-from local storage to the object store. Be aware that sharing metadata between multiple instances of `modelardbd` is 
-currently under development, thus only the instance of `modelardbd` that ingested a time series can currently query it.
+`modelardbd` supports two execution modes, *edge* and *cloud*. For storage, `modelardbd` uses local storage and an 
+Amazon S3-compatible or Azure Blob Storage object store (optional in edge mode). The execution mode dictates where 
+queries are executed. When `modelardbd` is deployed in edge mode, it executes queries against local storage and when it 
+is deployed in cloud mode, it executes queries against the object store. For both deployment modes, `modelardbd` 
+automatically compresses the ingested time series using multiple different types of models and continuously transfers 
+this compressed representation from local storage to the object store. Be aware that sharing metadata between multiple 
+instances of `modelardbd` is currently under development, thus only the instance of `modelardbd` that ingested a time series can currently query it.
 
 ### Start Server
 To run `modelardbd` in edge mode using only local storage, i.e., without transferring the ingested time series to an 
@@ -83,6 +83,23 @@ the ingested time series to the MinIO bucket `wind-turbine`:
 
 ```shell
 modelardbd edge path_to_local_data_folder s3://wind-turbine
+```
+
+`modelardbd` also supports using [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/)
+for the remote object store. To use [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/),
+set the following environment variables instead:
+
+```shell
+AZURE_STORAGE_ACCOUNT_NAME
+AZURE_STORAGE_ACCESS_KEY
+```
+
+Assuming a container named `wind-turbine` already exists, `modelardbd` can then be run in edge mode with transfer of
+the ingested time series to the [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/)
+container `wind-turbine`:
+
+```shell
+modelardbd edge path_to_local_data_folder azureblobstorage://wind-turbine
 ```
 
 To run `modelardbd` in cloud mode simply replace `edge` with `cloud` as shown below. Be aware that both a local data 


### PR DESCRIPTION
This PR makes it possible to use Azure Blob Storage when starting the server with the `object_store_type://bucket_name` syntax for the argument. Since both S3 and Azure Blob Storage object stores now need to be validated when we start the server, the previous check function was also replaced by a generalized version that is used both when starting the server and when updating the remote object store using the action. 