### PR TITLE
Add workspace packages and dev-release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,37 @@
 [workspace]
 members = ["crates/*"]
 
+[workspace.dependencies]
+arrow = "38.0.0"
+arrow-flight = "38.0.0"
+async-trait = "0.1.68"
+bytes = "1.4.0"
+datafusion = "24.0.0"
+dirs = "5.0.1"
+futures = "0.3.28"
+log = "0.4.17"
+object_store = "0.5.6"
+once_cell = "1.17.1"
+parquet = "38.0.0"
+proptest = "1.1.0"
+pyo3 = "0.18.3"
+pyo3-build-config = "0.18.3"
+rand = "0.8.5"
+ringbuf = "0.3.3"
+rusqlite = "0.29.0"
+rustyline = "11.0.0"
+serial_test = "2.0.0"
+snmalloc-rs = "0.3.3"
+sqlparser = "0.33.0"
+sysinfo = "0.28.4"
+tempfile = "3.5.0"
+tokio = "1.28.0"
+tokio-stream = "0.1.14"
+tonic = "0.9.2"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.17"
+uuid = "1.3.2"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,9 @@ uuid = "1.3.2"
 lto = true
 codegen-units = 1
 panic = "abort"
+
+[profile.dev-release]
+inherits = "release"
+lto = false
+codegen-units = 16
+panic = 'unwind'

--- a/crates/modelardb_client/Cargo.toml
+++ b/crates/modelardb_client/Cargo.toml
@@ -24,10 +24,10 @@ name = "modelardb"
 path = "src/main.rs"
 
 [dependencies]
-arrow = "38.0.0"
-arrow-flight = "38.0.0"
-bytes = "1.4.0"
-dirs = "5.0.1"
-rustyline = "11.0.0"
-tokio = "1.28.0"
-tonic = "0.9.2"
+arrow.workspace = true
+arrow-flight.workspace = true
+bytes.workspace = true
+dirs.workspace = true
+rustyline.workspace = true
+tokio.workspace = true
+tonic.workspace = true

--- a/crates/modelardb_common/Cargo.toml
+++ b/crates/modelardb_common/Cargo.toml
@@ -20,5 +20,5 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-arrow = "38.0.0"
-once_cell = "1.17.1"
+arrow.workspace = true
+once_cell.workspace = true

--- a/crates/modelardb_compression/Cargo.toml
+++ b/crates/modelardb_compression/Cargo.toml
@@ -20,9 +20,9 @@ edition = "2021"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]
-arrow = "38.0.0"
+arrow.workspace = true
 modelardb_common = { path = "../modelardb_common" }
 
 [dev-dependencies]
-proptest = "1.1.0"
-rand = "0.8.5"
+proptest.workspace = true
+rand.workspace = true

--- a/crates/modelardb_compression_python/Cargo.toml
+++ b/crates/modelardb_compression_python/Cargo.toml
@@ -24,13 +24,13 @@ name = "modelardb_compression_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow = { version = "38.0.0", features = ["ffi"] }
+arrow = { workspace = true, features = ["ffi"] }
 modelardb_common = { path = "../modelardb_common" }
 modelardb_compression = { path = "../modelardb_compression" }
-pyo3 = { version = "0.18.3", features = ["extension-module"] }
+pyo3 = { workspace = true, features = ["extension-module"] }
 
 [build-dependencies]
-pyo3-build-config = "0.18.3"
+pyo3-build-config.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["pyo3_build_config"]

--- a/crates/modelardb_server/Cargo.toml
+++ b/crates/modelardb_server/Cargo.toml
@@ -24,35 +24,35 @@ name = "modelardbd"
 path = "src/main.rs"
 
 [dependencies]
-arrow-flight = "38.0.0"
-async-trait = "0.1.68"
-bytes = "1.4.0"
-datafusion = "24.0.0"
-futures = "0.3.28"
+arrow-flight.workspace = true
+async-trait.workspace = true
+bytes.workspace = true
+datafusion.workspace = true
+futures.workspace = true
 modelardb_common = { path = "../modelardb_common" }
 modelardb_compression = { path = "../modelardb_compression" }
-object_store = { version = "0.5.6", features = ["aws", "azure"] }
-once_cell = "1.17.1"
-parquet = { version = "38.0.0", features = ["object_store"] }
-ringbuf = "0.3.3"
-rusqlite = { version = "0.29.0", features = ["bundled"] }
-snmalloc-rs = "0.3.3"
-sqlparser = "0.33.0"
-tokio = { version = "1.28.0", features = ["rt-multi-thread", "signal"] }
-tokio-stream = "0.1.14"
-tonic = "0.9.2"
-uuid = "1.3.2"
+object_store = { workspace = true, features = ["aws", "azure"] }
+once_cell.workspace = true
+parquet = { workspace = true, features = ["object_store"] }
+ringbuf.workspace = true
+rusqlite = { workspace = true, features = ["bundled"] }
+snmalloc-rs.workspace = true
+sqlparser.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
+tokio-stream.workspace = true
+tonic.workspace = true
+uuid.workspace = true
 
 # Log is a dependency so the compile time filters for log and tracing can be set to the same values.
-log = { version = "0.4.17", features = ["max_level_debug", "release_max_level_info"] }
-tracing = { version = "0.1.37", features = ["max_level_debug", "release_max_level_info"] }
-tracing-subscriber = "0.3.17"
+log = { workspace = true, features = ["max_level_debug", "release_max_level_info"] }
+tracing = { workspace = true, features = ["max_level_debug", "release_max_level_info"] }
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
-proptest = "1.1.0"
-serial_test = "2.0.0"
-sysinfo = "0.28.4"
-tempfile = "3.5.0"
+proptest.workspace = true
+serial_test.workspace = true
+sysinfo.workspace = true
+tempfile.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["log"]


### PR DESCRIPTION
Inspired by [Apache Arrow DataFusion](https://github.com/apache/arrow-datafusion/blob/main/Cargo.toml), this PR moves the [specification of the dependencies to the workspace](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table) to ensure each component uses the same versions and to make it simpler to update them. Features are still defined in the `Cargo.toml` file for each component as the features each component use sometimes differ. In addition, it adds [Cargo's default `release` profile ](https://doc.rust-lang.org/cargo/reference/profiles.html#release) as `dev-release`  as `release` is already used for [Apache Arrow DataFusion's optimized configuration](https://arrow.apache.org/datafusion/user-guide/example-usage.html#optimized-configuration) to ensure `cargo build --release` provides the best performance possible. As can be seen below a `dev-release` build is significantly faster to complete and should perform much closer to `release` than `debug`.

| Profile         | Build Time |
| ------------- | --------- |
| debug          |  1m 54s |
| dev-release  |  3m 39s  |
| release         | 10m 13s  |