### PR TITLE
Fix the operator metadata used for planning

### DIFF
--- a/crates/modelardb_server/src/query/generated_as_exec.rs
+++ b/crates/modelardb_server/src/query/generated_as_exec.rs
@@ -156,6 +156,11 @@ impl ExecutionPlan for GeneratedAsExec {
         }
     }
 
+    /// Specify that [`GeneratedAsExec`] never reorders the data it receives from its input.
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+
     /// Return a snapshot of the set of metrics being collected by the execution plain.
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())

--- a/crates/modelardb_server/src/query/generated_as_exec.rs
+++ b/crates/modelardb_server/src/query/generated_as_exec.rs
@@ -156,11 +156,6 @@ impl ExecutionPlan for GeneratedAsExec {
         }
     }
 
-    /// Specify that [`GeneratedAsExec`] never reorders the data it receives from its input.
-    fn maintains_input_order(&self) -> Vec<bool> {
-        vec![true]
-    }
-
     /// Return a snapshot of the set of metrics being collected by the execution plain.
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())

--- a/crates/modelardb_server/src/query/grid_exec.rs
+++ b/crates/modelardb_server/src/query/grid_exec.rs
@@ -177,11 +177,6 @@ impl ExecutionPlan for GridExec {
         vec![Some(physical_sort_requirements)]
     }
 
-    /// Specify that [`GridExec`] never reorders the data it receives from its input.
-    fn maintains_input_order(&self) -> Vec<bool> {
-        vec![true]
-    }
-
     /// Return a snapshot of the set of metrics being collected by the execution plain.
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())

--- a/crates/modelardb_server/src/query/grid_exec.rs
+++ b/crates/modelardb_server/src/query/grid_exec.rs
@@ -100,7 +100,7 @@ impl ExecutionPlan for GridExec {
     }
 
     /// Specify that the global order for the data points produced by all [`GridExec`] will be the
-    /// same. This is needed because [`SortedJoinExec`](crate::query::SortedJoinExec) assumes the
+    /// same. This is needed because [`crate::query::sorted_join_exec::SortedJoinExec`] assumes the
     /// data it receives from all of its inputs uses the same global sort order.
     fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
         Some(&QUERY_ORDER_DATA_POINT)

--- a/crates/modelardb_server/src/query/mod.rs
+++ b/crates/modelardb_server/src/query/mod.rs
@@ -77,7 +77,7 @@ pub static QUERY_ORDER_SEGMENT: Lazy<Vec<PhysicalSortExpr>> = Lazy::new(|| {
             options: sort_options,
         },
         PhysicalSortExpr {
-            expr: Arc::new(Column::new("start_time", 1)),
+            expr: Arc::new(Column::new("start_time", 2)),
             options: sort_options,
         },
     ]

--- a/crates/modelardb_server/src/query/mod.rs
+++ b/crates/modelardb_server/src/query/mod.rs
@@ -62,9 +62,9 @@ use crate::Context;
 /// [`GridExec`] requires for the segments its receives as its input. It is guaranteed by
 /// [`ParquetExec`] because the storage engine uses this sort order for each Apache Parquet file and
 /// these files are read sequentially by [`ParquetExec`]. Another sort order could also be used, the
