### PR TITLE
Support storing metadata for files in database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3063,6 +3063,7 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
+ "uuid",
  "webpki-roots",
  "whoami",
 ]

--- a/crates/modelardb_server/Cargo.toml
+++ b/crates/modelardb_server/Cargo.toml
@@ -37,7 +37,7 @@ parquet = { workspace = true, features = ["object_store"] }
 ringbuf.workspace = true
 snmalloc-rs = { workspace = true, features = ["build_cc"] }
 sqlparser.workspace = true
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }
+sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite", "uuid"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 tokio-stream.workspace = true
 tonic.workspace = true

--- a/crates/modelardb_server/src/metadata/mod.rs
+++ b/crates/modelardb_server/src/metadata/mod.rs
@@ -39,12 +39,13 @@ use datafusion::arrow::{error::ArrowError, ipc::writer::IpcWriteOptions};
 use datafusion::common::{DFSchema, ToDFSchema};
 use datafusion::execution::options::ParquetReadOptions;
 use futures::TryStreamExt;
+use log::LevelFilter;
 use modelardb_common::errors::ModelarDbError;
 use modelardb_common::types::UnivariateId;
 use modelardb_compression::ErrorBound;
 use sqlx::error::Error;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteRow};
-use sqlx::{Executor, Result, Row, SqlitePool};
+use sqlx::{ConnectOptions, Executor, Result, Row, SqlitePool};
 use tracing::{error, info, warn};
 
 use crate::metadata::model_table_metadata::ModelTableMetadata;
@@ -88,9 +89,11 @@ impl MetadataManager {
         }
 
         // Specify the metadata database's path and that it should be created if it does not exist.
-        let options = SqliteConnectOptions::new()
+        let mut options = SqliteConnectOptions::new()
             .filename(local_data_folder.join(METADATA_DATABASE_NAME))
             .create_if_missing(true);
+ 
+        options.log_statements(LevelFilter::Debug);
 
         // Create the metadata manager with the default values.
         let metadata_manager = Self {


### PR DESCRIPTION
This PR adds support for storing metadata about the Apache Parquet files that the storage engine creates for storing the compressed segments. By storing the metadata in the metadata database instead of in the file names, multiple file operations can be performed atomically as the files are first accessible when their metadata has been written to the metadata database. To significantly simplify retrieving files based on their time and value range, the special floating-point values are rewritten to their closets normal floating value by `rewrite_special_value_to_normal_value(value: Value)` before they are stored in the metadata database. While this reduces the metadata managers ability to prune away files slightly, e..g, `NaN` and `f32::MAX` becomes the same value, it seems to be uncommon for sensors that monitor physical entities to report values near `f32::MIN` or `f32::MAX` and [`ParquetExec`](https://docs.rs/datafusion/26.0.0/datafusion/physical_plan/file_format/struct.ParquetExec.html) prunes irrelevant data in each  file if it is passed a `predicate`. Thus, in practice, rewriting the special values to normal values should significantly simplify retrieving information about the the relevant files from the metadata database as simple SQL range queries can be used and the reduction in pruning power should only very rarely have an effect.