### PR TITLE
Store short segments in previous segment

### DIFF
--- a/crates/modelardb_common/src/macros.rs
+++ b/crates/modelardb_common/src/macros.rs
@@ -70,21 +70,22 @@ macro_rules! array {
 /// #         Arc::new(ValueArray::from(Vec::<Value>::new())),
 /// #         Arc::new(ValueArray::from(Vec::<Value>::new())),
 /// #         Arc::new(BinaryArray::from(Vec::<&[u8]>::new())),
+/// #         Arc::new(BinaryArray::from(Vec::<&[u8]>::new())),
 /// #         Arc::new(Float32Array::from(Vec::<f32>::new())),
 /// #     ],
 /// # ).unwrap();
 /// modelardb_common::arrays!(record_batch, univariate_ids, model_type_ids, start_times, end_times,
-/// timestamps, min_values, max_values, values, errors);
+/// timestamps, min_values, max_values, values, residuals, errors);
 /// ```
 ///
 /// # Panics
 ///
 /// Panics if `batch` does not contain nine columns or if the columns are not UInt64Array,
 /// UInt8Array, TimestampArray, TimestampArray, BinaryArray, ValueArray, ValueArray, BinaryArray,
-/// and Float32Array.
+/// BinaryArray, and Float32Array.
 #[macro_export]
 macro_rules! arrays {
-    ($batch:ident, $univariate_ids:ident, $model_type_ids:ident, $start_times:ident, $end_times:ident, $timestamps:ident, $min_values:ident, $max_values:ident, $values:ident, $errors:ident) => {
+    ($batch:ident, $univariate_ids:ident, $model_type_ids:ident, $start_times:ident, $end_times:ident, $timestamps:ident, $min_values:ident, $max_values:ident, $values:ident, $residuals:ident, $errors:ident) => {
         let $univariate_ids = $crate::array!($batch, 0, UInt64Array);
         let $model_type_ids = $crate::array!($batch, 1, UInt8Array);
         let $start_times = $crate::array!($batch, 2, TimestampArray);
@@ -93,6 +94,7 @@ macro_rules! arrays {
         let $min_values = $crate::array!($batch, 5, ValueArray);
         let $max_values = $crate::array!($batch, 6, ValueArray);
         let $values = $crate::array!($batch, 7, BinaryArray);
-        let $errors = $crate::array!($batch, 8, Float32Array);
+        let $residuals = $crate::array!($batch, 8, BinaryArray);
+        let $errors = $crate::array!($batch, 9, Float32Array);
     };
 }

--- a/crates/modelardb_common/src/macros.rs
+++ b/crates/modelardb_common/src/macros.rs
@@ -80,7 +80,7 @@ macro_rules! array {
 ///
 /// # Panics
 ///
-/// Panics if `batch` does not contain nine columns or if the columns are not UInt64Array,
+/// Panics if `batch` does not contain ten columns or if the columns are not UInt64Array,
 /// UInt8Array, TimestampArray, TimestampArray, BinaryArray, ValueArray, ValueArray, BinaryArray,
 /// BinaryArray, and Float32Array.
 #[macro_export]

--- a/crates/modelardb_common/src/schemas.rs
+++ b/crates/modelardb_common/src/schemas.rs
@@ -46,7 +46,7 @@ pub static COMPRESSED_SCHEMA: Lazy<CompressedSchema> = Lazy::new(|| {
         Field::new("min_value", ArrowValue::DATA_TYPE, false),
         Field::new("max_value", ArrowValue::DATA_TYPE, false),
         Field::new("values", DataType::Binary, false),
-        Field::new("residual", DataType::Binary, false),
+        Field::new("residuals", DataType::Binary, false),
         Field::new("error", DataType::Float32, false),
     ])))
 });

