### PR TITLE
Improve runtime errors for generated columns

### DIFF
--- a/crates/modelardb_server/src/query/generated_as_exec.rs
+++ b/crates/modelardb_server/src/query/generated_as_exec.rs
@@ -23,8 +23,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context as StdTaskContext, Poll};
 
+use datafusion::arrow::array::StringArray;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::temporal_conversions;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::expressions::PhysicalSortExpr;
@@ -35,6 +37,7 @@ use datafusion::physical_plan::{
 };
 use futures::stream::Stream;
 use futures::StreamExt;
+use modelardb_common::types::{TimestampArray, ValueArray};
 
 ///  A column the [`GeneratedAsExec`] must add to each of the [`RecordBatches`](RecordBatch) using
 /// [`GeneratedAsStream`] with the location it must be at and the [`PhysicalExpr`] that compute it.
@@ -195,6 +198,48 @@ impl GeneratedAsStream {
             baseline_metrics,
         }
     }
+
+    /// Format and return the first row in `batch` that causes `physical_expr` to fail, if
+    /// `physical_expr` never fails or if `batch` is from a normal table, [`None`] is returned.
+    fn failing_row(batch: &RecordBatch, physical_expr: &Arc<dyn PhysicalExpr>) -> Option<String> {
+        for row_index in 0..batch.num_rows() {
+            if physical_expr.evaluate(&batch.slice(row_index, 1)).is_err() {
+                let schema = batch.schema();
+                let mut formatted_values = Vec::with_capacity(batch.num_columns());
+
+                for column_index in 0..batch.num_columns() {
+                    let name = schema.field(column_index).name();
+                    let column = batch.column(column_index);
+
+                    if let Some(timestamps) = column.as_any().downcast_ref::<TimestampArray>() {
+                        // Store a readable version of timestamp if it is in the time interval that
+                        // can be represented by a NaiveDateTime, otherwise the integer is stored.
+                        let timestamp = timestamps.value(row_index);
+                        let formated_value = if let Some(naive_date_time) =
+                            temporal_conversions::timestamp_ms_to_datetime(timestamp)
+                        {
+                            format!("{name}: {}", naive_date_time)
+                        } else {
+                            format!("{name}: {}", timestamp)
+                        };
+                        formatted_values.push(formated_value);
+                    } else if let Some(fields) = column.as_any().downcast_ref::<ValueArray>() {
+                        formatted_values.push(format!("{name}: {}", fields.value(row_index)));
+                    } else if let Some(tags) = column.as_any().downcast_ref::<StringArray>() {
+                        formatted_values.push(format!("{name}: {}", tags.value(row_index)));
+                    } else {
+                        // The method has been called for a table with unsupported column types.
+                        return None;
+                    }
+                }
+
+                return Some(formatted_values.join(", "));
+            }
+        }
+
+        // physical_expr never failed for any of the rows in batch.
+        None
+    }
 }
 
 impl Stream for GeneratedAsStream {
@@ -227,8 +272,17 @@ impl Stream for GeneratedAsStream {
                         columns.push(generated_column.into_array(batch.num_rows()));
                         generated_columns += 1;
                     } else {
+                        let column_name = self.schema.field(column_to_generate.index).name();
+
                         // unwrap() is safe as it is only executed if a column was not generated.
-                        return Poll::Ready(Some(Err(maybe_generated_column.err().unwrap())));
+                        let physical_expr = &column_to_generate.physical_expr;
+                        let failing_row = Self::failing_row(&batch, physical_expr).unwrap();
+                        let cause = maybe_generated_column.err().unwrap();
+
+                        let error = format!(
+                            "Failed to create '{column_name}' for {{{failing_row}}} due to: {cause}"
+                        );
+                        return Poll::Ready(Some(Err(DataFusionError::Execution(error))));
                     };
                 }
 


### PR DESCRIPTION
This PR adds the column name and row to the error message that are returned if the values for a generated column cannot be generated, e.g., if the [PhysicalExpr](https://docs.rs/datafusion-physical-expr/latest/datafusion_physical_expr/trait.PhysicalExpr.html) divides by zero. Unfortunately, as far as I can tell, it is not possible to extract which row caused the error from [PhysicalExpr](https://docs.rs/datafusion-physical-expr/latest/datafusion_physical_expr/trait.PhysicalExpr.html), [DataFusionError](https://docs.rs/datafusion/latest/datafusion/error/enum.DataFusionError.html), or [ArrowError](https://docs.rs/arrow-schema/38.0.0/arrow_schema/enum.ArrowError.html). So the method `GeneratedAsStream::failing_row()` has been added which tries to evaluate the failed [PhysicalExpr](https://docs.rs/datafusion-physical-expr/latest/datafusion_physical_expr/trait.PhysicalExpr.html) for each row in the [`RecordBatch`](https://docs.rs/arrow/latest/arrow/record_batch/struct.RecordBatch.html). Since [`RecordBatch::slice()`](https://docs.rs/arrow/latest/arrow/record_batch/struct.RecordBatch.html#method.slice) simply increments atomic reference counts (the documentation states that [`Array::slice()`](https://github.com/apache/arrow-rs/blob/master/arrow-array/src/array/mod.rs#L131) is always zero-copy) and only allocates a single short [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html), the method is fast enough to execute in the case of a rare error that terminates the query. A small scale performance test with a table producing 304 [`RecordBatches`](https://docs.rs/arrow/latest/arrow/record_batch/struct.RecordBatch.html) containing 8912 rows each, showed that the method executed in 8ms - 10ms for 276 of the [`RecordBatches`](https://docs.rs/arrow/latest/arrow/record_batch/struct.RecordBatch.html) and 10ms - 20ms for 28 of the [`RecordBatches`](https://docs.rs/arrow/latest/arrow/record_batch/struct.RecordBatch.html) on a virtual machine with 8 vCPU and 16 GiB of memory. [`chrono`](https://crates.io/crates/chrono/0.4.24) is used for formatting the timestamps if possible as it is already a dependency of [`Apache Arrow DataFusion`](https://crates.io/crates/datafusion/24.0.0/dependencies) and is also used in the [Rust implementation of Apache Arrow to format timestamps](https://github.com/apache/arrow-rs/blob/master/arrow-cast/src/display.rs#L451).
