### PR TITLE
Increase the size of gRPC messages supported

### DIFF
--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -77,7 +77,11 @@ pub fn start_apache_arrow_flight_server(
         context,
         dictionaries_by_id: HashMap::new(),
     };
-    let flight_service_server = FlightServiceServer::new(handler);
+
+    // Increase the maximum message size from 4 MiB to 16 MiB to allow bulk-loading larger batches.
+    let flight_service_server =
+        FlightServiceServer::new(handler).max_decoding_message_size(16777216);
+
     info!("Starting Apache Arrow Flight on {}.", localhost_with_port);
     runtime
         .block_on(async {


### PR DESCRIPTION
This PR increases the size of gRPC messages that `modelardbd` accepts to from 4 MiB to 16 MiB (chosen because [Apache Arrow Ballista used it](https://github.com/apache/arrow-ballista/commit/10e021a9a3fcdc1a5c07c89737f3c2bb33cc1b7d)). This is simplifies use of the Python scripts in [ModelarData/Utilities](https://github.com/ModelarData/Utilities) as `pyarrow` does not seem to limit the message size by default and setting [`pyarrow.flight.FlightClient.write_size_limit_bytes`](https://arrow.apache.org/docs/python/generated/pyarrow.flight.FlightClient.html) to 4 MiB to match the default value of [`max_decoding_message_size`](https://docs.rs/arrow-flight/latest/arrow_flight/flight_service_server/struct.FlightServiceServer.html#method.max_decoding_message_size) in [`arrow_flight::flight_service_server::FlightServiceServer`](https://docs.rs/arrow-flight/latest/arrow_flight/flight_service_server/struct.FlightServiceServer.html) simply causes `pyarrow` to raise the following exception `pyarrow._flight.FlightWriteSizeExceededError: IPC payload size exceeded soft limit`.