--- a/crates/modelardb_common/src/schemas.rs
+++ b/crates/modelardb_common/src/schemas.rs
@@ -46,6 +46,7 @@ pub static COMPRESSED_SCHEMA: Lazy<CompressedSchema> = Lazy::new(|| {
         Field::new("min_value", ArrowValue::DATA_TYPE, false),
         Field::new("max_value", ArrowValue::DATA_TYPE, false),
         Field::new("values", DataType::Binary, false),
+        Field::new("residual", DataType::Binary, false),
         Field::new("error", DataType::Float32, false),
     ])))
 });

--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -666,14 +666,16 @@ mod tests {
     #[test]
     fn test_try_compress_regular_constant_time_series() {
         let timestamps = test_util::generate_timestamps(TRY_COMPRESS_TEST_LENGTH, false);
-        let values =
+        let mut values =
             test_util::generate_values(&timestamps, StructureOfValues::Constant, None, None);
 
         let (uncompressed_timestamps, compressed_record_batch) =
             create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_ZERO);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
 
-        assert_compressed_record_batch_with_segments_from_regular_time_series(
+        assert_compressed_record_batch_with_segments_from_time_series(
             &uncompressed_timestamps,
+            &uncompressed_values,
             &compressed_record_batch,
             &[models::PMC_MEAN_ID],
         )
@@ -682,14 +684,16 @@ mod tests {
     #[test]
     fn test_try_compress_irregular_constant_time_series() {
         let timestamps = test_util::generate_timestamps(TRY_COMPRESS_TEST_LENGTH, true);
-        let values =
+        let mut values =
             test_util::generate_values(&timestamps, StructureOfValues::Constant, None, None);
 
         let (uncompressed_timestamps, compressed_record_batch) =
             create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_ZERO);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
 
-        assert_compressed_record_batch_with_segments_from_regular_time_series(
+        assert_compressed_record_batch_with_segments_from_time_series(
             &uncompressed_timestamps,
+            &uncompressed_values,
             &compressed_record_batch,
             &[models::PMC_MEAN_ID],
         )
@@ -698,7 +702,7 @@ mod tests {
     #[test]
     fn test_try_compress_regular_almost_constant_time_series() {
         let timestamps = test_util::generate_timestamps(TRY_COMPRESS_TEST_LENGTH, false);
-        let values = test_util::generate_values(
+        let mut values = test_util::generate_values(
             &timestamps,
             StructureOfValues::Random,
             Some(9.8),
@@ -707,9 +711,11 @@ mod tests {
 
         let (uncompressed_timestamps, compressed_record_batch) =
             create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_FIVE);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
 
-        assert_compressed_record_batch_with_segments_from_regular_time_series(
+        assert_compressed_record_batch_with_segments_from_time_series(
             &uncompressed_timestamps,
+            &uncompressed_values,
             &compressed_record_batch,
             &[models::PMC_MEAN_ID],
         )
@@ -718,7 +724,7 @@ mod tests {
     #[test]
     fn test_try_compress_irregular_almost_constant_time_series() {
         let timestamps = test_util::generate_timestamps(TRY_COMPRESS_TEST_LENGTH, true);
-        let values = test_util::generate_values(
+        let mut values = test_util::generate_values(
             &timestamps,
             StructureOfValues::Random,
             Some(9.8),
@@ -727,9 +733,11 @@ mod tests {
 
         let (uncompressed_timestamps, compressed_record_batch) =
             create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_FIVE);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
 
-        assert_compressed_record_batch_with_segments_from_regular_time_series(
+        assert_compressed_record_batch_with_segments_from_time_series(
             &uncompressed_timestamps,
+            &uncompressed_values,
             &compressed_record_batch,
             &[models::PMC_MEAN_ID],
         )
@@ -738,13 +746,16 @@ mod tests {
     #[test]
     fn test_try_compress_regular_linear_time_series() {
         let timestamps = test_util::generate_timestamps(TRY_COMPRESS_TEST_LENGTH, false);
-        let values = test_util::generate_values(&timestamps, StructureOfValues::Linear, None, None);
+        let mut values =
+            test_util::generate_values(&timestamps, StructureOfValues::Linear, None, None);
 
         let (uncompressed_timestamps, compressed_record_batch) =
             create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_ZERO);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
 
-        assert_compressed_record_batch_with_segments_from_regular_time_series(
+        assert_compressed_record_batch_with_segments_from_time_series(
             &uncompressed_timestamps,
+            &uncompressed_values,
             &compressed_record_batch,
             &[models::SWING_ID],
         )
@@ -753,13 +764,16 @@ mod tests {
     #[test]
     fn test_try_compress_irregular_linear_time_series() {
         let timestamps = test_util::generate_timestamps(TRY_COMPRESS_TEST_LENGTH, true);
-        let values = test_util::generate_values(&timestamps, StructureOfValues::Linear, None, None);
+        let mut values =
+            test_util::generate_values(&timestamps, StructureOfValues::Linear, None, None);
 
         let (uncompressed_timestamps, compressed_record_batch) =
             create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_FIVE);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
 
-        assert_compressed_record_batch_with_segments_from_regular_time_series(
+        assert_compressed_record_batch_with_segments_from_time_series(
             &uncompressed_timestamps,
+            &uncompressed_values,
             &compressed_record_batch,
             &[models::SWING_ID],
         )
@@ -768,7 +782,7 @@ mod tests {
     #[test]
     fn test_try_compress_regular_almost_linear_time_series() {
         let timestamps = test_util::generate_timestamps(TRY_COMPRESS_TEST_LENGTH, false);
-        let values = test_util::generate_values(
+        let mut values = test_util::generate_values(
             &timestamps,
             StructureOfValues::AlmostLinear,
             Some(9.8),
@@ -777,9 +791,11 @@ mod tests {
 
         let (uncompressed_timestamps, compressed_record_batch) =
             create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_FIVE);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
 
-        assert_compressed_record_batch_with_segments_from_regular_time_series(
+        assert_compressed_record_batch_with_segments_from_time_series(
             &uncompressed_timestamps,
+            &uncompressed_values,
             &compressed_record_batch,
             &[models::SWING_ID],
         )
@@ -788,7 +804,7 @@ mod tests {
     #[test]
     fn test_try_compress_irregular_almost_linear_time_series() {
         let timestamps = test_util::generate_timestamps(TRY_COMPRESS_TEST_LENGTH, true);
-        let values = test_util::generate_values(
+        let mut values = test_util::generate_values(
             &timestamps,
             StructureOfValues::AlmostLinear,
             Some(9.8),
@@ -797,9 +813,11 @@ mod tests {
 
         let (uncompressed_timestamps, compressed_record_batch) =
             create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_FIVE);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
 
-        assert_compressed_record_batch_with_segments_from_regular_time_series(
+        assert_compressed_record_batch_with_segments_from_time_series(
             &uncompressed_timestamps,
+            &uncompressed_values,
             &compressed_record_batch,
             &[models::SWING_ID],
         )
@@ -808,7 +826,7 @@ mod tests {
     #[test]
     fn test_try_compress_regular_random_time_series() {
         let timestamps = test_util::generate_timestamps(TRY_COMPRESS_TEST_LENGTH, false);
-        let values = test_util::generate_values(
+        let mut values = test_util::generate_values(
             &timestamps,
             StructureOfValues::Random,
             Some(0.0),
@@ -817,9 +835,11 @@ mod tests {
 
         let (uncompressed_timestamps, compressed_record_batch) =
             create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_ZERO);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
 
-        assert_compressed_record_batch_with_segments_from_regular_time_series(
+        assert_compressed_record_batch_with_segments_from_time_series(
             &uncompressed_timestamps,
+            &uncompressed_values,
             &compressed_record_batch,
             &[models::GORILLA_ID],
         )
@@ -828,7 +848,7 @@ mod tests {
     #[test]
     fn test_try_compress_irregular_random_time_series() {
         let timestamps = test_util::generate_timestamps(TRY_COMPRESS_TEST_LENGTH, true);
-        let values = test_util::generate_values(
+        let mut values = test_util::generate_values(
             &timestamps,
             StructureOfValues::Random,
             Some(0.0),
@@ -837,9 +857,11 @@ mod tests {
 
         let (uncompressed_timestamps, compressed_record_batch) =
             create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_ZERO);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
 
-        assert_compressed_record_batch_with_segments_from_regular_time_series(
+        assert_compressed_record_batch_with_segments_from_time_series(
             &uncompressed_timestamps,
+            &uncompressed_values,
             &compressed_record_batch,
             &[models::GORILLA_ID],
         )
@@ -848,6 +870,64 @@ mod tests {
     #[test]
     fn test_try_compress_regular_random_linear_constant_time_series() {
         let timestamps = test_util::generate_timestamps(3 * TRY_COMPRESS_TEST_LENGTH, false);
+        try_compress_random_linear_constant_time_series(timestamps);
+    }
+
+    #[test]
+    fn test_try_compress_irregular_random_linear_constant_time_series() {
+        let timestamps = test_util::generate_timestamps(3 * TRY_COMPRESS_TEST_LENGTH, true);
+        try_compress_random_linear_constant_time_series(timestamps);
+    }
+
+    fn try_compress_random_linear_constant_time_series(timestamps: Vec<i64>) {
+        let mut random = test_util::generate_values(
+            &timestamps[0..TRY_COMPRESS_TEST_LENGTH],
+            StructureOfValues::Random,
+            Some(0.0),
+            Some(f32::MAX),
+        );
+        let mut linear = test_util::generate_values(
+            &timestamps[TRY_COMPRESS_TEST_LENGTH..2 * TRY_COMPRESS_TEST_LENGTH],
+            StructureOfValues::Linear,
+            None,
+            None,
+        );
+        let mut constant = test_util::generate_values(
+            &timestamps[2 * TRY_COMPRESS_TEST_LENGTH..],
+            StructureOfValues::Constant,
+            None,
+            None,
+        );
+        let mut values = vec![];
+        values.append(&mut random);
+        values.append(&mut linear);
+        values.append(&mut constant);
+
+        let (uncompressed_timestamps, compressed_record_batch) =
+            create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_ZERO);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
+
+        assert_compressed_record_batch_with_segments_from_time_series(
+            &uncompressed_timestamps,
+            &uncompressed_values,
+            &compressed_record_batch,
+            &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
+        )
+    }
+
+    #[test]
+    fn test_try_compress_constant_linear_random_regular_time_series() {
+        let timestamps = test_util::generate_timestamps(3 * TRY_COMPRESS_TEST_LENGTH, false);
+        try_compress_constant_linear_random_time_series(timestamps);
+    }
+
+    #[test]
+    fn test_try_compress_constant_linear_random_irregular_time_series() {
+        let timestamps = test_util::generate_timestamps(3 * TRY_COMPRESS_TEST_LENGTH, true);
+        try_compress_constant_linear_random_time_series(timestamps);
+    }
+
+    fn try_compress_constant_linear_random_time_series(timestamps: Vec<i64>) {
         let mut constant = test_util::generate_values(
             &timestamps[0..TRY_COMPRESS_TEST_LENGTH],
             StructureOfValues::Constant,
@@ -867,17 +947,19 @@ mod tests {
             Some(f32::MAX),
         );
         let mut values = vec![];
-        values.append(&mut random);
-        values.append(&mut linear);
         values.append(&mut constant);
+        values.append(&mut linear);
+        values.append(&mut random);
 
         let (uncompressed_timestamps, compressed_record_batch) =
             create_and_compress_time_series(&values, &timestamps, ERROR_BOUND_ZERO);
+        let uncompressed_values = ValueArray::from_iter_values(values.drain(..));
 
-        assert_compressed_record_batch_with_segments_from_regular_time_series(
+        assert_compressed_record_batch_with_segments_from_time_series(
             &uncompressed_timestamps,
+            &uncompressed_values,
             &compressed_record_batch,
-            &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
+            &[models::PMC_MEAN_ID, models::SWING_ID],
         )
     }
 
@@ -910,8 +992,9 @@ mod tests {
         (uncompressed_timestamps, compressed_record_batch)
     }
 
-    fn assert_compressed_record_batch_with_segments_from_regular_time_series(
+    fn assert_compressed_record_batch_with_segments_from_time_series(
         uncompressed_timestamps: &TimestampArray,
+        uncompressed_values: &ValueArray,
         compressed_record_batch: &RecordBatch,
         expected_model_type_ids: &[u8],
     ) {
@@ -920,22 +1003,48 @@ mod tests {
             compressed_record_batch.num_rows()
         );
 
-        let mut total_compressed_length = 0;
-        for (segment, expected_model_type_id) in expected_model_type_ids.iter().enumerate() {
-            let model_type_id =
-                modelardb_common::array!(compressed_record_batch, 1, UInt8Array).value(segment);
-            assert_eq!(*expected_model_type_id, model_type_id);
+        let mut univariate_id_builder = UInt64Builder::new();
+        let mut timestamp_builder = TimestampBuilder::new();
+        let mut value_builder = ValueBuilder::new();
 
-            let start_time =
-                modelardb_common::array!(compressed_record_batch, 2, TimestampArray).value(segment);
-            let end_time =
-                modelardb_common::array!(compressed_record_batch, 3, TimestampArray).value(segment);
-            let timestamps =
-                modelardb_common::array!(compressed_record_batch, 4, BinaryArray).value(segment);
+        modelardb_common::arrays!(
+            compressed_record_batch,
+            univariate_ids,
+            model_type_ids,
+            start_times,
+            end_times,
+            timestamps,
+            min_values,
+            max_values,
+            values,
+            residuals,
+            _error_array
+        );
 
-            total_compressed_length += models::len(start_time, end_time, timestamps);
+        for (row_index, expected_model_type_id) in expected_model_type_ids.iter().enumerate() {
+            models::grid(
+                univariate_ids.value(row_index),
+                model_type_ids.value(row_index),
+                start_times.value(row_index),
+                end_times.value(row_index),
+                timestamps.value(row_index),
+                min_values.value(row_index),
+                max_values.value(row_index),
+                values.value(row_index),
+                residuals.value(row_index),
+                &mut univariate_id_builder,
+                &mut timestamp_builder,
+                &mut value_builder,
+            );
+
+            assert_eq!(model_type_ids.value(row_index), *expected_model_type_id);
         }
-        assert_eq!(uncompressed_timestamps.len(), total_compressed_length);
+
+        assert_eq!(
+            uncompressed_timestamps.len(),
+            timestamp_builder.finish().len()
+        );
+        assert_eq!(uncompressed_values.len(), value_builder.finish().len());
     }
 
     // Tests for merge_segments().

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -293,7 +293,7 @@ pub fn grid(
     let residuals_length = if residuals.is_empty() {
         0
     } else {
-        // The number of the residuals are stored as the last byte.
+        // The number of residuals are stored as the last byte.
         residuals[residuals.len() - 1]
     };
 

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -271,32 +271,46 @@ pub fn sum(
     }
 }
 
-/// Reconstruct the data points for a time series segment whose values are
-/// represented by a model. Each data point is split into its three components
-/// and appended to `univariate_ids`, `timestamps`, and `values`.
+/// Reconstruct the data points for a time series segment whose values are represented by a model
+/// and residuals. Each data point is split into its three components and appended to
+/// `univariate_ids`, `timestamps`, and `values`.
 #[allow(clippy::too_many_arguments)]
 pub fn grid(
     univariate_id: UnivariateId,
     model_type_id: u8,
-    timestamps: &[u8],
     start_time: Timestamp,
     end_time: Timestamp,
-    values: &[u8],
+    timestamps: &[u8],
     min_value: Value,
     max_value: Value,
+    values: &[u8],
+    residuals: &[u8],
     univariate_id_builder: &mut UnivariateIdBuilder,
     timestamp_builder: &mut TimestampBuilder,
     value_builder: &mut ValueBuilder,
 ) {
-    timestamps::decompress_all_timestamps(start_time, end_time, timestamps, timestamp_builder);
-    let new_timestamps = &timestamp_builder.values_slice()[value_builder.values_slice().len()..];
+    // Extract the number of residuals stored.
+    let residuals_length = if residuals.is_empty() {
+        0
+    } else {
+        // The number of the residuals are stored as the last byte.
+        residuals[residuals.len() - 1]
+    };
 
+    // Decompress all of timestamps.
+    let model_timestamps_start = timestamp_builder.values_slice().len();
+    timestamps::decompress_all_timestamps(start_time, end_time, timestamps, timestamp_builder);
+    let model_timestamps_end = timestamp_builder.values_slice().len() - residuals_length as usize;
+    let model_timestamps =
+        &timestamp_builder.values_slice()[model_timestamps_start..model_timestamps_end];
+
+    // Reconstruct the values from the model.
     match model_type_id {
         PMC_MEAN_ID => pmc_mean::grid(
             univariate_id,
             min_value, // For PMC-Mean, min and max is the same value.
             univariate_id_builder,
-            new_timestamps,
+            model_timestamps,
             value_builder,
         ),
         SWING_ID => swing::grid(
@@ -307,17 +321,28 @@ pub fn grid(
             max_value,
             values,
             univariate_id_builder,
-            new_timestamps,
+            model_timestamps,
             value_builder,
         ),
         GORILLA_ID => gorilla::grid(
             univariate_id,
             values,
             univariate_id_builder,
-            new_timestamps,
+            model_timestamps,
             value_builder,
         ),
         _ => panic!("Unknown model type."),
+    }
+
+    // Reconstruct the values from the residuals.
+    if residuals_length > 0 {
+        gorilla::grid(
+            univariate_id,
+            &residuals[..residuals.len() - 1],
+            univariate_id_builder,
+            &timestamp_builder.values_slice()[model_timestamps_end..],
+            value_builder,
+        );
     }
 }
 

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -106,6 +106,9 @@ pub fn is_value_within_error_bound(
 pub struct SelectedModel {
     /// Id of the model type that created this model.
     pub model_type_id: u8,
+    /// Index of the first data point in the `UncompressedDataBuffer` that the
+    /// selected model represents.
+    pub start_index: usize,
     /// Index of the last data point in the `UncompressedDataBuffer` that the
     /// selected model represents.
     pub end_index: usize,
@@ -149,6 +152,7 @@ impl SelectedModel {
 
         Self {
             model_type_id: PMC_MEAN_ID,
+            start_index,
             end_index,
             min_value: value,
             max_value: value,
@@ -167,6 +171,7 @@ impl SelectedModel {
 
         Self {
             model_type_id: SWING_ID,
+            start_index,
             end_index,
             min_value,
             max_value,
@@ -207,6 +212,7 @@ pub fn compress_residual_value_range(
 
     SelectedModel {
         model_type_id: GORILLA_ID,
+        start_index,
         end_index,
         min_value,
         max_value,

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -578,7 +578,7 @@ mod tests {
             min_value_array,
             max_value_array,
             values_array,
-            _residual_array,
+            residuals_array,
             _error_array
         );
 
@@ -594,12 +594,13 @@ mod tests {
         models::grid(
             0,
             model_type_id_array.value(0),
-            timestamps_array.value(0),
             start_time_array.value(0),
             end_time_array.value(0),
-            values_array.value(0),
+            timestamps_array.value(0),
             min_value_array.value(0),
             max_value_array.value(0),
+            values_array.value(0),
+            residuals_array.value(0),
             &mut reconstructed_ids,
             &mut reconstructed_timestamps,
             &mut reconstructed_values,

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -578,6 +578,7 @@ mod tests {
             min_value_array,
             max_value_array,
             values_array,
+            _residual_array,
             _error_array
         );
 

--- a/crates/modelardb_compression_python/src/lib.rs
+++ b/crates/modelardb_compression_python/src/lib.rs
@@ -103,6 +103,7 @@ fn decompress<'a>(compressed: &'a PyAny, python: Python<'a>) -> PyResult<&'a PyA
         min_values,
         max_values,
         values,
+        _residuals,
         _error_array
     );
 

--- a/crates/modelardb_compression_python/src/lib.rs
+++ b/crates/modelardb_compression_python/src/lib.rs
@@ -103,7 +103,7 @@ fn decompress<'a>(compressed: &'a PyAny, python: Python<'a>) -> PyResult<&'a PyA
         min_values,
         max_values,
         values,
-        _residuals,
+        residuals,
         _error_array
     );
 
@@ -115,12 +115,13 @@ fn decompress<'a>(compressed: &'a PyAny, python: Python<'a>) -> PyResult<&'a PyA
         models::grid(
             univariate_ids.value(row_index),
             model_type_ids.value(row_index),
-            timestamps.value(row_index),
             start_times.value(row_index),
             end_times.value(row_index),
-            values.value(row_index),
+            timestamps.value(row_index),
             min_values.value(row_index),
             max_values.value(row_index),
+            values.value(row_index),
+            residuals.value(row_index),
             &mut univariate_id_builder,
             &mut timestamp_builder,
             &mut value_builder,

--- a/crates/modelardb_server/src/optimizer/model_simple_aggregates.rs
+++ b/crates/modelardb_server/src/optimizer/model_simple_aggregates.rs
@@ -278,6 +278,7 @@ impl PhysicalExpr for ModelCountPhysicalExpr {
             _min_values,
             _max_values,
             _values,
+            _residuals,
             _error_array
         );
 
@@ -564,6 +565,7 @@ impl PhysicalExpr for ModelSumPhysicalExpr {
             min_values,
             max_values,
             values,
+            _residuals,
             _error_array
         );
 
@@ -685,6 +687,7 @@ impl PhysicalExpr for ModelAvgPhysicalExpr {
             min_values,
             max_values,
             values,
+            _residuals,
             _error_array
         );
 

--- a/crates/modelardb_server/src/query/grid_exec.rs
+++ b/crates/modelardb_server/src/query/grid_exec.rs
@@ -256,6 +256,7 @@ impl GridStream {
             min_values,
             max_values,
             values,
+            _residuals,
             _error_array
         );
 

--- a/crates/modelardb_server/src/query/grid_exec.rs
+++ b/crates/modelardb_server/src/query/grid_exec.rs
@@ -26,7 +26,7 @@ use std::task::{Context as StdTaskContext, Poll};
 
 use async_trait::async_trait;
 use datafusion::arrow::array::{
-    Array, ArrayRef, BinaryArray, Float32Array, UInt64Array, UInt8Array,
+    Array, ArrayRef, BinaryArray, Float32Array, UInt64Array, UInt64Builder, UInt8Array,
 };
 use datafusion::arrow::compute::filter_record_batch;
 use datafusion::arrow::datatypes::SchemaRef;
@@ -265,7 +265,7 @@ impl GridStream {
         // from each segment in the new batch as each segment contains at least one data point.
         let current_rows = self.current_batch.num_rows() - self.current_batch_offset;
         let new_rows = batch.num_rows();
-        let mut univariate_id_builder = UInt64Array::builder(current_rows + new_rows);
+        let mut univariate_id_builder = UInt64Builder::with_capacity(current_rows + new_rows);
         let mut timestamp_builder = TimestampBuilder::with_capacity(current_rows + new_rows);
         let mut value_builder = ValueBuilder::with_capacity(current_rows + new_rows);
 

--- a/crates/modelardb_server/src/query/grid_exec.rs
+++ b/crates/modelardb_server/src/query/grid_exec.rs
@@ -256,7 +256,7 @@ impl GridStream {
             min_values,
             max_values,
             values,
-            _residuals,
+            residuals,
             _error_array
         );
 
@@ -289,12 +289,13 @@ impl GridStream {
             models::grid(
                 univariate_ids.value(row_index),
                 model_type_ids.value(row_index),
-                timestamps.value(row_index),
                 start_times.value(row_index),
                 end_times.value(row_index),
-                values.value(row_index),
+                timestamps.value(row_index),
                 min_values.value(row_index),
                 max_values.value(row_index),
+                values.value(row_index),
+                residuals.value(row_index),
                 &mut univariate_id_builder,
                 &mut timestamp_builder,
                 &mut value_builder,

--- a/crates/modelardb_server/src/storage/data_transfer.rs
+++ b/crates/modelardb_server/src/storage/data_transfer.rs
@@ -249,7 +249,7 @@ mod tests {
 
     const TABLE_NAME: &str = "table";
     const COLUMN_INDEX: u16 = 5;
-    const COMPRESSED_FILE_SIZE: usize = 2126;
+    const COMPRESSED_FILE_SIZE: usize = 2348;
 
     // Tests for path_is_compressed_file().
     #[test]

--- a/crates/modelardb_server/src/storage/data_transfer.rs
+++ b/crates/modelardb_server/src/storage/data_transfer.rs
@@ -249,7 +249,7 @@ mod tests {
 
     const TABLE_NAME: &str = "table";
     const COLUMN_INDEX: u16 = 5;
-    const COMPRESSED_FILE_SIZE: usize = 2348;
+    const COMPRESSED_FILE_SIZE: usize = 2351;
 
     // Tests for path_is_compressed_file().
     #[test]

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -862,7 +862,7 @@ pub mod test_util {
     use modelardb_common::schemas::COMPRESSED_SCHEMA;
     use modelardb_common::types::{TimestampArray, ValueArray};
 
-    pub const COMPRESSED_SEGMENTS_SIZE: usize = 2055;
+    pub const COMPRESSED_SEGMENTS_SIZE: usize = 2351;
 
     /// Return a [`RecordBatch`] containing three compressed segments.
     pub fn compressed_segments_record_batch() -> RecordBatch {
@@ -886,6 +886,7 @@ pub mod test_util {
         let min_value = ValueArray::from(min_values);
         let max_value = ValueArray::from(max_values);
         let values = BinaryArray::from_vec(vec![b"1111", b"1000", b"0000"]);
+        let residuals = BinaryArray::from_vec(vec![b"", b"", b""]);
         let error = Float32Array::from(vec![0.2, 0.5, 0.1]);
 
         let schema = COMPRESSED_SCHEMA.clone();
@@ -901,6 +902,7 @@ pub mod test_util {
                 Arc::new(min_value),
                 Arc::new(max_value),
                 Arc::new(values),
+                Arc::new(residuals),
                 Arc::new(error),
             ],
         )


### PR DESCRIPTION
This PR makes the compression store the values in short Gorilla segments as part of the previous segment if any exists. As each segment contains a significant amount of metadata can short segments require more storage than the uncompressed timestamps and values. Small scale experiments show that the changes in this PR reduce the amount of storage required from 2.6% to 10.5%. The amount of storage can be further reduced by not storing the first value in full for these residual values and instead computing the XOR to the last value represented by the model in the segment, however, this is not done in this PR as it will require some refactoring of `crates/modelardb_compression/src/models/gorilla.rs` and thus make the smaller changes in this PR harder to review.