### PR TITLE
Compute code coverage for all OSes

### DIFF
--- a/.github/workflows/cargo-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/cargo-build-lint-and-test-on-pr-and-push.yml
@@ -22,8 +22,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: -C instrument-coverage -D warnings
   RUSTDOCFLAGS: -D warnings
+  LLVM_PROFILE_FILE: modelardb-%p-%m.profraw
 
 jobs:
   cargo_build_lint_and_test:
@@ -36,10 +37,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Rustup Update
       run: rustup update
-    - name: Cargo Install
+    - name: Rustup Add llvm-tools
+      run: rustup component add llvm-tools-preview
+    - name: Cargo Install grcov
+      run: cargo install grcov
+    - name: Cargo Install machete
       run: cargo install cargo-machete
+
     - name: Cargo Build
       run: cargo build --verbose --all-targets
     - name: Cargo Clippy
@@ -50,3 +57,10 @@ jobs:
       run: cargo machete --with-metadata
     - name: Cargo Test
       run: cargo test --verbose --all-targets
+
+    - name: grcov --output-types html
+      run: grcov . --source-dir . --binary-path ./target/debug/ --output-types html --branch --ignore-not-existing -o ./target/debug/coverage/
+    - uses: actions/upload-artifact@v3
+      with:
+        name: Code Coverage ${{ matrix.operating-system }}
+        path: ./target/debug/coverage/


### PR DESCRIPTION
This PR uses GitHub Actions to compute code coverage for all crates in the repository using [LLVM's instrumentation-based coverage](https://doc.rust-lang.org/rustc/instrument-coverage.html) and then [grcov](https://github.com/mozilla/grcov) to produce a HTML report which is attached to the workflow run as an [artifact with a 90 days retention period](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts). A minor limitation of this approach is that the small number of Python unit test in repository is not included. GitHub does not seem to support [visualization code coverage like GitLab](https://docs.gitlab.com/ee/ci/testing/test_coverage_visualization.html), so it seems necessary to either [post comments with Markdown on PRs](https://github.com/marketplace/actions/code-coverage-summary), [host it on GitHub Pages](https://dev.to/mbarzeev/auto-publish-your-test-coverage-report-on-github-pages-35be), or [host it using a service like Codecov](https://about.codecov.io/for/open-source/) if the report needs to be more easily available in the future.