### PR TITLE
Replace CMake with cc and update docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,6 +2940,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80756c9f5dacaa9ff49afddb77ea18e80013228128ced3c2162f13306a225dd7"
 dependencies = [
+ "cc",
  "cmake",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-RUN apt-get update && apt-get -y install cmake
-
 RUN cargo build --release
 
 CMD ["target/release/modelardbd", "edge", "data", "s3://modelardata"]

--- a/README.md
+++ b/README.md
@@ -4,45 +4,45 @@
 [![Cargo Build, Lint, and Test](https://github.com/ModelarData/ModelarDB-RS/actions/workflows/cargo-build-lint-and-test-on-pr-and-push.yml/badge.svg)](https://github.com/ModelarData/ModelarDB-RS/actions/workflows/cargo-build-lint-and-test-on-pr-and-push.yml)
 [![Python unittest](https://github.com/ModelarData/ModelarDB-RS/actions/workflows/python-unittest-on-pr-and-push.yml/badge.svg)](https://github.com/ModelarData/ModelarDB-RS/actions/workflows/python-unittest-on-pr-and-push.yml)
 
-ModelarDB is an efficient high-performance time series management system that is designed to efficiently ingest, 
-transfer, store, and analyze high-frequency time series across the edge and cloud. It provides state-of-the-art 
-lossless compression, lossy compression, and query performance by efficiently compressing time series on the edge 
-using multiple different types of models such as constant and linear functions. As a result, the high-frequency time 
-series can be transferred to the cloud through a connection with very limited bandwidth and stored in the cloud at 
-a low cost. The compressed time series can be efficiently queried on both the edge and in the cloud using a relational 
-interface and SQL without any knowledge about the model-based representation. A query optimizer automatically rewrites 
+ModelarDB is an efficient high-performance time series management system that is designed to efficiently ingest,
+transfer, store, and analyze high-frequency time series across the edge and cloud. It provides state-of-the-art
+lossless compression, lossy compression, and query performance by efficiently compressing time series on the edge
+using multiple different types of models such as constant and linear functions. As a result, the high-frequency time
+series can be transferred to the cloud through a connection with very limited bandwidth and stored in the cloud at
+a low cost. The compressed time series can be efficiently queried on both the edge and in the cloud using a relational
+interface and SQL without any knowledge about the model-based representation. A query optimizer automatically rewrites
 the queries to exploit the model-based representation.
 
-ModelarDB is designed to be cross-platform and is currently automatically tested on Microsoft Windows, macOS, and Ubuntu 
-through [GitHub Actions](https://github.com/ModelarData/ModelarDB-RS/actions). It is also known to work on FreeBSD which 
-is [currently not supported by GitHub Actions](https://github.com/actions/runner/issues/385). It is implemented in 
-[Rust](https://www.rust-lang.org/) and uses [Apache Arrow Flight](https://github.com/apache/arrow-rs/tree/master/arrow-flight) 
-for communicating with clients, [Apache Arrow DataFusion](https://github.com/apache/arrow-datafusion) as its query 
-engine, [Apache Arrow](https://github.com/apache/arrow-rs) as its in-memory data format, and 
+ModelarDB is designed to be cross-platform and is currently automatically tested on Microsoft Windows, macOS, and Ubuntu
+through [GitHub Actions](https://github.com/ModelarData/ModelarDB-RS/actions). It is also known to work on FreeBSD which
+is [currently not supported by GitHub Actions](https://github.com/actions/runner/issues/385). It is implemented in
+[Rust](https://www.rust-lang.org/) and uses [Apache Arrow Flight](https://github.com/apache/arrow-rs/tree/master/arrow-flight)
+for communicating with clients, [Apache Arrow DataFusion](https://github.com/apache/arrow-datafusion) as its query
+engine, [Apache Arrow](https://github.com/apache/arrow-rs) as its in-memory data format, and
 [Apache Parquet](https://github.com/apache/arrow-rs/tree/master/parquet) as its on-disk data format.
 
 ModelarDB intentionally does not gather usage data. So, all users are highly encouraged to post comments, suggestions,
 and bugs as GitHub issues, especially if a limitation of ModelarDB prevents it from being used in a particular domain.
 
 ## Installation
-Refer to the [Installation](docs/user/README.md#installation) section of the [User](docs/user/README.md) documentation 
-for installation instructions on setting up ModelarDB on four major operating systems. To easily experiment with 
-ModelarDB, instructions for setting up a [Docker](https://docs.docker.com/) environment are included in the 
+Refer to the [Installation](docs/user/README.md#installation) section of the [User](docs/user/README.md) documentation
+for installation instructions on setting up ModelarDB on four major operating systems. To easily experiment with
+ModelarDB, instructions for setting up a [Docker](https://docs.docker.com/) environment are included in the
 [Docker](docs/user/README.md#docker) section.
 
 ## Usage
-Usage instructions for running a server, ingesting data, and querying data using ModelarDB are included in the 
+Usage instructions for running a server, ingesting data, and querying data using ModelarDB are included in the
 [Usage](docs/user/README.md#usage) section of the [User](docs/user/README.md) documentation.
 
 ## Development
-Refer to the [Development](docs/dev/README.md) section of the documentation for an overview of the structure of the 
-project, a detailed description of each major component, and an outline of the guidelines that should be adhered 
+Refer to the [Development](docs/dev/README.md) section of the documentation for an overview of the structure of the
+project, a detailed description of each major component, and an outline of the guidelines that should be adhered
 to when contributing to the project.
 
 ## Research-Based
-A deprecated JVM-based prototype of ModelarDB was developed as part of a [research project](https://github.com/skejserjensen/ModelarDB) 
-at Aalborg University and later as an [open-source project](https://github.com/ModelarData/ModelarDB). While the 
-deprecated JVM-based prototype validated the benefits of using a model-based representation for time series, it 
+A deprecated JVM-based prototype of ModelarDB was developed as part of a [research project](https://github.com/skejserjensen/ModelarDB)
+at Aalborg University and later as an [open-source project](https://github.com/ModelarData/ModelarDB). While the
+deprecated JVM-based prototype validated the benefits of using a model-based representation for time series, it
 has been superseded by this current, much more efficient, Rust-based implementation.
 
 ## License

--- a/crates/modelardb_server/Cargo.toml
+++ b/crates/modelardb_server/Cargo.toml
@@ -35,7 +35,7 @@ object_store = { workspace = true, features = ["aws", "azure"] }
 once_cell.workspace = true
 parquet = { workspace = true, features = ["object_store"] }
 ringbuf.workspace = true
-snmalloc-rs.workspace = true
+snmalloc-rs = { workspace = true, features = ["build_cc"] }
 sqlparser.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -8,33 +8,27 @@ setting up a Docker environment are also provided. Once installed, using Modelar
 The following commands are for Ubuntu Server. However, equivalent commands should work for other Linux distributions.
 
 1. Install [build-essential](https://packages.ubuntu.com/jammy/build-essential): `sudo apt install build-essential`
-2. Install [CMake](https://cmake.org/): `sudo apt install cmake`
 
 ### macOS
 1. Install the Xcode Command Line Developer Tools: `xcode-select --install`
-2. Install [CMake](https://cmake.org/) and follow the _"How to Install For Command Line Use"_ menu item.
 
 ### FreeBSD
-1. Install [CMake](https://cmake.org/) as the *root* user: `pkg install cmake`
-2. Install [cURL](https://curl.se/) as the *root* user: `pkg install curl`
+1. Install [cURL](https://curl.se/) as the *root* user: `pkg install curl`
 
 ### Windows
 1. Install a supported version of [Visual Studio](https://visualstudio.microsoft.com/vs/older-downloads/) with Visual C++:
    - [Visual Studio 2019](https://visualstudio.microsoft.com/vs/older-downloads/#visual-studio-2019-and-other-products) ([Supported](https://github.com/microsoft/snmalloc/blob/main/docs/BUILDING.md#building-on-windows))
    - [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) ([Supported](https://github.com/microsoft/snmalloc/blob/main/docs/BUILDING.md#building-on-windows))
-2. Install [CMake](https://cmake.org/) and select one of the following options during installation:
-   - _Add CMake to the system PATH for all users_
-   - _Add CMake to the system PATH for current user_
 
 ### All
-3. Install the latest stable [Rust Toolchain](https://rustup.rs/).
-4. Build, test, and run the system using Cargo:
+2. Install the latest stable [Rust Toolchain](https://rustup.rs/).
+3. Build, test, and run the system using Cargo:
    - Debug Build: `cargo build`
    - Release Build: `cargo build --release`
    - Run Tests: `cargo test`
    - Run Server: `cargo run --bin modelardbd path_to_local_data_folder`
    - Run Client: `cargo run --bin modelardb [server_address] [query_file]`
-5. Move `modelardbd` and `modelardb` from the `target` directory to any directory.
+4. Move `modelardbd`, `modelardbm`, and `modelardb` from the `target` directory to any directory.
 
 ## Usage
 `modelardbd` supports two execution modes, *edge* and *cloud*. For storage, `modelardbd` uses local storage and an


### PR DESCRIPTION
This PR replaces CMake with the `cc` crate, thus CMake is no longer needed to build the system. The documentation has also been updated to reflect this. As the GitHub Action Runners all include CMake, the changes has been manually tested on FreeBSD, Linux, macOS, and Microsoft Windows systems without CMake.