### PR TITLE
Server configuration component

### DIFF
--- a/crates/modelardb_common/src/errors.rs
+++ b/crates/modelardb_common/src/errors.rs
@@ -29,7 +29,8 @@ use std::fmt::{Display, Formatter};
 pub enum ModelarDbError {
     /// Error returned by the model types.
     CompressionError(String),
-    /// Error returned when failing to create a new instance of a struct.
+    /// Error returned when failing to create a new instance of a struct or when updating a struct
+    /// field with an invalid value.
     ConfigurationError(String),
     /// Error returned when failing to retrieve data from the storage engine.
     DataRetrievalError(String),

--- a/crates/modelardb_common/src/schemas.rs
+++ b/crates/modelardb_common/src/schemas.rs
@@ -22,7 +22,7 @@ use once_cell::sync::Lazy;
 
 use crate::types::{
     ArrowTimestamp, ArrowUnivariateId, ArrowValue, CompressedSchema, MetricSchema, QuerySchema,
-    UncompressedSchema,
+    UncompressedSchema, ConfigurationSchema
 };
 
 /// [`RecordBatch`](arrow::record_batch::RecordBatch) [`Schema`](arrow::datatypes::Schema) used for
@@ -92,5 +92,14 @@ pub static QUERY_SCHEMA: Lazy<QuerySchema> = Lazy::new(|| {
         Field::new("univariate_id", ArrowUnivariateId::DATA_TYPE, false),
         Field::new("timestamp", ArrowTimestamp::DATA_TYPE, false),
         Field::new("value", ArrowValue::DATA_TYPE, false),
+    ])))
+});
+
+/// [`RecordBatch`](arrow::record_batch::RecordBatch) [`Schema`](arrow::datatypes::Schema) used for
+/// the configuration.
+pub static CONFIGURATION_SCHEMA: Lazy<ConfigurationSchema> = Lazy::new(|| {
+    ConfigurationSchema(Arc::new(Schema::new(vec![
+        Field::new("setting", DataType::Utf8, false),
+        Field::new("value", DataType::UInt64, false),
     ])))
 });

--- a/crates/modelardb_common/src/types.rs
+++ b/crates/modelardb_common/src/types.rs
@@ -54,3 +54,6 @@ pub struct MetricSchema(pub arrow::datatypes::SchemaRef);
 
 #[derive(Clone)]
 pub struct QuerySchema(pub arrow::datatypes::SchemaRef);
+
+#[derive(Clone)]
+pub struct ConfigurationSchema(pub arrow::datatypes::SchemaRef);

