### PR TITLE
Rewrite value if within error bound in Gorilla

### DIFF
--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -85,6 +85,7 @@ pub fn try_compress(
             if residual_start_index != current_index {
                 compress_and_store_residual_value_range(
                     univariate_id,
+                    error_bound,
                     residual_start_index,
                     current_index - 1,
                     uncompressed_timestamps,
@@ -116,6 +117,7 @@ pub fn try_compress(
     if residual_start_index != current_index {
         compress_and_store_residual_value_range(
             univariate_id,
+            error_bound,
             residual_start_index,
             current_index - 1,
             uncompressed_timestamps,
@@ -132,14 +134,19 @@ pub fn try_compress(
 /// timestamps from `uncompressed_timestamps` as a segment in `compressed_record_batch_builder`.
 fn compress_and_store_residual_value_range(
     univariate_id: u64,
+    error_bound: ErrorBound,
     start_index: usize,
     end_index: usize,
     uncompressed_timestamps: &TimestampArray,
     uncompressed_values: &ValueArray,
     compressed_record_batch_builder: &mut CompressedSegmentBatchBuilder,
 ) {
-    let selected_model =
-        models::compress_residual_value_range(start_index, end_index, uncompressed_values);
+    let selected_model = models::compress_residual_value_range(
+        error_bound,
+        start_index,
+        end_index,
+        uncompressed_values,
+    );
 
     store_selected_model_in_batch_builder(
         univariate_id,

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -48,7 +48,7 @@ pub(super) const VALUE_SIZE_IN_BYTES: u8 = mem::size_of::<Value>() as u8;
 pub(super) const VALUE_SIZE_IN_BITS: u8 = 8 * VALUE_SIZE_IN_BYTES;
 
 /// General error bound that is guaranteed to not be negative, infinite, or NAN. For [`PMCMean`],
-/// [`Swing`], and [`Gorilla`],  the error bound is interpreted as a relative per value error bound
+/// [`Swing`], and [`Gorilla`], the error bound is interpreted as a relative per value error bound
 /// in percentage. [`Gorilla`] only uses lossy compression if it receives a value that can be
 /// compressed within the error bound, thus it will never exceed the error bound.
 #[derive(Debug, Copy, Clone)]
@@ -365,46 +365,52 @@ mod tests {
         assert!(ErrorBound::try_new(f32::NAN).is_err())
     }
 
-    // is_value_within_error_bound().
+    // Tests for is_value_within_error_bound().
     proptest! {
     #[test]
     fn test_same_value_is_always_within_error_bound(value in ProptestValue::ANY) {
         prop_assert!(is_value_within_error_bound(ErrorBound::try_new(0.0).unwrap(), value, value));
     }
 
+    #[test]
     fn test_other_value_is_never_within_error_bound_of_positive_infinity(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
-        prop_assert!(is_value_within_error_bound(
+        prop_assert!(!is_value_within_error_bound(
             ErrorBound::try_new(f32::MAX).unwrap(), Value::INFINITY, value));
     }
 
+    #[test]
     fn test_other_value_is_never_within_error_bound_of_negative_infinity(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
-        prop_assert!(is_value_within_error_bound(
+        prop_assert!(!is_value_within_error_bound(
             ErrorBound::try_new(f32::MAX).unwrap(), Value::NEG_INFINITY, value));
     }
 
+    #[test]
     fn test_other_value_is_never_within_error_bound_of_nan(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
-        prop_assert!(is_value_within_error_bound(
+        prop_assert!(!is_value_within_error_bound(
             ErrorBound::try_new(f32::MAX).unwrap(), Value::NAN, value));
     }
 
+    #[test]
     fn test_positive_infinity_is_never_within_error_bound_of_other_value(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
-        prop_assert!(is_value_within_error_bound(
+        prop_assert!(!is_value_within_error_bound(
             ErrorBound::try_new(f32::MAX).unwrap(), value, Value::INFINITY));
     }
 
+    #[test]
     fn test_negative_infinity_is_never_within_error_bound_of_other_value(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
-        prop_assert!(is_value_within_error_bound(
+        prop_assert!(!is_value_within_error_bound(
             ErrorBound::try_new(f32::MAX).unwrap(), value, Value::NEG_INFINITY));
     }
 
+    #[test]
     fn test_nan_is_never_within_error_bound_of_other_value(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
-        prop_assert!(is_value_within_error_bound(
+        prop_assert!(!is_value_within_error_bound(
             ErrorBound::try_new(f32::MAX).unwrap(), value, Value::NAN));
     }
     }
@@ -512,7 +518,6 @@ mod tests {
     }
 
     // Tests for compress_residual_value_range().
-    // TODO
     #[test]
     fn test_compress_all_residual_value_range() {
         let error_bound = ErrorBound::try_new(0.0).unwrap();

--- a/crates/modelardb_compression/src/models/pmc_mean.rs
+++ b/crates/modelardb_compression/src/models/pmc_mean.rs
@@ -61,8 +61,8 @@ impl PMCMean {
         let next_sum_of_values = self.sum_of_values + value as f64;
         let next_length = self.length + 1;
         let average = (next_sum_of_values / next_length as f64) as Value;
-        if self.is_value_within_error_bound(next_min_value, average)
-            && self.is_value_within_error_bound(next_max_value, average)
+        if models::is_value_within_error_bound(self.error_bound, next_min_value, average)
+            && models::is_value_within_error_bound(self.error_bound, next_max_value, average)
         {
             self.min_value = next_min_value;
             self.max_value = next_max_value;
@@ -91,20 +91,6 @@ impl PMCMean {
     /// is the average value of the time series segment the model represents.
     pub fn model(&self) -> Value {
         (self.sum_of_values / self.length as f64) as Value
-    }
-
-    /// Determine if `approximate_value` is within [`PMCMean's`](PMCMean)
-    /// relative error bound of `real_value`.
-    fn is_value_within_error_bound(&self, real_value: Value, approximate_value: Value) -> bool {
-        // Needed because result becomes NAN and approximate_value is rejected
-        // if approximate_value and real_value are zero, and because NAN != NAN.
-        if models::equal_or_nan(real_value as f64, approximate_value as f64) {
-            true
-        } else {
-            let difference = real_value - approximate_value;
-            let result = Value::abs(difference / real_value);
-            (result * 100.0) <= self.error_bound
-        }
     }
 }
 


### PR DESCRIPTION
This PR adds preliminary support for lossy compression to Gorilla by changing the current value to the previous value if possible within the error bound. Experiments showed that this can reduce the amount of storage required by up to 22%. I also tried rewriting the current value to be as close as possible numerically to the previous value if the current value cannot be reduced to the previous value within the error bound. However, this increased the amount of stored by up to  2.6% compared to only rewriting the current value if it is within the error bound of the previous value. It is probably possible to rewrite the current value to produce the smallest result when XOR'ed with the previous value, however, this would require a significant amount of work that probably cannot be reused if we switch to [Chimp](https://www.vldb.org/pvldb/vol15/p3058-liakos.pdf/) or [Elf](https://www.vldb.org/pvldb/vol16/p1763-li.pdf), so I suggest we simply rewrite the current value to the previous value if it is within the error bound for now.