### PR TITLE
AS must be followed by (expr) to match RDBMSs

### DIFF
--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -146,8 +146,7 @@ impl TestContext {
             TableType::ModelTableAsField => {
                 format!(
                     "CREATE MODEL TABLE {table_name}(timestamp TIMESTAMP,
-                 generated FIELD AS CAST(COS(CAST(value AS DOUBLE) * PI() / 180.0) AS REAL),
-                 value FIELD(0.0))"
+                 generated FIELD AS (value + CAST(37.0 AS REAL)), value FIELD(0.0))"
                 )
             }
         };


### PR DESCRIPTION
This PR adds the requirement that the expression used to generate a column must be surrounded by parentheses to more closely match RDBMs like [MySQL](https://dev.mysql.com/doc/refman/8.0/en/create-table-generated-columns.html) and [PostgreSQL](https://www.postgresql.org/docs/current/ddl-generated-columns.html).