### PR TITLE
Update the installation guide for Windows

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -16,7 +16,7 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
 1. Install [cURL](https://curl.se/) as the *root* user: `pkg install curl`
 
 ### Windows
-1. Install the Microsoft Visual C++ Prerequisites for Rust and Python 3:
+1. Install the latest versions of the Microsoft Visual C++ Prerequisites for Rust and Python 3:
    - Microsoft Visual C++ Prerequisites for Rust: see [The rustup book](https://rust-lang.github.io/rustup/installation/windows-msvc.html).
    - Python 3: install [Python 3](https://www.python.org/) and select _"Add python.exe to PATH"_.
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -16,9 +16,9 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
 1. Install [cURL](https://curl.se/) as the *root* user: `pkg install curl`
 
 ### Windows
-1. Install a supported version of [Visual Studio](https://visualstudio.microsoft.com/vs/older-downloads/) with Visual C++:
-   - [Visual Studio 2019](https://visualstudio.microsoft.com/vs/older-downloads/#visual-studio-2019-and-other-products) ([Supported](https://github.com/microsoft/snmalloc/blob/main/docs/BUILDING.md#building-on-windows))
-   - [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) ([Supported](https://github.com/microsoft/snmalloc/blob/main/docs/BUILDING.md#building-on-windows))
+1. Install the Microsoft Visual C++ Prerequisites for Rust and Python 3:
+   - Microsoft Visual C++ Prerequisites for Rust: see [The rustup book](https://rust-lang.github.io/rustup/installation/windows-msvc.html).
+   - Python 3: install [Python 3](https://www.python.org/) and select _"Add python.exe to PATH"_.
 
 ### All
 2. Install the latest stable [Rust Toolchain](https://rustup.rs/).


### PR DESCRIPTION
This PR updates the installation instructions to make it clear that Microsoft Visual C++ (MSVC) and Python 3 is required to build all of the crates in the project on Microsoft Windows. Since the MSVC components the `rustup` book states should be installed before the MSVC-based Rust toolchain can be used on Microsoft Windows are sufficient to compile all creates in the proejct, our simple installation instructions have been replaced with a link to the much more detailed instructions in the `rustup` book.