--- a/crates/modelardb_server/src/common_test.rs
+++ b/crates/modelardb_server/src/common_test.rs
@@ -49,7 +49,7 @@ pub const COMPRESSED_SEGMENTS_SIZE: usize = 1399;
 /// and the data folder set to `path`.
 pub async fn test_context(path: &Path) -> Arc<Context> {
     let metadata_manager = MetadataManager::try_new(path).await.unwrap();
-    let configuration_manager = ConfigurationManager::new(ServerMode::Edge);
+    let configuration_manager = Arc::new(RwLock::new(ConfigurationManager::new(ServerMode::Edge)));
 
     let session = test_session_context();
     let object_store_url = storage::QUERY_DATA_FOLDER_SCHEME_WITH_HOST

--- a/crates/modelardb_server/src/common_test.rs
+++ b/crates/modelardb_server/src/common_test.rs
@@ -71,7 +71,7 @@ pub async fn test_context(path: &Path) -> Arc<Context> {
         StorageEngine::try_new(
             path.to_owned(),
             None,
-            configuration_manager.clone(),
+            &configuration_manager,
             metadata_manager.clone(),
             true,
         )

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -35,7 +35,7 @@ impl ConfigurationManager {
         Self {
             server_mode,
             uncompressed_reserved_memory_in_bytes: 512 * 1024 * 1024, // 512 MiB
-            compressed_reserved_memory_in_bytes: 512 * 1024 * 1024, // 512 MiB
+            compressed_reserved_memory_in_bytes: 512 * 1024 * 1024,   // 512 MiB
         }
     }
 
@@ -47,10 +47,16 @@ impl ConfigurationManager {
         &self.uncompressed_reserved_memory_in_bytes
     }
 
+    // TODO: The remaining memory in the storage engine needs to be updated when updating these.
+    // TODO: Check if other places need to be updated.
+
     /// TODO: If the system currently uses less than `new_uncompressed_reserved_memory_in_bytes` bytes
     ///       for uncompressed memory, set the new value and return [`Ok`], otherwise return
     ///       [`ConfigurationError`](ModelarDbError::ConfigurationError).
-    fn set_uncompressed_reserved_memory_in_bytes(&mut self, new_uncompressed_reserved_memory_in_bytes: usize) -> Result<(), ModelarDbError> {
+    fn set_uncompressed_reserved_memory_in_bytes(
+        &mut self,
+        new_uncompressed_reserved_memory_in_bytes: usize,
+    ) -> Result<(), ModelarDbError> {
         self.uncompressed_reserved_memory_in_bytes = new_uncompressed_reserved_memory_in_bytes;
         Ok(())
     }
@@ -62,7 +68,10 @@ impl ConfigurationManager {
     /// TODO: If the system currently uses less than `new_compressed_reserved_memory_in_bytes` bytes
     ///       for compressed memory, set the new value and return [`Ok`], otherwise return
     ///       [`ConfigurationError`](ModelarDbError::ConfigurationError).
-    fn set_compressed_reserved_memory_in_bytes(&mut self, new_compressed_reserved_memory_in_bytes: usize) -> Result<(), ModelarDbError> {
+    fn set_compressed_reserved_memory_in_bytes(
+        &mut self,
+        new_compressed_reserved_memory_in_bytes: usize,
+    ) -> Result<(), ModelarDbError> {
         self.compressed_reserved_memory_in_bytes = new_compressed_reserved_memory_in_bytes;
         Ok(())
     }

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -16,6 +16,8 @@
 //! Management of the system's configuration, including the server mode, and the amount of
 //! reserved memory for uncompressed and compressed data.
 
+use modelardb_common::errors::ModelarDbError;
+
 use crate::ServerMode;
 
 /// Store's the system's configuration and provides functionality for updating the configuration.
@@ -45,7 +47,23 @@ impl ConfigurationManager {
         &self.uncompressed_reserved_memory_in_bytes
     }
 
+    /// TODO: If the system currently uses less than `new_uncompressed_reserved_memory_in_bytes` bytes
+    ///       for uncompressed memory, set the new value and return [`Ok`], otherwise return
+    ///       [`ConfigurationError`](ModelarDbError::ConfigurationError).
+    fn set_uncompressed_reserved_memory_in_bytes(&mut self, new_uncompressed_reserved_memory_in_bytes: usize) -> Result<(), ModelarDbError> {
+        self.uncompressed_reserved_memory_in_bytes = new_uncompressed_reserved_memory_in_bytes;
+        Ok(())
+    }
+
     fn compressed_reserved_memory_in_bytes(&self) -> &usize {
         &self.compressed_reserved_memory_in_bytes
+    }
+
+    /// TODO: If the system currently uses less than `new_compressed_reserved_memory_in_bytes` bytes
+    ///       for compressed memory, set the new value and return [`Ok`], otherwise return
+    ///       [`ConfigurationError`](ModelarDbError::ConfigurationError).
+    fn set_compressed_reserved_memory_in_bytes(&mut self, new_compressed_reserved_memory_in_bytes: usize) -> Result<(), ModelarDbError> {
+        self.compressed_reserved_memory_in_bytes = new_compressed_reserved_memory_in_bytes;
+        Ok(())
     }
 }

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -98,40 +98,57 @@ impl ConfigurationManager {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::common_test::test_context;
 
     // TODO: Test that the value is updated in the storage engine as well.
     // Tests for ConfigurationManager.
-    #[test]
-    fn test_set_uncompressed_reserved_memory_in_bytes() {
-        let mut configuration_manager = ConfigurationManager::new(ServerMode::Edge);
+    #[tokio::test]
+    async fn test_set_uncompressed_reserved_memory_in_bytes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let context = test_context(temp_dir.path()).await;
+
+        let configuration_manager = context.configuration_manager.clone();
+        let storage_engine = context.storage_engine.clone();
+
         assert_eq!(
-            *configuration_manager.uncompressed_reserved_memory_in_bytes(),
+            *configuration_manager.read().await.uncompressed_reserved_memory_in_bytes(),
             512 * 1024 * 1024
         );
 
         configuration_manager
-            .set_uncompressed_reserved_memory_in_bytes(1024)
-            .unwrap();
+            .write()
+            .await
+            .set_uncompressed_reserved_memory_in_bytes(1024, storage_engine)
+            .await;
+
         assert_eq!(
-            *configuration_manager.uncompressed_reserved_memory_in_bytes(),
+            *configuration_manager.read().await.uncompressed_reserved_memory_in_bytes(),
             1024
         );
     }
 
-    #[test]
-    fn test_set_compressed_reserved_memory_in_bytes() {
-        let mut configuration_manager = ConfigurationManager::new(ServerMode::Edge);
+    #[tokio::test]
+    async fn test_set_compressed_reserved_memory_in_bytes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let context = test_context(temp_dir.path()).await;
+
+        let configuration_manager = context.configuration_manager.clone();
+        let storage_engine = context.storage_engine.clone();
+
         assert_eq!(
-            *configuration_manager.compressed_reserved_memory_in_bytes(),
+            *configuration_manager.read().await.compressed_reserved_memory_in_bytes(),
             512 * 1024 * 1024
         );
 
         configuration_manager
-            .set_compressed_reserved_memory_in_bytes(1024)
+            .write()
+            .await
+            .set_compressed_reserved_memory_in_bytes(1024, storage_engine)
+            .await
             .unwrap();
+
         assert_eq!(
-            *configuration_manager.compressed_reserved_memory_in_bytes(),
+            *configuration_manager.read().await.compressed_reserved_memory_in_bytes(),
             1024
         );
     }

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -21,6 +21,7 @@ use modelardb_common::errors::ModelarDbError;
 use crate::ServerMode;
 
 /// Store's the system's configuration and provides functionality for updating the configuration.
+#[derive(Clone)]
 pub struct ConfigurationManager {
     /// The mode of the server used to determine the behaviour when modifying the remote object store.
     server_mode: ServerMode,

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -51,8 +51,8 @@ impl ConfigurationManager {
     // TODO: The remaining memory in the storage engine needs to be updated when updating these.
     // TODO: Check if other places need to be updated.
 
-    /// TODO: If the system currently uses less than `new_uncompressed_reserved_memory_in_bytes` bytes
-    ///       for uncompressed memory, set the new value and return [`Ok`], otherwise return
+    /// TODO: Set the new value and update the uncompressed remaining reserved memory in the storage
+    ///       engine. If the value was updated, return [`Ok`], otherwise return
     ///       [`ConfigurationError`](ModelarDbError::ConfigurationError).
     pub(crate) fn set_uncompressed_reserved_memory_in_bytes(
         &mut self,
@@ -66,8 +66,8 @@ impl ConfigurationManager {
         &self.compressed_reserved_memory_in_bytes
     }
 
-    /// TODO: If the system currently uses less than `new_compressed_reserved_memory_in_bytes` bytes
-    ///       for compressed memory, set the new value and return [`Ok`], otherwise return
+    /// TODO: Set the new value and update the compressed remaining reserved memory in the storage engine.
+    ///       If the value was updated, return [`Ok`], otherwise return
     ///       [`ConfigurationError`](ModelarDbError::ConfigurationError).
     pub(crate) fn set_compressed_reserved_memory_in_bytes(
         &mut self,
@@ -75,5 +75,30 @@ impl ConfigurationManager {
     ) -> Result<(), ModelarDbError> {
         self.compressed_reserved_memory_in_bytes = new_compressed_reserved_memory_in_bytes;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TODO: Test that the value is updated in the storage engine as well.
+    // Tests for ConfigurationManager.
+    #[test]
+    fn test_set_uncompressed_reserved_memory_in_bytes() {
+        let mut configuration_manager = ConfigurationManager::new(ServerMode::Edge);
+        assert_eq!(*configuration_manager.uncompressed_reserved_memory_in_bytes(), 512 * 1024 * 1024);
+
+        configuration_manager.set_uncompressed_reserved_memory_in_bytes(1024).unwrap();
+        assert_eq!(*configuration_manager.uncompressed_reserved_memory_in_bytes(), 1024);
+    }
+
+    #[test]
+    fn test_set_compressed_reserved_memory_in_bytes() {
+        let mut configuration_manager = ConfigurationManager::new(ServerMode::Edge);
+        assert_eq!(*configuration_manager.compressed_reserved_memory_in_bytes(), 512 * 1024 * 1024);
+
+        configuration_manager.set_compressed_reserved_memory_in_bytes(1024).unwrap();
+        assert_eq!(*configuration_manager.compressed_reserved_memory_in_bytes(), 1024);
     }
 }

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -1,0 +1,39 @@
+/* Copyright 2023 The ModelarDB Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Management of the system's configuration, including the server mode, and the amount of
+//! reserved memory for uncompressed and compressed data.
+
+use crate::ServerMode;
+
+/// Store's the system's configuration and provides functionality for updating the configuration.
+pub struct ConfigurationManager {
+    /// The mode of the server used to determine the behaviour when modifying the remote object store.
+    pub server_mode: ServerMode,
+    /// Amount of memory to reserve for storing uncompressed data buffers.
+    pub uncompressed_reserved_memory_in_bytes: usize,
+    /// Amount of memory to reserve for storing compressed data buffers.
+    pub compressed_reserved_memory_in_bytes: usize,
+}
+
+impl ConfigurationManager {
+    pub fn new(server_mode: ServerMode) -> Self {
+        Self {
+            server_mode,
+            uncompressed_reserved_memory_in_bytes: 512 * 1024 * 1024, // 512 MiB
+            compressed_reserved_memory_in_bytes: 512 * 1024 * 1024, // 512 MiB
+        }
+    }
+}

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-//! Management of the system's configuration, including the server mode, and the amount of
-//! reserved memory for uncompressed and compressed data.
+//! Management of the system's configuration. The configuration consists of the server mode and
+//! the amount of reserved memory for uncompressed and compressed data.
 
 use std::sync::Arc;
 use modelardb_common::errors::ModelarDbError;
@@ -23,10 +23,11 @@ use tokio::sync::RwLock;
 use crate::storage::StorageEngine;
 use crate::ServerMode;
 
-/// Store's the system's configuration and provides functionality for updating the configuration.
+/// Manages the system's configuration and provides functionality for updating the configuration.
 #[derive(Clone)]
 pub struct ConfigurationManager {
-    /// The mode of the server used to determine the behaviour when modifying the remote object store.
+    /// The mode of the server used to determine the behaviour when modifying the remote object
+    /// store and querying.
     server_mode: ServerMode,
     /// Amount of memory to reserve for storing uncompressed data buffers.
     uncompressed_reserved_memory_in_bytes: usize,
@@ -51,12 +52,14 @@ impl ConfigurationManager {
         &self.uncompressed_reserved_memory_in_bytes
     }
 
-    /// Set the new value and update the uncompressed remaining reserved memory in the storage engine.
+    /// Set the new value and update the amount of memory for uncompressed data in the storage engine.
     pub(crate) async fn set_uncompressed_reserved_memory_in_bytes(
         &mut self,
         new_uncompressed_reserved_memory_in_bytes: usize,
         storage_engine: Arc<RwLock<StorageEngine>>,
     ) {
+        // Since the storage engine only keeps track of the remaining reserved memory, calculate
+        // how much the value should change.
         let value_change = new_uncompressed_reserved_memory_in_bytes as isize
             - self.uncompressed_reserved_memory_in_bytes as isize;
 
@@ -73,7 +76,7 @@ impl ConfigurationManager {
         &self.compressed_reserved_memory_in_bytes
     }
 
-    /// Set the new value and update the compressed remaining reserved memory in the storage engine.
+    /// Set the new value and update the amount of memory for compressed data in the storage engine.
     /// If the value was updated, return [`Ok`], otherwise return
     /// [`ConfigurationError`](ModelarDbError::ConfigurationError).
     pub(crate) async fn set_compressed_reserved_memory_in_bytes(
@@ -81,6 +84,8 @@ impl ConfigurationManager {
         new_compressed_reserved_memory_in_bytes: usize,
         storage_engine: Arc<RwLock<StorageEngine>>,
     ) -> Result<(), ModelarDbError> {
+        // Since the storage engine only keeps track of the remaining reserved memory, calculate
+        // how much the value should change.
         let value_change = new_compressed_reserved_memory_in_bytes as isize
             - self.compressed_reserved_memory_in_bytes as isize;
 

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -100,7 +100,6 @@ impl ConfigurationManager {
 mod tests {
     use crate::common_test;
 
-    // TODO: Test that the value is updated in the storage engine as well.
     // Tests for ConfigurationManager.
     #[tokio::test]
     async fn test_set_uncompressed_reserved_memory_in_bytes() {

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -39,11 +39,11 @@ impl ConfigurationManager {
         }
     }
 
-    fn server_mode(&self) -> &ServerMode {
+    pub(crate) fn server_mode(&self) -> &ServerMode {
         &self.server_mode
     }
 
-    fn uncompressed_reserved_memory_in_bytes(&self) -> &usize {
+    pub(crate) fn uncompressed_reserved_memory_in_bytes(&self) -> &usize {
         &self.uncompressed_reserved_memory_in_bytes
     }
 
@@ -53,7 +53,7 @@ impl ConfigurationManager {
     /// TODO: If the system currently uses less than `new_uncompressed_reserved_memory_in_bytes` bytes
     ///       for uncompressed memory, set the new value and return [`Ok`], otherwise return
     ///       [`ConfigurationError`](ModelarDbError::ConfigurationError).
-    fn set_uncompressed_reserved_memory_in_bytes(
+    pub(crate) fn set_uncompressed_reserved_memory_in_bytes(
         &mut self,
         new_uncompressed_reserved_memory_in_bytes: usize,
     ) -> Result<(), ModelarDbError> {
@@ -61,14 +61,14 @@ impl ConfigurationManager {
         Ok(())
     }
 
-    fn compressed_reserved_memory_in_bytes(&self) -> &usize {
+    pub(crate) fn compressed_reserved_memory_in_bytes(&self) -> &usize {
         &self.compressed_reserved_memory_in_bytes
     }
 
     /// TODO: If the system currently uses less than `new_compressed_reserved_memory_in_bytes` bytes
     ///       for compressed memory, set the new value and return [`Ok`], otherwise return
     ///       [`ConfigurationError`](ModelarDbError::ConfigurationError).
-    fn set_compressed_reserved_memory_in_bytes(
+    pub(crate) fn set_compressed_reserved_memory_in_bytes(
         &mut self,
         new_compressed_reserved_memory_in_bytes: usize,
     ) -> Result<(), ModelarDbError> {

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -21,11 +21,11 @@ use crate::ServerMode;
 /// Store's the system's configuration and provides functionality for updating the configuration.
 pub struct ConfigurationManager {
     /// The mode of the server used to determine the behaviour when modifying the remote object store.
-    pub server_mode: ServerMode,
+    server_mode: ServerMode,
     /// Amount of memory to reserve for storing uncompressed data buffers.
-    pub uncompressed_reserved_memory_in_bytes: usize,
+    uncompressed_reserved_memory_in_bytes: usize,
     /// Amount of memory to reserve for storing compressed data buffers.
-    pub compressed_reserved_memory_in_bytes: usize,
+    compressed_reserved_memory_in_bytes: usize,
 }
 
 impl ConfigurationManager {
@@ -35,5 +35,17 @@ impl ConfigurationManager {
             uncompressed_reserved_memory_in_bytes: 512 * 1024 * 1024, // 512 MiB
             compressed_reserved_memory_in_bytes: 512 * 1024 * 1024, // 512 MiB
         }
+    }
+
+    fn server_mode(&self) -> &ServerMode {
+        &self.server_mode
+    }
+
+    fn uncompressed_reserved_memory_in_bytes(&self) -> &usize {
+        &self.uncompressed_reserved_memory_in_bytes
+    }
+
+    fn compressed_reserved_memory_in_bytes(&self) -> &usize {
+        &self.compressed_reserved_memory_in_bytes
     }
 }

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -66,7 +66,7 @@ impl ConfigurationManager {
         storage_engine
             .write()
             .await
-            .set_uncompressed_remaining_memory_in_bytes(value_change)
+            .adjust_uncompressed_remaining_memory_in_bytes(value_change)
             .await;
 
         self.uncompressed_reserved_memory_in_bytes = new_uncompressed_reserved_memory_in_bytes;
@@ -92,7 +92,7 @@ impl ConfigurationManager {
         storage_engine
             .write()
             .await
-            .set_compressed_remaining_memory_in_bytes(value_change)
+            .adjust_compressed_remaining_memory_in_bytes(value_change)
             .await
             .map_err(|error| ModelarDbError::ConfigurationError(error.to_string()))?;
 

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -98,21 +98,21 @@ impl ConfigurationManager {
 
 #[cfg(test)]
 mod tests {
-    use crate::common_test::test_context;
+    use crate::common_test;
 
     // TODO: Test that the value is updated in the storage engine as well.
     // Tests for ConfigurationManager.
     #[tokio::test]
     async fn test_set_uncompressed_reserved_memory_in_bytes() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let context = test_context(temp_dir.path()).await;
+        let context = common_test::test_context(temp_dir.path()).await;
 
         let configuration_manager = context.configuration_manager.clone();
         let storage_engine = context.storage_engine.clone();
 
         assert_eq!(
             *configuration_manager.read().await.uncompressed_reserved_memory_in_bytes(),
-            512 * 1024 * 1024
+            common_test::UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES
         );
 
         configuration_manager
@@ -130,14 +130,14 @@ mod tests {
     #[tokio::test]
     async fn test_set_compressed_reserved_memory_in_bytes() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let context = test_context(temp_dir.path()).await;
+        let context = common_test::test_context(temp_dir.path()).await;
 
         let configuration_manager = context.configuration_manager.clone();
         let storage_engine = context.storage_engine.clone();
 
         assert_eq!(
             *configuration_manager.read().await.compressed_reserved_memory_in_bytes(),
-            512 * 1024 * 1024
+            common_test::COMPRESSED_RESERVED_MEMORY_IN_BYTES
         );
 
         configuration_manager

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -25,6 +25,7 @@ mod parser;
 mod query;
 mod remote;
 mod storage;
+mod configuration;
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -19,13 +19,13 @@
 #![allow(clippy::too_many_arguments)]
 
 mod common_test;
+mod configuration;
 mod metadata;
 mod optimizer;
 mod parser;
 mod query;
 mod remote;
 mod storage;
-mod configuration;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -42,6 +42,7 @@ use once_cell::sync::Lazy;
 use tokio::runtime::Runtime;
 use tokio::sync::RwLock;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use crate::configuration::ConfigurationManager;
 
 use crate::metadata::MetadataManager;
 use crate::storage::StorageEngine;
@@ -82,6 +83,8 @@ pub struct DataFolders {
 pub struct Context {
     /// Metadata for the tables and model tables in the data folder.
     pub metadata_manager: MetadataManager,
+    /// Updatable configuration of the server.
+    pub configuration_manager: ConfigurationManager,
     /// Main interface for Apache Arrow DataFusion.
     pub session: SessionContext,
     /// Manages all uncompressed and compressed data in the system.
@@ -121,11 +124,9 @@ fn main() -> Result<(), String> {
 
     // Create the components for the Context.
     let metadata_manager = runtime
-        .block_on(MetadataManager::try_new(
-            &data_folders.local_data_folder,
-            server_mode,
-        ))
+        .block_on(MetadataManager::try_new(&data_folders.local_data_folder))
         .map_err(|error| format!("Unable to create a MetadataManager: {error}"))?;
+    let configuration_manager = ConfigurationManager::new(server_mode);
     let session = create_session_context(data_folders.query_data_folder);
     let storage_engine = RwLock::new(
         runtime
@@ -144,6 +145,7 @@ fn main() -> Result<(), String> {
     // Create the Context.
     let context = Arc::new(Context {
         metadata_manager,
+        configuration_manager,
         session,
         storage_engine,
     });

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -134,6 +134,7 @@ fn main() -> Result<(), String> {
                 StorageEngine::try_new(
                     data_folders.local_data_folder,
                     data_folders.remote_data_folder,
+                    configuration_manager.clone(),
                     metadata_manager.clone(),
                     true,
                 )

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -136,7 +136,7 @@ fn main() -> Result<(), String> {
                 StorageEngine::try_new(
                     data_folders.local_data_folder,
                     data_folders.remote_data_folder,
-                    configuration_manager.clone(),
+                    &configuration_manager,
                     metadata_manager.clone(),
                     true,
                 )

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -31,7 +31,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::{env, fs};
 
-use crate::configuration::ConfigurationManager;
 use datafusion::execution::context::{SessionConfig, SessionContext, SessionState};
 use datafusion::execution::runtime_env::RuntimeEnv;
 use modelardb_common::arguments::{
@@ -44,6 +43,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::RwLock;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+use crate::configuration::ConfigurationManager;
 use crate::metadata::MetadataManager;
 use crate::storage::StorageEngine;
 

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -88,7 +88,7 @@ pub struct Context {
     /// Main interface for Apache Arrow DataFusion.
     pub session: SessionContext,
     /// Manages all uncompressed and compressed data in the system.
-    pub storage_engine: RwLock<StorageEngine>,
+    pub storage_engine: Arc<RwLock<StorageEngine>>,
 }
 
 /// Setup tracing that prints to stdout, parse the command line arguments to
@@ -130,7 +130,7 @@ fn main() -> Result<(), String> {
     let configuration_manager = Arc::new(RwLock::new(ConfigurationManager::new(server_mode)));
     let session = create_session_context(data_folders.query_data_folder);
 
-    let storage_engine = RwLock::new(
+    let storage_engine = Arc::new(RwLock::new(
         runtime
             .block_on(async {
                 StorageEngine::try_new(
@@ -143,7 +143,7 @@ fn main() -> Result<(), String> {
                 .await
             })
             .map_err(|error| error.to_string())?,
-    );
+    ));
 
     // Create the Context.
     let context = Arc::new(Context {

--- a/crates/modelardb_server/src/metadata/mod.rs
+++ b/crates/modelardb_server/src/metadata/mod.rs
@@ -13,14 +13,13 @@
  * limitations under the License.
  */
 
-//! Management of the metadata database which stores the system's configuration and the metadata
-//! required for the tables and model tables. Tables can store arbitrary data, while model tables
-//! can only store time series as segments containing metadata and models. At runtime, the location
-//! of the data for the tables and the model table metadata are stored in Apache Arrow DataFusion's
-//! catalog, while this module stores the system's configuration and a mapping from model table name
-//! and tag values to hashes. These hashes can be combined with the corresponding model table's
-//! field column indices to uniquely identify each univariate time series stored in the storage
-//! engine by a univariate id.
+//! Management of the metadata database which stores the metadata required for the tables and
+//! model tables. Tables can store arbitrary data, while model tables can only store time series as
+//! segments containing metadata and models. At runtime, the location of the data for the tables and
+//! the model table metadata are stored in Apache Arrow DataFusion's catalog, while this module stores
+//! a mapping from model table name and tag values to hashes. These hashes can be combined with the
+//! corresponding model table's field column indices to uniquely identify each univariate time series
+//! stored in the storage engine by a univariate id.
 
 pub mod model_table_metadata;
 
@@ -51,16 +50,15 @@ use crate::metadata::model_table_metadata::ModelTableMetadata;
 use crate::parser;
 use crate::query::ModelTable;
 use crate::storage::COMPRESSED_DATA_FOLDER;
-use crate::{Context, ServerMode};
+use crate::Context;
 
 use self::model_table_metadata::GeneratedColumn;
 
 /// Name used for the file containing the SQLite database storing the metadata.
 pub const METADATA_DATABASE_NAME: &str = "metadata.sqlite3";
 
-/// Store's the system's configuration and the metadata required for reading from and writing to the
-/// tables and model tables. The data that needs to be persisted are stored in the metadata
-/// database.
+/// Store's the metadata required for reading from and writing to the tables and model tables.
+/// The data that needs to be persisted are stored in the metadata database.
 #[derive(Clone)]
 pub struct MetadataManager {
     /// Folder for storing metadata and Apache Parquet files on the local file
@@ -71,18 +69,12 @@ pub struct MetadataManager {
     /// Cache of tag value hashes used to signify when to persist new unsaved
     /// tag combinations.
     tag_value_hashes: HashMap<String, u64>,
-    /// The mode of the server used to determine the behaviour when modifying the remote object store.
-    pub server_mode: ServerMode,
-    /// Amount of memory to reserve for storing uncompressed data buffers.
-    pub uncompressed_reserved_memory_in_bytes: usize,
-    /// Amount of memory to reserve for storing compressed data buffers.
-    pub compressed_reserved_memory_in_bytes: usize,
 }
 
 impl MetadataManager {
     /// Return [`MetadataManager`] if a pool of connections to the metadata database in
     /// `local_data_folder` can be made, otherwise [`Error`] is returned.
-    pub async fn try_new(local_data_folder: &Path, server_mode: ServerMode) -> Result<Self> {
+    pub async fn try_new(local_data_folder: &Path) -> Result<Self> {
         if !Self::is_path_a_data_folder(local_data_folder) {
             warn!("The data folder is not empty and does not contain data from ModelarDB");
         }
@@ -97,10 +89,6 @@ impl MetadataManager {
             local_data_folder: local_data_folder.to_path_buf(),
             metadata_database_pool: SqlitePool::connect_with(options).await?,
             tag_value_hashes: HashMap::new(),
-            server_mode,
-            // Default values for parameters.
-            uncompressed_reserved_memory_in_bytes: 512 * 1024 * 1024, // 512 MiB
-            compressed_reserved_memory_in_bytes: 512 * 1024 * 1024,   // 512 MiB
         };
 
         // Create the necessary tables in the metadata database.

--- a/crates/modelardb_server/src/metadata/mod.rs
+++ b/crates/modelardb_server/src/metadata/mod.rs
@@ -834,7 +834,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_metadata_database_tables() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
 
         // Verify that the tables were created and has the expected columns.
         metadata_manager
@@ -869,14 +869,14 @@ mod tests {
     async fn test_get_data_folder_path() {
         let temp_dir = tempfile::tempdir().unwrap();
         let temp_dir_path = temp_dir.path();
-        let metadata_manager = common_test::test_metadata_manager(temp_dir_path).await;
+        let metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
         assert_eq!(temp_dir_path, metadata_manager.local_data_folder());
     }
 
     #[tokio::test]
     async fn test_get_new_tag_hash() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let mut metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let mut metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
 
         let model_table_metadata = common_test::model_table_metadata();
         metadata_manager
@@ -911,7 +911,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_existing_tag_hash() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let mut metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let mut metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
 
         let model_table_metadata = common_test::model_table_metadata();
         metadata_manager
@@ -958,7 +958,7 @@ mod tests {
     #[tokio::test]
     async fn test_compute_univariate_ids_using_fields_and_tags_for_missing_model_table() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
 
         assert!(metadata_manager
             .compute_univariate_ids_using_fields_and_tags("model_table", None, 10, &[])
@@ -970,7 +970,7 @@ mod tests {
     async fn test_compute_univariate_ids_using_fields_and_tags_for_empty_model_table() {
         // Save a model table to the metadata database.
         let temp_dir = tempfile::tempdir().unwrap();
-        let metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
 
         let model_table_metadata = common_test::model_table_metadata();
         metadata_manager
@@ -990,7 +990,7 @@ mod tests {
     async fn test_compute_univariate_ids_using_no_fields_and_tags_for_model_table() {
         // Save a model table to the metadata database.
         let temp_dir = tempfile::tempdir().unwrap();
-        let mut metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let mut metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
         initialize_model_table_with_tag_values(&mut metadata_manager, &["tag_value1"]).await;
 
         // Lookup all univariate ids for the table by not passing any fields or tags.
@@ -1006,7 +1006,7 @@ mod tests {
     ) {
         // Save a model table to the metadata database.
         let temp_dir = tempfile::tempdir().unwrap();
-        let mut metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let mut metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
         initialize_model_table_with_tag_values(&mut metadata_manager, &["tag_value1"]).await;
 
         // Lookup the univariate ids for the fallback column by only requesting tag columns.
@@ -1021,7 +1021,7 @@ mod tests {
     async fn test_compute_the_univariate_ids_for_a_specific_field_column_for_model_table() {
         // Save a model table to the metadata database.
         let temp_dir = tempfile::tempdir().unwrap();
-        let mut metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let mut metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
         initialize_model_table_with_tag_values(
             &mut metadata_manager,
             &["tag_value1", "tag_value2"],
@@ -1047,7 +1047,7 @@ mod tests {
     async fn test_compute_the_univariate_ids_for_a_specific_tag_value_for_model_table() {
         // Save a model table to the metadata database.
         let temp_dir = tempfile::tempdir().unwrap();
-        let mut metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let mut metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
         initialize_model_table_with_tag_values(
             &mut metadata_manager,
             &["tag_value1", "tag_value2"],
@@ -1107,7 +1107,7 @@ mod tests {
     async fn test_save_table_metadata() {
         // Save a table to the metadata database.
         let temp_dir = tempfile::tempdir().unwrap();
-        let metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
 
         let table_name = "table_name";
         metadata_manager
@@ -1153,7 +1153,7 @@ mod tests {
     async fn test_save_model_table_metadata() {
         // Save a model table to the metadata database.
         let temp_dir = tempfile::tempdir().unwrap();
-        let metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
 
         let model_table_metadata = common_test::model_table_metadata();
         metadata_manager

--- a/crates/modelardb_server/src/metadata/mod.rs
+++ b/crates/modelardb_server/src/metadata/mod.rs
@@ -1506,7 +1506,7 @@ mod tests {
         // the TempDir which created the folder containing the database leaves it in read-only mode.
         let temp_dir = tempfile::tempdir().unwrap();
 
-        let metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let metadata_manager = MetadataManager::try_new(temp_dir.path()).await.unwrap();
         let model_table_metadata = common_test::model_table_metadata();
 
         metadata_manager
@@ -1582,7 +1582,7 @@ mod tests {
     }
 
     async fn create_metadata_manager_and_save_model_table(temp_dir: &Path) -> MetadataManager {
-        let metadata_manager = common_test::test_metadata_manager(temp_dir).await;
+        let metadata_manager = MetadataManager::try_new(temp_dir).await.unwrap();
         let model_table_metadata = common_test::model_table_metadata();
 
         metadata_manager

--- a/crates/modelardb_server/src/metadata/mod.rs
+++ b/crates/modelardb_server/src/metadata/mod.rs
@@ -95,7 +95,7 @@ impl CompressedFile {
 }
 
 /// Store's the metadata required for reading from and writing to the tables and model tables.
-/// The data that needs to be persisted are stored in the metadata database.
+/// The data that needs to be persisted is stored in the metadata database.
 #[derive(Clone)]
 pub struct MetadataManager {
     /// Folder for storing metadata and Apache Parquet files on the local file

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -840,13 +840,19 @@ impl FlightService for FlightServiceHandler {
             })?;
 
             let mut configuration_manager = self.context.configuration_manager.write().await;
+            let storage_engine = self.context.storage_engine.clone();
 
             match setting {
-                "uncompressed_reserved_memory_in_bytes" => configuration_manager
-                    .set_uncompressed_reserved_memory_in_bytes(new_value)
-                    .map_err(|error| Status::internal(error.to_string())),
+                "uncompressed_reserved_memory_in_bytes" => {
+                    configuration_manager
+                        .set_uncompressed_reserved_memory_in_bytes(new_value, storage_engine)
+                        .await;
+
+                    Ok(())
+                }
                 "compressed_reserved_memory_in_bytes" => configuration_manager
-                    .set_compressed_reserved_memory_in_bytes(new_value)
+                    .set_compressed_reserved_memory_in_bytes(new_value, storage_engine)
+                    .await
                     .map_err(|error| Status::internal(error.to_string())),
                 _ => Err(Status::unimplemented(format!(
                     "{setting} is not a valid setting in the server configuration."

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -760,7 +760,7 @@ impl FlightService for FlightServiceHandler {
             }))))
         } else if action.r#type == "UpdateRemoteObjectStore" {
             // If on a cloud node, both the remote data folder and the query data folder should be updated.
-            if self.context.metadata_manager.server_mode == ServerMode::Cloud {
+            if self.context.configuration_manager.server_mode() == &ServerMode::Cloud {
                 // TODO: The query data folder should be updated in the session context.
                 return Err(Status::unimplemented(
                     "Currently not possible to update remote object store on cloud nodes.",

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -678,7 +678,7 @@ impl FlightService for FlightServiceHandler {
     /// the object store type, specifically either 's3' or 'azureblobstorage'. The remaining
     /// arguments should be the arguments required to connect to the object store.
     /// * `GetConfiguration`: Get the current server configuration. The value of each setting in the
-    /// configuration is returned in a single [`RecordBatch`](arrow::record_batch::RecordBatch).
+    /// configuration is returned in a single [`RecordBatch`].
     /// * `UpdateConfiguration`: Update a single setting in the configuration. Each argument in the
     /// body should start with the size of the argument, immediately followed by the argument value.
     /// The first argument should be the setting to update, specifically either

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -810,11 +810,11 @@ impl FlightService for FlightServiceHandler {
         } else if action.r#type == "GetConfiguration" {
             // Extract the configuration data from the configuration manager.
             let configuration_manager = self.context.configuration_manager.read().await;
-            let settings = vec![
+            let settings = [
                 "uncompressed_reserved_memory_in_bytes",
                 "compressed_reserved_memory_in_bytes",
             ];
-            let values = vec![
+            let values = [
                 *configuration_manager.uncompressed_reserved_memory_in_bytes() as u64,
                 *configuration_manager.compressed_reserved_memory_in_bytes() as u64,
             ];
@@ -825,8 +825,8 @@ impl FlightService for FlightServiceHandler {
             let batch = RecordBatch::try_new(
                 schema.0.clone(),
                 vec![
-                    Arc::new(StringArray::from(settings)),
-                    Arc::new(UInt64Array::from(values)),
+                    Arc::new(StringArray::from_iter_values(settings)),
+                    Arc::new(UInt64Array::from_iter_values(values)),
                 ],
             )
             .unwrap();
@@ -836,7 +836,7 @@ impl FlightService for FlightServiceHandler {
             let (setting, offset_data) = extract_argument(&action.body)?;
             let (new_value, _offset_data) = extract_argument(offset_data)?;
             let new_value: usize = new_value.parse().map_err(|error| {
-                Status::internal(format!("New value for {setting} is not valid: {error}"))
+                Status::invalid_argument(format!("New value for {setting} is not valid: {error}"))
             })?;
 
             let mut configuration_manager = self.context.configuration_manager.write().await;

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -864,12 +864,24 @@ impl FlightService for FlightServiceHandler {
                 .to_owned(),
         };
 
+        let get_configuration = ActionType {
+            r#type: "GetConfiguration".to_owned(),
+            description: "Get the current server configuration.".to_owned(),
+        };
+
+        let update_configuration = ActionType {
+            r#type: "UpdateConfiguration".to_owned(),
+            description: "Update a specific setting in the server configuration.".to_owned(),
+        };
+
         let output = stream::iter(vec![
             Ok(create_command_statement_update_action),
             Ok(flush_data_to_disk),
             Ok(flush_edge_action),
             Ok(collect_metrics),
             Ok(update_remote_object_store),
+            Ok(get_configuration),
+            Ok(update_configuration),
         ]);
 
         Ok(Response::new(Box::pin(output)))

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -1116,6 +1116,19 @@ mod tests {
         assert_eq!(data_manager.compressed_data_buffers.values().len(), 0);
     }
 
+    #[tokio::test]
+    #[should_panic(expected = "Not enough compressed data to free up the required memory.")]
+    async fn test_panic_if_decreasing_compressed_remaining_memory_in_bytes_below_zero() {
+        let (_temp_dir, mut data_manager) = create_compressed_data_manager().await;
+
+        data_manager
+            .set_compressed_remaining_memory_in_bytes(
+                -((common_test::COMPRESSED_RESERVED_MEMORY_IN_BYTES + 1) as isize),
+            )
+            .await
+            .unwrap();
+    }
+
     /// Create a [`CompressedDataManager`] with a folder that is deleted once the test is finished.
     async fn create_compressed_data_manager() -> (TempDir, CompressedDataManager) {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -354,9 +354,9 @@ impl CompressedDataManager {
         Ok(())
     }
 
-    /// Change the compressed remaining memory in bytes according to `value_change`. If less than 0
-    /// bytes remain, save compressed data to free memory. If all the data is saved successfully
-    /// return [`Ok`], otherwise return [`IOError`].
+    /// Change the amount of memory for compressed data in bytes according to `value_change`. If
+    /// less than zero bytes remain, save compressed data to free memory. If all the data is saved
+    /// successfully return [`Ok`], otherwise return [`IOError`].
     pub(super) async fn set_compressed_remaining_memory_in_bytes(
         &mut self,
         value_change: isize,

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -616,7 +616,6 @@ mod tests {
     /// Create a [`CompressedDataManager`] with a folder that is deleted once the test is finished.
     async fn create_compressed_data_manager() -> (TempDir, CompressedDataManager) {
         let temp_dir = tempfile::tempdir().unwrap();
-        let configuration_manager = common_test::test_configuration_manager();
 
         let local_data_folder = temp_dir.path().to_path_buf();
         (
@@ -624,9 +623,7 @@ mod tests {
             CompressedDataManager::try_new(
                 None,
                 local_data_folder,
-                configuration_manager
-                    .compressed_reserved_memory_in_bytes()
-                    .clone(),
+                common_test::COMPRESSED_RESERVED_MEMORY_IN_BYTES,
                 Arc::new(RwLock::new(Metric::new())),
             )
             .unwrap(),

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -613,23 +613,6 @@ mod tests {
         );
     }
 
-    /// Create a [`CompressedDataManager`] with a folder that is deleted once the test is finished.
-    async fn create_compressed_data_manager() -> (TempDir, CompressedDataManager) {
-        let temp_dir = tempfile::tempdir().unwrap();
-
-        let local_data_folder = temp_dir.path().to_path_buf();
-        (
-            temp_dir,
-            CompressedDataManager::try_new(
-                None,
-                local_data_folder,
-                common_test::COMPRESSED_RESERVED_MEMORY_IN_BYTES,
-                Arc::new(RwLock::new(Metric::new())),
-            )
-            .unwrap(),
-        )
-    }
-
     // Tests for save_and_get_saved_compressed_files().
     #[tokio::test]
     async fn test_can_get_compressed_file_for_table() {
@@ -1092,6 +1075,38 @@ mod tests {
             )
             .await;
         assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_increase_compressed_remaining_memory_in_bytes() {
+        let (_temp_dir, mut data_manager) = create_compressed_data_manager().await;
+
+        data_manager
+            .set_compressed_remaining_memory_in_bytes(10000)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            data_manager.compressed_remaining_memory_in_bytes as usize,
+            common_test::COMPRESSED_RESERVED_MEMORY_IN_BYTES + 10000
+        )
+    }
+
+    /// Create a [`CompressedDataManager`] with a folder that is deleted once the test is finished.
+    async fn create_compressed_data_manager() -> (TempDir, CompressedDataManager) {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let local_data_folder = temp_dir.path().to_path_buf();
+        (
+            temp_dir,
+            CompressedDataManager::try_new(
+                None,
+                local_data_folder,
+                common_test::COMPRESSED_RESERVED_MEMORY_IN_BYTES,
+                Arc::new(RwLock::new(Metric::new())),
+            )
+            .unwrap(),
+        )
     }
 
     // Tests for is_compressed_file_within_time_and_value_range().

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -357,12 +357,12 @@ impl CompressedDataManager {
     /// Change the compressed remaining memory in bytes according to `value_change`. If less than 0
     /// bytes remain, save compressed data to free memory. If all the data is saved successfully
     /// return [`Ok`], otherwise return [`IOError`].
-    fn set_compressed_remaining_memory_in_bytes(
+    pub(super) async fn set_compressed_remaining_memory_in_bytes(
         &mut self,
         value_change: isize,
     ) -> Result<(), IOError> {
         self.compressed_remaining_memory_in_bytes += value_change;
-        self.save_compressed_data_to_free_memory()?;
+        self.save_compressed_data_to_free_memory().await?;
 
         Ok(())
     }

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -600,7 +600,7 @@ mod tests {
     /// Create a [`CompressedDataManager`] with a folder that is deleted once the test is finished.
     async fn create_compressed_data_manager() -> (TempDir, CompressedDataManager) {
         let temp_dir = tempfile::tempdir().unwrap();
-        let metadata_manager = common_test::test_metadata_manager(temp_dir.path()).await;
+        let configuration_manager = common_test::test_configuration_manager();
 
         let local_data_folder = temp_dir.path().to_path_buf();
         (
@@ -608,7 +608,7 @@ mod tests {
             CompressedDataManager::try_new(
                 None,
                 local_data_folder,
-                metadata_manager.compressed_reserved_memory_in_bytes,
+                configuration_manager.compressed_reserved_memory_in_bytes().clone(),
                 Arc::new(RwLock::new(Metric::new())),
             )
             .unwrap(),

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -357,7 +357,7 @@ impl CompressedDataManager {
     /// Change the amount of memory for compressed data in bytes according to `value_change`. If
     /// less than zero bytes remain, save compressed data to free memory. If all the data is saved
     /// successfully return [`Ok`], otherwise return [`IOError`].
-    pub(super) async fn set_compressed_remaining_memory_in_bytes(
+    pub(super) async fn adjust_compressed_remaining_memory_in_bytes(
         &mut self,
         value_change: isize,
     ) -> Result<(), IOError> {
@@ -1082,7 +1082,7 @@ mod tests {
         let (_temp_dir, mut data_manager) = create_compressed_data_manager().await;
 
         data_manager
-            .set_compressed_remaining_memory_in_bytes(10000)
+            .adjust_compressed_remaining_memory_in_bytes(10000)
             .await
             .unwrap();
 
@@ -1104,7 +1104,7 @@ mod tests {
             .unwrap();
 
         data_manager
-            .set_compressed_remaining_memory_in_bytes(
+            .adjust_compressed_remaining_memory_in_bytes(
                 -(common_test::COMPRESSED_RESERVED_MEMORY_IN_BYTES as isize),
             )
             .await
@@ -1122,7 +1122,7 @@ mod tests {
         let (_temp_dir, mut data_manager) = create_compressed_data_manager().await;
 
         data_manager
-            .set_compressed_remaining_memory_in_bytes(
+            .adjust_compressed_remaining_memory_in_bytes(
                 -((common_test::COMPRESSED_RESERVED_MEMORY_IN_BYTES + 1) as isize),
             )
             .await

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -385,6 +385,18 @@ impl StorageEngine {
         Ok(())
     }
 
+    /// Change the uncompressed remaining memory in bytes according to `value_change`.
+    pub async fn set_uncompressed_remaining_memory_in_bytes(&mut self, value_change: isize) {
+        self.uncompressed_data_manager.set_uncompressed_remaining_memory_in_bytes(value_change).await;
+    }
+
+    /// Change the compressed remaining memory in bytes according to `value_change`. If the value is
+    /// changed successfully return [`Ok`], otherwise return [`IOError`].
+    pub async fn set_compressed_remaining_memory_in_bytes(&mut self, value_change: isize) -> Result<(), IOError> {
+        self.compressed_data_manager.set_compressed_remaining_memory_in_bytes(value_change).await?;
+        Ok(())
+    }
+
     /// Write `batch` to an Apache Parquet file at the location given by `file_path`. `file_path`
     /// must use the extension '.parquet'. Return [`Ok`] if the file was written successfully,
     /// otherwise [`ParquetError`].

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -118,7 +118,7 @@ impl StorageEngine {
     pub async fn try_new(
         local_data_folder: PathBuf,
         remote_data_folder: Option<Arc<dyn ObjectStore>>,
-        configuration_manager: Arc<RwLock<ConfigurationManager>>,
+        configuration_manager: &Arc<RwLock<ConfigurationManager>>,
         metadata_manager: MetadataManager,
         compress_directly: bool,
     ) -> Result<Self, IOError> {
@@ -383,15 +383,15 @@ impl StorageEngine {
         Ok(())
     }
 
-    /// Change the uncompressed remaining memory in bytes according to `value_change`.
+    /// Change the amount of memory for uncompressed data in bytes according to `value_change`.
     pub async fn set_uncompressed_remaining_memory_in_bytes(&mut self, value_change: isize) {
         self.uncompressed_data_manager
             .set_uncompressed_remaining_memory_in_bytes(value_change)
             .await;
     }
 
-    /// Change the compressed remaining memory in bytes according to `value_change`. If the value is
-    /// changed successfully return [`Ok`], otherwise return [`IOError`].
+    /// Change the amount of memory for compressed data in bytes according to `value_change`. If
+    /// the value is changed successfully return [`Ok`], otherwise return [`IOError`].
     pub async fn set_compressed_remaining_memory_in_bytes(
         &mut self,
         value_change: isize,

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{fmt, mem};
 
+use crate::configuration::ConfigurationManager;
 use bytes::buf::BufMut;
 use datafusion::arrow::array::UInt32Array;
 use datafusion::arrow::compute;
@@ -61,7 +62,6 @@ use tonic::codegen::Bytes;
 use tonic::Status;
 use tracing::debug;
 use uuid::{uuid, Uuid};
-use crate::configuration::ConfigurationManager;
 
 use crate::metadata::model_table_metadata::ModelTableMetadata;
 use crate::metadata::MetadataManager;
@@ -118,13 +118,15 @@ impl StorageEngine {
     pub async fn try_new(
         local_data_folder: PathBuf,
         remote_data_folder: Option<Arc<dyn ObjectStore>>,
-        configuration_manager: ConfigurationManager,
+        configuration_manager: Arc<RwLock<ConfigurationManager>>,
         metadata_manager: MetadataManager,
         compress_directly: bool,
     ) -> Result<Self, IOError> {
         // Create a metric for used disk space. The metric is wrapped in an Arc and a read/write lock
         // since it is appended to by multiple components, potentially at the same time.
         let used_disk_space_metric = Arc::new(RwLock::new(Metric::new()));
+
+        let configuration_manager = configuration_manager.read().await;
 
         // Create the uncompressed data manager.
         let uncompressed_data_manager = UncompressedDataManager::try_new(
@@ -154,7 +156,9 @@ impl StorageEngine {
         let compressed_data_manager = CompressedDataManager::try_new(
             data_transfer,
             local_data_folder,
-            configuration_manager.compressed_reserved_memory_in_bytes().clone(),
+            configuration_manager
+                .compressed_reserved_memory_in_bytes()
+                .clone(),
             used_disk_space_metric,
         )?;
 

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -384,20 +384,20 @@ impl StorageEngine {
     }
 
     /// Change the amount of memory for uncompressed data in bytes according to `value_change`.
-    pub async fn set_uncompressed_remaining_memory_in_bytes(&mut self, value_change: isize) {
+    pub async fn adjust_uncompressed_remaining_memory_in_bytes(&mut self, value_change: isize) {
         self.uncompressed_data_manager
-            .set_uncompressed_remaining_memory_in_bytes(value_change)
+            .adjust_uncompressed_remaining_memory_in_bytes(value_change)
             .await;
     }
 
     /// Change the amount of memory for compressed data in bytes according to `value_change`. If
     /// the value is changed successfully return [`Ok`], otherwise return [`IOError`].
-    pub async fn set_compressed_remaining_memory_in_bytes(
+    pub async fn adjust_compressed_remaining_memory_in_bytes(
         &mut self,
         value_change: isize,
     ) -> Result<(), IOError> {
         self.compressed_data_manager
-            .set_compressed_remaining_memory_in_bytes(value_change)
+            .adjust_compressed_remaining_memory_in_bytes(value_change)
             .await
     }
 

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -61,6 +61,7 @@ use tonic::codegen::Bytes;
 use tonic::Status;
 use tracing::debug;
 use uuid::{uuid, Uuid};
+use crate::configuration::ConfigurationManager;
 
 use crate::metadata::model_table_metadata::ModelTableMetadata;
 use crate::metadata::MetadataManager;
@@ -117,6 +118,7 @@ impl StorageEngine {
     pub async fn try_new(
         local_data_folder: PathBuf,
         remote_data_folder: Option<Arc<dyn ObjectStore>>,
+        configuration_manager: ConfigurationManager,
         metadata_manager: MetadataManager,
         compress_directly: bool,
     ) -> Result<Self, IOError> {
@@ -127,6 +129,7 @@ impl StorageEngine {
         // Create the uncompressed data manager.
         let uncompressed_data_manager = UncompressedDataManager::try_new(
             local_data_folder.clone(),
+            configuration_manager.uncompressed_reserved_memory_in_bytes().clone(),
             &metadata_manager,
             compress_directly,
             used_disk_space_metric.clone(),
@@ -151,7 +154,7 @@ impl StorageEngine {
         let compressed_data_manager = CompressedDataManager::try_new(
             data_transfer,
             local_data_folder,
-            metadata_manager.compressed_reserved_memory_in_bytes,
+            configuration_manager.compressed_reserved_memory_in_bytes().clone(),
             used_disk_space_metric,
         )?;
 

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -131,7 +131,7 @@ impl StorageEngine {
         // Create the uncompressed data manager.
         let uncompressed_data_manager = UncompressedDataManager::try_new(
             local_data_folder.clone(),
-            configuration_manager.uncompressed_reserved_memory_in_bytes().clone(),
+            *configuration_manager.uncompressed_reserved_memory_in_bytes(),
             &metadata_manager,
             compress_directly,
             used_disk_space_metric.clone(),
@@ -156,9 +156,7 @@ impl StorageEngine {
         let compressed_data_manager = CompressedDataManager::try_new(
             data_transfer,
             local_data_folder,
-            configuration_manager
-                .compressed_reserved_memory_in_bytes()
-                .clone(),
+            *configuration_manager.compressed_reserved_memory_in_bytes(),
             used_disk_space_metric,
         )?;
 
@@ -387,14 +385,20 @@ impl StorageEngine {
 
     /// Change the uncompressed remaining memory in bytes according to `value_change`.
     pub async fn set_uncompressed_remaining_memory_in_bytes(&mut self, value_change: isize) {
-        self.uncompressed_data_manager.set_uncompressed_remaining_memory_in_bytes(value_change).await;
+        self.uncompressed_data_manager
+            .set_uncompressed_remaining_memory_in_bytes(value_change)
+            .await;
     }
 
     /// Change the compressed remaining memory in bytes according to `value_change`. If the value is
     /// changed successfully return [`Ok`], otherwise return [`IOError`].
-    pub async fn set_compressed_remaining_memory_in_bytes(&mut self, value_change: isize) -> Result<(), IOError> {
-        self.compressed_data_manager.set_compressed_remaining_memory_in_bytes(value_change).await?;
-        Ok(())
+    pub async fn set_compressed_remaining_memory_in_bytes(
+        &mut self,
+        value_change: isize,
+    ) -> Result<(), IOError> {
+        self.compressed_data_manager
+            .set_compressed_remaining_memory_in_bytes(value_change)
+            .await
     }
 
     /// Write `batch` to an Apache Parquet file at the location given by `file_path`. `file_path`

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -505,11 +505,13 @@ impl UncompressedDataManager {
     /// bytes remain, spill uncompressed data to disk. If all the data is spilled successfully
     /// return [`Ok`], otherwise return [`IOError`].
     pub(super) async fn set_uncompressed_remaining_memory_in_bytes(&mut self, value_change: isize) {
-        let mut current_remaining_memory: isize = self.uncompressed_remaining_memory_in_bytes as isize + value_change;
+        let mut current_remaining_memory: isize =
+            self.uncompressed_remaining_memory_in_bytes as isize + value_change;
 
         while current_remaining_memory < 0 {
             self.spill_finished_buffer().await;
-            current_remaining_memory = self.uncompressed_remaining_memory_in_bytes as isize + value_change;
+            current_remaining_memory =
+                self.uncompressed_remaining_memory_in_bytes as isize + value_change;
         }
 
         self.uncompressed_remaining_memory_in_bytes = current_remaining_memory as usize;
@@ -989,7 +991,6 @@ mod tests {
         path: &Path,
     ) -> (MetadataManager, UncompressedDataManager, ModelTableMetadata) {
         let mut metadata_manager = MetadataManager::try_new(path).await.unwrap();
-        let configuration_manager = common_test::test_configuration_manager();
 
         // Ensure the expected metadata is available through the metadata manager.
         let query_schema = Arc::new(Schema::new(vec![
@@ -1027,7 +1028,7 @@ mod tests {
         // UncompressedDataManager::try_new() lookup the error bounds for each univariate_id.
         let uncompressed_data_manager = UncompressedDataManager::try_new(
             metadata_manager.local_data_folder().to_owned(),
-            configuration_manager.uncompressed_reserved_memory_in_bytes().clone(),
+            common_test::UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES,
             &metadata_manager,
             false,
             Arc::new(RwLock::new(Metric::new())),

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -1018,6 +1018,20 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    #[should_panic(expected = "Not enough reserved memory for the necessary uncompressed buffers.")]
+    async fn test_panic_if_decreasing_uncompressed_remaining_memory_in_bytes_below_zero() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_metadata_manager, mut data_manager, _model_table_metadata) =
+            create_managers(temp_dir.path()).await;
+
+        data_manager
+            .set_uncompressed_remaining_memory_in_bytes(
+                -((common_test::UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES + 1) as isize),
+            )
+            .await;
+    }
+
     /// Insert `count` data points into `data_manager`.
     async fn insert_data_points(
         count: usize,

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -501,9 +501,9 @@ impl UncompressedDataManager {
         panic!("Not enough reserved memory for the necessary uncompressed buffers.");
     }
 
-    /// Change the uncompressed remaining memory in bytes according to `value_change`. If less than 0
-    /// bytes remain, spill uncompressed data to disk. If all the data is spilled successfully
-    /// return [`Ok`], otherwise return [`IOError`].
+    /// Change the amount of memory for uncompressed data in bytes according to `value_change`. If
+    /// less than zero bytes remain, spill uncompressed data to disk. If all the data is spilled
+    /// successfully return [`Ok`], otherwise return [`IOError`].
     pub(super) async fn set_uncompressed_remaining_memory_in_bytes(&mut self, value_change: isize) {
         let mut current_remaining_memory: isize =
             self.uncompressed_remaining_memory_in_bytes as isize + value_change;

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -969,6 +969,25 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn test_increase_uncompressed_remaining_memory_in_bytes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_metadata_manager, mut data_manager, _model_table_metadata) =
+            create_managers(temp_dir.path()).await;
+
+        assert_eq!(
+            data_manager.uncompressed_remaining_memory_in_bytes,
+            common_test::UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES
+        );
+
+        data_manager.set_uncompressed_remaining_memory_in_bytes(10000).await;
+
+        assert_eq!(
+            data_manager.uncompressed_remaining_memory_in_bytes,
+            common_test::UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES + 10000
+        )
+    }
+
     /// Insert `count` data points into `data_manager`.
     async fn insert_data_points(
         count: usize,

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -504,7 +504,7 @@ impl UncompressedDataManager {
     /// Change the amount of memory for uncompressed data in bytes according to `value_change`. If
     /// less than zero bytes remain, spill uncompressed data to disk. If all the data is spilled
     /// successfully return [`Ok`], otherwise return [`IOError`].
-    pub(super) async fn set_uncompressed_remaining_memory_in_bytes(&mut self, value_change: isize) {
+    pub(super) async fn adjust_uncompressed_remaining_memory_in_bytes(&mut self, value_change: isize) {
         let mut current_remaining_memory: isize =
             self.uncompressed_remaining_memory_in_bytes as isize + value_change;
 
@@ -976,7 +976,7 @@ mod tests {
             create_managers(temp_dir.path()).await;
 
         data_manager
-            .set_uncompressed_remaining_memory_in_bytes(10000)
+            .adjust_uncompressed_remaining_memory_in_bytes(10000)
             .await;
 
         assert_eq!(
@@ -1000,7 +1000,7 @@ mod tests {
         .await;
 
         data_manager
-            .set_uncompressed_remaining_memory_in_bytes(
+            .adjust_uncompressed_remaining_memory_in_bytes(
                 -(common_test::UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES as isize),
             )
             .await;
@@ -1026,7 +1026,7 @@ mod tests {
             create_managers(temp_dir.path()).await;
 
         data_manager
-            .set_uncompressed_remaining_memory_in_bytes(
+            .adjust_uncompressed_remaining_memory_in_bytes(
                 -((common_test::UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES + 1) as isize),
             )
             .await;

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -970,12 +970,12 @@ mod tests {
         }
     }
 
-    /// Create an [`UncompressedDataManager`] with a folder that is deleted once the test is
-    /// finished.
+    /// Create an [`UncompressedDataManager`] with a folder that is deleted once the test is finished.
     async fn create_managers(
         path: &Path,
     ) -> (MetadataManager, UncompressedDataManager, ModelTableMetadata) {
-        let mut metadata_manager = common_test::test_metadata_manager(path).await;
+        let mut metadata_manager = MetadataManager::try_new(path).await.unwrap();
+        let configuration_manager = common_test::test_configuration_manager();
 
         // Ensure the expected metadata is available through the metadata manager.
         let query_schema = Arc::new(Schema::new(vec![
@@ -1013,6 +1013,7 @@ mod tests {
         // UncompressedDataManager::try_new() lookup the error bounds for each univariate_id.
         let uncompressed_data_manager = UncompressedDataManager::try_new(
             metadata_manager.local_data_folder().to_owned(),
+            configuration_manager.uncompressed_reserved_memory_in_bytes().clone(),
             &metadata_manager,
             false,
             Arc::new(RwLock::new(Metric::new())),

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -72,6 +72,7 @@ impl UncompressedDataManager {
     /// [`IOError`] is returned.
     pub(super) async fn try_new(
         local_data_folder: PathBuf,
+        uncompressed_remaining_memory_in_bytes: usize,
         metadata_manager: &MetadataManager,
         compress_directly: bool,
         used_disk_space_metric: Arc<RwLock<Metric>>,
@@ -119,8 +120,7 @@ impl UncompressedDataManager {
             current_batch_index: 0,
             active_uncompressed_data_buffers: HashMap::new(),
             finished_uncompressed_data_buffers: finished_data_buffers,
-            uncompressed_remaining_memory_in_bytes: metadata_manager
-                .uncompressed_reserved_memory_in_bytes,
+            uncompressed_remaining_memory_in_bytes,
             compress_directly,
             used_uncompressed_memory_metric: Metric::new(),
             ingested_data_points_metric: Metric::new(),

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -763,7 +763,7 @@ fn test_optimized_query_results_equals_non_optimized_query_results() {
 }
 
 #[test]
-fn test_cannot_update_invalid_setting() {
+fn test_cannot_update_non_existing_setting() {
     let mut test_context = TestContext::new();
     let response = test_context.update_configuration("invalid", "1");
 

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -551,6 +551,8 @@ fn test_can_list_actions() {
             "CommandStatementUpdate",
             "FlushEdge",
             "FlushMemory",
+            "GetConfiguration",
+            "UpdateConfiguration",
             "UpdateRemoteObjectStore",
         ]
     );

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -738,3 +738,31 @@ fn test_optimized_query_results_equals_non_optimized_query_results() {
 
     assert_eq!(optimized_query, non_optimized_query);
 }
+
+#[test]
+fn test_cannot_update_invalid_setting() {
+    let mut test_context = TestContext::new();
+
+    let setting = "invalid".as_bytes();
+    let setting_size = &[0, setting.len() as u8];
+
+    let setting_value = "1".as_bytes();
+    let setting_value_size = &[0, setting_value.len() as u8];
+
+    let action = Action {
+        r#type: "UpdateConfiguration".to_owned(),
+        body: [setting_size, setting, setting_value_size, setting_value]
+            .concat()
+            .into(),
+    };
+
+    test_context.runtime.block_on(async {
+        let response = test_context.client.do_action(Request::new(action)).await;
+
+        assert!(response.is_err());
+        assert_eq!(
+            response.err().unwrap().message(),
+            "invalid is not a valid setting in the server configuration."
+        );
+    })
+}


### PR DESCRIPTION
This PR includes a new separate server configuration component. The configuration has been moved out of the metadata manager and the new component has been added to the context so it is still available to the rest of the system. The configuration component also includes setters for the uncompressed and compressed reserved memory. Since they affect the remaining memory in the storage engine, setters have also been added to the storage managers. Finally, the PR also includes some new actions to get and update the configuration and integration/unit tests for the new functionality. 