-/// current query pipeline simply requires that the [`RecordBatches`](RecordBatch)
-/// [`SortedJoinExec`] receive from its inputs all contain data points for the same time interval
-/// and that they are sorted the same.
+/// current query pipeline simply requires that the
+/// [`RecordBatches`](datafusion::arrow::record_batch::RecordBatch) [`SortedJoinExec`] receive from
+/// its inputs all contain data points for the same time interval and that they are sorted the same.
 pub static QUERY_ORDER_SEGMENT: Lazy<Vec<PhysicalSortExpr>> = Lazy::new(|| {
     let sort_options = SortOptions {
         descending: false,
@@ -88,8 +88,8 @@ pub static QUERY_ORDER_SEGMENT: Lazy<Vec<PhysicalSortExpr>> = Lazy::new(|| {
 /// [`GridExec`] because it receives segments sorted by [`QUERY_ORDER_SEGMENT`] from [`ParquetExec`]
 /// and because these segments cannot contain data points for overlapping time intervals. Another
 /// sort order could also be used, the current query pipeline simply requires that the
-/// [`RecordBatches`](RecordBatch) [`SortedJoinExec`] receive from its inputs all contain data
-/// points for the same time interval and that they are sorted the same.
+/// [`RecordBatches`](datafusion::arrow::record_batch::RecordBatch) [`SortedJoinExec`] receive from
+/// its inputs all contain data points for the same time interval and that they are sorted the same.
 pub static QUERY_ORDER_DATA_POINT: Lazy<Vec<PhysicalSortExpr>> = Lazy::new(|| {
     let sort_options = SortOptions {
         descending: false,

--- a/crates/modelardb_server/src/query/mod.rs
+++ b/crates/modelardb_server/src/query/mod.rs
@@ -84,7 +84,7 @@ pub static QUERY_ORDER_SEGMENT: Lazy<Vec<PhysicalSortExpr>> = Lazy::new(|| {
 });
 
 /// The global sort order [`GridExec`] guarantees for the data points it produces and that
-/// [`SortedJoinExec`] requires for the data points its receives as its input. It is guaranteed by
+/// [`SortedJoinExec`] requires for the data points it receives as its input. It is guaranteed by
 /// [`GridExec`] because it receives segments sorted by [`QUERY_ORDER_SEGMENT`] from [`ParquetExec`]
 /// and because these segments cannot contain data points for overlapping time intervals. Another
 /// sort order could also be used, the current query pipeline simply requires that the

--- a/crates/modelardb_server/src/query/sorted_join_exec.rs
+++ b/crates/modelardb_server/src/query/sorted_join_exec.rs
@@ -106,7 +106,8 @@ impl ExecutionPlan for SortedJoinExec {
     }
 
     /// Specify that the record batches produced by the execution plan will have an unknown order as
-    /// the output from [`SortedJoinExec`] does not include the `univariate_id` but instead tags.
+    /// the output from [`crate::query::sorted_join_exec::SortedJoinExec`] does not include the
+    /// `univariate_id` but instead tags.
     fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
         None
     }

--- a/crates/modelardb_server/src/query/sorted_join_exec.rs
+++ b/crates/modelardb_server/src/query/sorted_join_exec.rs
@@ -171,7 +171,7 @@ impl ExecutionPlan for SortedJoinExec {
     }
 
     /// Specify that [`SortedJoinStream`] requires one partition for each input as it assumes that
-    /// the global sort order are the same for all inputs and Apache Arrow DataFusion only
+    /// the global sort order is the same for all inputs and Apache Arrow DataFusion only
     /// guarantees the sort order within each partition rather than the inputs' global sort order.
     fn required_input_distribution(&self) -> Vec<Distribution> {
         vec![Distribution::SinglePartition; self.inputs.len()]

--- a/crates/modelardb_server/src/query/sorted_join_exec.rs
+++ b/crates/modelardb_server/src/query/sorted_join_exec.rs
@@ -185,11 +185,6 @@ impl ExecutionPlan for SortedJoinExec {
         vec![Some(physical_sort_requirements); self.inputs.len()]
     }
 
-    /// Specify that [`SortedJoinStream`] never reorders the data it receives from its input.
-     fn maintains_input_order(&self) -> Vec<bool> {
-        vec![true; self.inputs.len()]
-    }
-
     /// Return a snapshot of the set of metrics being collected by the execution plain.
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -570,12 +570,13 @@ fn test_can_ingest_multiple_time_series_with_different_tags() {
 
     test_context.flush_data_to_disk();
 
+    // The result set is implicitly ordered by the value of the tags when hashed and then time.
     let query = test_context
-        .execute_query(format!("SELECT * FROM {TABLE_NAME} ORDER BY timestamp"))
+        .execute_query(format!("SELECT * FROM {TABLE_NAME} ORDER BY tag, timestamp"))
         .unwrap();
 
-    let combined = compute::concat_batches(&data_points[0].schema(), &data_points).unwrap();
-    assert_eq!(combined, query[0]);
+    let expected = compute::concat_batches(&data_points[0].schema(), &data_points).unwrap();
+    assert_eq!(expected, query[0]);
 }
 
 #[test]

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -570,9 +570,8 @@ fn test_can_ingest_multiple_time_series_with_different_tags() {
 
     test_context.flush_data_to_disk();
 
-    // The result set is implicitly ordered by the value of the tags when hashed and then time.
     let query = test_context
-        .execute_query(format!("SELECT * FROM {TABLE_NAME} ORDER BY tag, timestamp"))
+        .execute_query(format!("SELECT * FROM {TABLE_NAME} ORDER BY timestamp"))
         .unwrap();
 
     let expected = compute::concat_batches(&data_points[0].schema(), &data_points).unwrap();


### PR DESCRIPTION
As Apache Arrow DataFusion's optimizer rules has been re-enabled by #101, this PR updates the metadata returned by each  [`ExecutionPlan`](https://docs.rs/datafusion/latest/datafusion/physical_plan/trait.ExecutionPlan.html) added to Apache Arrow DataFusion in `modelardbd`. This is to ensure Apache Arrow DataFusion's optimizer knows which optimizations are possible, and more importantly, safe. For example, n * [`ParquetExec` -> `GridExec` -> `PartitionExec`] -> `SortedJoinExec` is not safe as far as I can tell since the documentation for [`ExecutionPlan::required_input_ordering()`](https://docs.rs/datafusion/latest/datafusion/physical_plan/trait.ExecutionPlan.html#method.required_input_ordering) states that it _"Specifies the ordering requirements for all of the children. For each child, it’s the local ordering requirement within each partition rather than the global ordering"_ and the documentation for [`FileScanConfig::file_groups`](https://docs.rs/datafusion/latest/datafusion/physical_plan/file_format/struct.FileScanConfig.html#structfield.file_groups) (`FileScanConfig` is used to configure [`ParquetExec`](https://docs.rs/datafusion/latest/datafusion/physical_plan/file_format/struct.ParquetExec.html)) states that _"Apache Arrow DataFusion may attempt to read each partition of files concurrently, however files within a partition will be read sequentially, one after the next."_ so it does not seem possible to use multiple partitions while also ensuring that the batches of data points received by `SortedJoinExec` all has the same sort order.