### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "arrow"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990dfa1a9328504aa135820da1c95066537b69ad94c04881b785f64328e0fa6b"
+checksum = "1aea9fcb25bbb70f7f922f95b99ca29c1013dab47f6df61a6f24861842dd7f2e"
 dependencies = [
  "ahash 0.8.2",
  "arrow-arith",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b2e52de0ab54173f9b08232b7184c26af82ee7ab4ac77c83396633c90199fa"
+checksum = "8d967b42f7b12c91fd78acd396b20c2973b184c8866846674abbb00c963e93ab"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10849b60c17dbabb334be1f4ef7550701aa58082b71335ce1ed586601b2f423"
+checksum = "3190f208ee7aa0f3596fa0098d42911dec5e123ca88c002a08b24877ad14c71e"
 dependencies = [
  "ahash 0.8.2",
  "arrow-buffer",
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0746ae991b186be39933147117f8339eb1c4bbbea1c8ad37e7bf5851a1a06ba"
+checksum = "5d33c733c5b6c44a0fc526f29c09546e04eb56772a7a21e48e602f368be381f6"
 dependencies = [
  "half",
  "num",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88897802515d7b193e38b27ddd9d9e43923d410a9e46307582d756959ee9595"
+checksum = "abd349520b6a1ed4924ae2afc9d23330a3044319e4ec3d5b124c09e4d440ae87"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8220d9741fc37961262710ceebd8451a5b393de57c464f0267ffdda1775c0a"
+checksum = "c80af3c3e290a2a7e1cc518f1471dff331878cb4af9a5b088bf030b89debf649"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f937efa1aaad9dc86f6a0e382c2fa736a4943e2090c946138079bdf060cef"
+checksum = "b1c8361947aaa96d331da9df3f7a08bdd8ab805a449994c97f5c4d24c4b7e2cf"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1362a6a02e31734c67eb2e9a30dca1689d306cfe2fc00bc6430512091480ce"
+checksum = "bd1fc687f3e4ffe91ccb7f2ffb06143ff97029448d427a9641006242bcbd0c24"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -209,17 +209,17 @@ dependencies = [
  "base64 0.21.0",
  "bytes",
  "futures",
+ "paste",
  "prost",
- "prost-derive",
  "tokio",
  "tonic",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b75296ff01833f602552dff26a423fc213db8e5049b540ca4a00b1c957e41c"
+checksum = "9a46ee000b9fbd1e8db6e8b26acb8c760838512b39d8c9f9d73892cb55351d50"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e501d3de4d612c90677594896ca6c0fa075665a7ff980dc4189bb531c17e19f6"
+checksum = "4bf2366607be867ced681ad7f272371a5cf1fc2941328eef7b4fee14565166fb"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -245,14 +245,15 @@ dependencies = [
  "indexmap",
  "lexical-core",
  "num",
+ "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d2671eb3793f9410230ac3efb0e6d36307be8a2dac5fad58ac9abde8e9f01e"
+checksum = "304069901c867200e21ec868ae7521165875470ef2f1f6d58f979a443d63997e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -265,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc11fa039338cebbf4e29cf709c8ac1d6a65c7540063d4a25f991ab255ca85c8"
+checksum = "0d57fe8ceef3392fdd493269d8a2d589de17bafce151aacbffbddac7a57f441a"
 dependencies = [
  "ahash 0.8.2",
  "arrow-array",
@@ -280,18 +281,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04f17f7b86ded0b5baf98fe6123391c4343e031acc3ccc5fa604cc180bff220"
+checksum = "a16b88a93ac8350f0200b1cd336a1f887315925b8dd7aa145a37b8bdbd8497a4"
 dependencies = [
  "bitflags 2.0.2",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163e35de698098ff5f5f672ada9dc1f82533f10407c7a11e2cd09f3bcf31d18a"
+checksum = "98e8a4d6ca37d5212439b24caad4d80743fcbb706706200dd174bb98e68fe9d8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -302,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdfbed1b10209f0dc68e6aa4c43dc76079af65880965c7c3b73f641f23d4aba"
+checksum = "cbb594efa397eb6a546f42b1f8df3d242ea84dbfda5232e06035dc2b2e2c8459"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -331,27 +332,6 @@ dependencies = [
  "xz2",
  "zstd 0.11.2+zstd.1.5.2",
  "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
-dependencies = [
- "async-stream-impl",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
 ]
 
 [[package]]
@@ -842,12 +822,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bdb93fee4f30368f1f71bfd5cd28882ec9fab0183db7924827b76129d33227c"
+checksum = "a8a7d4b334f4512ff2fdbce87f511f570ae895af1ac7c729e77c12583253b22a"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
+ "arrow-array",
+ "arrow-schema",
  "async-compression",
  "async-trait",
  "bytes",
@@ -890,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82401ce129e601d406012b6d718f8978ba84c386e1c342fa155877120d68824"
+checksum = "80abfcb1dbc6390f952f21de9069e6177ad6318fcae5fbceabb50666d96533dd"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -905,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08b2078aed21a27239cd93f3015e492a58b0d50ebeeaf8d2236cf108ef583ce"
+checksum = "df2524f1b4b58319895b112809d2a59e54fa662d0e46330a455f22882c2cb7b9"
 dependencies = [
  "dashmap",
  "datafusion-common",
@@ -923,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b5b977ce9695fb4c67614266ec57f384fc11e9a9f9b3e6d0e62b9c5a9f2c1f"
+checksum = "af8040b7a75b04685f4db0a1b11ffa93cd163c1bc13751df3f5cf76baabaf5a1"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -935,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b2bb9e73ed778d1bc5af63a270f0154bf6eab5099c77668a6362296888e46b"
+checksum = "74ceae25accc0f640a4238283f55f3a9fd181d55398703a4330fb2c46261e6a2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -953,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80cd8ea5ab0a07b1b2a3e17d5909f1b1035bd129ffeeb5c66842a32e682f8f79"
+checksum = "df4cf228b312f2758cb78e93fe3d2dc602345028efdf7cfa5b338cb370d0a347"
 dependencies = [
  "ahash 0.8.2",
  "arrow",
@@ -973,6 +955,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "lazy_static",
+ "libc",
  "md-5",
  "paste",
  "petgraph",
@@ -985,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-row"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a95d6badab19fd6e9195fdc5209ac0a7e5ce9bcdedc67767b9ffc1b4e645760"
+checksum = "b52b486fb3d81bb132e400304be01af5aba0ad6737e3518045bb98944991fe32"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -997,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "22.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a78f8fc67123c4357e63bc0c87622a2a663d26f074958d749a633d0ecde90f"
+checksum = "773e985c182e41cfd68f7a7b483ab6bfb68beaac241c348cd4b1bf9f9d61b762"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1665,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libm"
@@ -2096,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321a15f8332645759f29875b07f8233d16ed8ec1b3582223de81625a9f8506b7"
+checksum = "b5022d98333271f4ca3e87bab760498e61726bf5a6ca919123c80517e20ded29"
 dependencies = [
  "ahash 0.8.2",
  "arrow-array",
@@ -2302,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb848f80438f926a9ebddf0a539ed6065434fd7aae03a89312a9821f81b8501"
+checksum = "e3b1ac5b3731ba34fdaa9785f8d74d17448cd18f30cf19e0c7e7b1fdb5272109"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -2319,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a42e7f42e917ce6664c832d5eee481ad514c98250c49e0b03b20593e2c7ed0"
+checksum = "9cb946f5ac61bb61a5014924910d936ebd2b23b705f7a4a3c40b05c720b079a3"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2329,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0707f0ab26826fe4ccd59b69106e9df5e12d097457c7b8f9c0fd1d2743eec4d"
+checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2339,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978d18e61465ecd389e1f235ff5a467146dc4e3c3968b90d274fe73a5dd4a438"
+checksum = "a9d39c55dab3fc5a4b25bbd1ac10a2da452c4aca13bb450f22818a002e29648d"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2351,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0e1128f85ce3fca66e435e08aa2089a2689c1c48ce97803e13f63124058462"
+checksum = "97daff08a4c48320587b5224cc98d609e3c27b6d437315bd40b605c98eeb5918"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2922,9 +2905,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqlparser"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0366f270dbabb5cc2e4c88427dc4c08bba144f81e32fbd459a013f26a4d16aa0"
+checksum = "355dc4d4b6207ca8a3434fc587db0a8016130a574dbcdbfb93d7f7b5bc5b211a"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -3191,14 +3174,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3210,15 +3192,12 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -3287,16 +3266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3309,9 +3278,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",

--- a/crates/modelardb_client/Cargo.toml
+++ b/crates/modelardb_client/Cargo.toml
@@ -24,10 +24,10 @@ name = "modelardb"
 path = "src/main.rs"
 
 [dependencies]
-arrow = "36.0.0"
-arrow-flight = "36.0.0"
+arrow = "37.0.0"
+arrow-flight = "37.0.0"
 bytes = "1.4.0"
 dirs = "5.0.0"
 rustyline = "11.0.0"
 tokio = "1.27.0"
-tonic = "0.8.3"
+tonic = "0.9.2"

--- a/crates/modelardb_common/Cargo.toml
+++ b/crates/modelardb_common/Cargo.toml
@@ -20,5 +20,5 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-arrow = "36.0.0"
+arrow = "37.0.0"
 once_cell = "1.17.1"

--- a/crates/modelardb_common/src/schemas.rs
+++ b/crates/modelardb_common/src/schemas.rs
@@ -69,7 +69,7 @@ pub static METRIC_SCHEMA: Lazy<MetricSchema> = Lazy::new(|| {
         Field::new("metric", DataType::Utf8, false),
         Field::new(
             "timestamps",
-            DataType::List(Box::new(Field::new(
+            DataType::List(Arc::new(Field::new(
                 "item",
                 ArrowTimestamp::DATA_TYPE,
                 true,
@@ -78,7 +78,7 @@ pub static METRIC_SCHEMA: Lazy<MetricSchema> = Lazy::new(|| {
         ),
         Field::new(
             "values",
-            DataType::List(Box::new(Field::new("item", DataType::UInt32, true))),
+            DataType::List(Arc::new(Field::new("item", DataType::UInt32, true))),
             false,
         ),
     ])))

--- a/crates/modelardb_compression/Cargo.toml
+++ b/crates/modelardb_compression/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-arrow = "36.0.0"
+arrow = "37.0.0"
 modelardb_common = { path = "../modelardb_common" }
 
 [dev-dependencies]

--- a/crates/modelardb_compression_python/Cargo.toml
+++ b/crates/modelardb_compression_python/Cargo.toml
@@ -24,13 +24,13 @@ name = "modelardb_compression_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow = { version = "36.0.0", features = ["ffi"] }
+arrow = { version = "37.0.0", features = ["ffi"] }
 modelardb_common = { path = "../modelardb_common" }
 modelardb_compression = { path = "../modelardb_compression" }
-pyo3 = { version = "0.18.2", features = ["extension-module"] }
+pyo3 = { version = "0.18.3", features = ["extension-module"] }
 
 [build-dependencies]
-pyo3-build-config = "0.18.2"
+pyo3-build-config = "0.18.3"
 
 [package.metadata.cargo-machete]
 ignored = ["pyo3_build_config"]

--- a/crates/modelardb_compression_python/src/convert.rs
+++ b/crates/modelardb_compression_python/src/convert.rs
@@ -128,7 +128,7 @@ fn rust_schema_to_python<'a>(schema: &'a Schema, python: Python<'a>) -> PyResult
 /// Convert an Apache Arrow array from Rust to Python.
 fn rust_array_to_python<'a>(array: &'a Arc<dyn Array>, python: Python<'a>) -> PyResult<&'a PyAny> {
     // Create FFI representations of the array's components.
-    let ffi_arrow_array = FFI_ArrowArray::new(array.data());
+    let ffi_arrow_array = FFI_ArrowArray::new(&array.to_data());
     let ffi_arrow_schema = FFI_ArrowSchema::try_from(array.data_type()).map_err(to_py_err)?;
 
     // Construct the array from its FFI representation using a hidden method and return it.

--- a/crates/modelardb_server/Cargo.toml
+++ b/crates/modelardb_server/Cargo.toml
@@ -24,29 +24,29 @@ name = "modelardbd"
 path = "src/main.rs"
 
 [dependencies]
-arrow-flight = "36.0.0"
+arrow-flight = "37.0.0"
 async-trait = "0.1.68"
 bytes = "1.4.0"
-datafusion = "22.0.0"
+datafusion = "23.0.0"
 futures = "0.3.28"
 modelardb_common = { path = "../modelardb_common" }
 modelardb_compression = { path = "../modelardb_compression" }
 object_store = { version = "0.5.6", features = ["aws", "azure"] }
 once_cell = "1.17.1"
-parquet = { version = "36.0.0", features = ["object_store"] }
+parquet = { version = "37.0.0", features = ["object_store"] }
 ringbuf = "0.3.3"
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 snmalloc-rs = "0.3.3"
-sqlparser = "0.32.0"
+sqlparser = "0.33.0"
 tokio = { version = "1.27.0", features = ["rt-multi-thread", "signal"] }
 tokio-stream = "0.1.12"
-tonic = "0.8.3"
+tonic = "0.9.2"
 uuid = "1.3.1"
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same values.
 log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }
 tracing = { version = "0.1.37", features = ["max_level_debug", "release_max_level_info"] }
-tracing-subscriber = "0.3.16"
+tracing-subscriber = "0.3.17"
 
 [dev-dependencies]
 proptest = "1.1.0"

--- a/crates/modelardb_server/src/optimizer/model_simple_aggregates.rs
+++ b/crates/modelardb_server/src/optimizer/model_simple_aggregates.rs
@@ -51,6 +51,7 @@ fn new_aggregate(
             *aggregate_exec.mode(),
             aggregate_exec.group_expr().clone(),
             vec![model_aggregate_expr],
+            vec![],
             grid_exec.children()[0].clone(), //Removes the GridExec
             aggregate_exec.input_schema(),
         )
@@ -136,7 +137,7 @@ impl PhysicalOptimizerRule for ModelSimpleAggregatesPhysicalOptimizerRule {
 }
 
 // Aggregate Expressions.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum ModelAggregateType {
     Count,
     Min,
@@ -167,6 +168,18 @@ impl ModelAggregateExpr {
             aggregate_type,
             data_type,
         })
+    }
+}
+
+impl PartialEq<dyn Any> for ModelAggregateExpr {
+    fn eq(&self, other: &dyn Any) -> bool {
+        if let Some(other_model_aggregate_expr) = other.downcast_ref::<ModelAggregateExpr>() {
+            self.name == other_model_aggregate_expr.name
+                && self.aggregate_type == other_model_aggregate_expr.aggregate_type
+                && self.data_type == other_model_aggregate_expr.data_type
+        } else {
+            false
+        }
     }
 }
 

--- a/crates/modelardb_server/src/parser.rs
+++ b/crates/modelardb_server/src/parser.rs
@@ -532,30 +532,33 @@ fn column_defs_to_schema(column_defs: &Vec<ColumnDef>) -> Result<Schema, DataFus
     Ok(Schema::new(fields))
 }
 
-/* Start of code copied from datafusion-sql v14.0.0/v15.0.0/v20.0.0. */
-// The following two functions have been copied from datafusion-sql v14.0.0/v15.0.0/v20.0.0 as
-// parser.rs used the version of convert_simple_data_type() implemented as a free function in
+/* Start of code copied from datafusion-sql v14.0.0/v15.0.0/v20.0.0/23.0.0. */
+// The following two functions have been copied from datafusion-sql v14.0.0/v15.0.0/v20.0.0/23.0.0
+// as parser.rs used the version of convert_simple_data_type() implemented as a free function in
 // datafusion-sql v14.0.0 to convert from sqlparser::ast::DataType (SQLDataType) to
 // datafusion::arrow::datatypes::DataType and it was changed to a private instance method in
 // datafusion-sql v15.0.0. As Apache Arrow DataFusion no longer seems to provide an API for
 // converting from SQLDataType to DataType, the version of convert_simple_data_type() in
-// datafusion-sql v14.0.0 has been copied to parser.rs and has been updated according to the changes
-// made in datafusion-sql v15.0.0 and datafusion-sql v20.0.0 to the greatest degree possible. As the
-// private function make_decimal_type() is used by convert_simple_data_type() it has also been
-// copied from datafusion-sql v15.0.0. As these functions have been copied from datafusion-sql they
-// should be updated whenever a new version of datafusion-sql is released. Also significant effort
-// should be made to try and replace these two functions with calls to Apache Arrow DataFusion's
-// public API whenever a new version of Apache Arrow DataFusion is released.
+// datafusion-sql v14.0.0 has been copied to parser.rs and has been updated according to the
+// changes made in datafusion-sql v15.0.0, datafusion-sql v20.0.0, and datafusion-sql v23.0.0 to
+// the greatest degree possible. As the private function make_decimal_type() is used by
+// convert_simple_data_type() it has also been copied from datafusion-sql v15.0.0. As these
+// functions have been copied from datafusion-sql they should be updated whenever a new version of
+// datafusion-sql is released. Also significant effort should be made to try and replace these two
+// functions with calls to Apache Arrow DataFusion's public API whenever a new version of Apache
+// Arrow DataFusion is released.
 
 /// Convert a simple [`SQLDataType`] to the relational representation of the [`DataType`]. This
-/// function is copied from [datafusion-sql v14.0.0] and updated with the changes in [datafusion-sql
-/// v15.0.0] and [datafusion-sql v20.0.0] as it was changed from a public function to a private
-/// method in [datafusion-sql v15.0.0] and extended in [datafusion-sql v20.0.0]. All versions of
-/// datafusion-sql were released under version 2.0 of the Apache License.
+/// function is copied from [datafusion-sql v14.0.0] and updated with the changes in
+/// [datafusion-sql v15.0.0], [datafusion-sql v20.0.0], and [datafusion-sql v23.0.0] as it was
+/// changed from a public function to a private method in [datafusion-sql v15.0.0] and extended in
+/// [datafusion-sql v20.0.0] and [datafusion-sql v23.0.0]. All versions of datafusion-sql were
+/// released under version 2.0 of the Apache License.
 ///
 /// [datafusion-sql v14.0.0]: https://github.com/apache/arrow-datafusion/blob/14.0.0/datafusion/sql/src/planner.rs#L2812
 /// [datafusion-sql v15.0.0]: https://github.com/apache/arrow-datafusion/blob/15.0.0/datafusion/sql/src/planner.rs#L2790
 /// [datafusion-sql v20.0.0]: https://github.com/apache/arrow-datafusion/blob/20.0.0/datafusion/sql/src/planner.rs#L235
+/// [datafusion-sql v23.0.0]: https://github.com/apache/arrow-datafusion/blob/23.0.0/datafusion/sql/src/planner.rs#L304
 pub fn convert_simple_data_type(sql_type: &SQLDataType) -> DataFusionResult<DataType> {
     match sql_type {
         SQLDataType::Boolean => Ok(DataType::Boolean),
@@ -582,7 +585,7 @@ pub fn convert_simple_data_type(sql_type: &SQLDataType) -> DataFusionResult<Data
             } else {
                 None
             };
-            Ok(DataType::Timestamp(TimeUnit::Nanosecond, tz))
+            Ok(DataType::Timestamp(TimeUnit::Nanosecond, tz.map(Into::into)))
         }
         SQLDataType::Date => Ok(DataType::Date32),
         SQLDataType::Time(None, tz_info) => {

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -40,11 +40,11 @@ use datafusion::arrow::compute;
 use datafusion::arrow::compute::kernels::aggregate;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::parquet::basic::ZstdLevel;
 use datafusion::parquet::arrow::async_reader::{
     ParquetObjectReader, ParquetRecordBatchStreamBuilder,
 };
 use datafusion::parquet::arrow::ArrowWriter;
+use datafusion::parquet::basic::ZstdLevel;
 use datafusion::parquet::basic::{Compression, Encoding};
 use datafusion::parquet::errors::ParquetError;
 use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
@@ -640,7 +640,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    use datafusion::arrow::datatypes::Schema;
+    use datafusion::arrow::datatypes::{Field, Schema};
     use object_store::local::LocalFileSystem;
     use tempfile::{self, TempDir};
 
@@ -663,7 +663,8 @@ mod tests {
 
     #[test]
     fn test_write_empty_batch_to_apache_parquet_file() {
-        let schema = Schema::new(vec![]);
+        let fields: Vec<Field> = vec![];
+        let schema = Schema::new(fields);
         let batch = RecordBatch::new_empty(Arc::new(schema));
 
         let temp_dir = tempfile::tempdir().unwrap();
@@ -861,7 +862,7 @@ pub mod test_util {
     use modelardb_common::schemas::COMPRESSED_SCHEMA;
     use modelardb_common::types::{TimestampArray, ValueArray};
 
-    pub const COMPRESSED_SEGMENTS_SIZE: usize = 2680;
+    pub const COMPRESSED_SEGMENTS_SIZE: usize = 2055;
 
     /// Return a [`RecordBatch`] containing three compressed segments.
     pub fn compressed_segments_record_batch() -> RecordBatch {


### PR DESCRIPTION
This PR primarily updates Apache Arrow DataFusion to [v23.0.0](https://crates.io/crates/datafusion/23.0.0) and fixes all known breaking changes. New versions of Apache Arrow DataFusion usually have breaking changes, so updating to each new release ensures that the number of changes required does not accumulate. The changes in v23.0.0 only required minor fixes for the code and the tests, and there were only a small change to `convert_simple_data_type()` and no changes to `make_decimal_type()` which were copied from Apache Arrow DataFusion [v14.0.0](https://crates.io/crates/datafusion/14.0.0) and manually updated since.