### PR TITLE
Fix incorrect merging of models

### DIFF
--- a/crates/modelardb_compression/src/merge.rs
+++ b/crates/modelardb_compression/src/merge.rs
@@ -33,8 +33,8 @@ use crate::types::CompressedSegmentBatchBuilder;
 /// * Are from same time series.
 /// * Contain the exact same models.
 /// * Are consecutive in terms of time.
-/// Assumes that the segments for each `univariate_id` is sorted by time and if the consecutive
-/// segments A, B, and C exist for an `univariate_id` and the segments A and C are in
+/// Assumes that the segments for each `univariate_id` are sorted by time and if the consecutive
+/// segments A, B, and C exist for a `univariate_id` and the segments A and C are in
 /// `compressed_segments` then B is also in `compressed_segments`. If only A and C are in
 /// `compressed_segments` a segment that overlaps with B will be created if A and C are merged.
 pub fn try_merge_segments(compressed_segments: RecordBatch) -> Result<RecordBatch, ModelarDbError> {
@@ -253,8 +253,10 @@ fn merge_segments(
                 // Merge timestamps and compute the new segment's minimum and maximum value.
                 let mut timestamp_builder = TimestampBuilder::new();
 
-                let mut min_value = f32::MAX;
-                let mut max_value = f32::MIN;
+                // NaN is used as the initial value as it will be overwritten be any value. Thus, it
+                // is the only initial value that preserves a minimum and maximum value that is NaN.
+                let mut min_value = f32::NAN;
+                let mut max_value = f32::NAN;
 
                 for maybe_segment_index in merge_indices
                     .iter()

--- a/crates/modelardb_compression/src/merge.rs
+++ b/crates/modelardb_compression/src/merge.rs
@@ -20,22 +20,23 @@
 
 use std::collections::HashMap;
 
-use arrow::array::{BinaryArray, Float32Array, UInt64Array, UInt8Array};
+use arrow::array::{Array, BinaryArray, Float32Array, UInt64Array, UInt8Array};
 use arrow::record_batch::RecordBatch;
 use modelardb_common::errors::ModelarDbError;
 use modelardb_common::schemas::COMPRESSED_SCHEMA;
 use modelardb_common::types::{TimestampArray, TimestampBuilder, ValueArray};
 
-use crate::models::timestamps;
+use crate::models::{self, timestamps};
 use crate::types::CompressedSegmentBatchBuilder;
 
 /// Merge segments in `compressed_segments` if their schema is [`COMPRESSED_SCHEMA`] and they:
 /// * Are from same time series.
 /// * Contain the exact same models.
 /// * Are consecutive in terms of time.
-/// Assumes that if the consecutive segments A, B, and C exist for a time series and the segments A
-/// and C are in `compressed_segments` then B is also in `compressed_segments`. If only A and C are
-/// in `compressed_segments` a segment that overlaps with B will be created if A and C are merged.
+/// Assumes that the segments for each `univariate_id` is sorted by time and if the consecutive
+/// segments A, B, and C exist for an `univariate_id` and the segments A and C are in
+/// `compressed_segments` then B is also in `compressed_segments`. If only A and C are in
+/// `compressed_segments` a segment that overlaps with B will be created if A and C are merged.
 pub fn try_merge_segments(compressed_segments: RecordBatch) -> Result<RecordBatch, ModelarDbError> {
     if compressed_segments.schema() != COMPRESSED_SCHEMA.0 {
         return Err(ModelarDbError::CompressionError(
@@ -43,7 +44,6 @@ pub fn try_merge_segments(compressed_segments: RecordBatch) -> Result<RecordBatc
         ));
     }
 
-    // Extract the columns from the RecordBatch.
     modelardb_common::arrays!(
         compressed_segments,
         univariate_ids,
@@ -58,141 +58,270 @@ pub fn try_merge_segments(compressed_segments: RecordBatch) -> Result<RecordBatc
         errors
     );
 
-    // For each segment, check if it can be merged with another adjacent segment.
-    let num_rows = compressed_segments.num_rows();
-    let mut can_segments_be_merged = false;
-    let mut univariate_id_to_previous_index = HashMap::new();
-    let mut indices_to_merge_per_univariate_id = HashMap::new();
+    let maybe_merge_indices_per_univariate_id = compute_mergeable_segments(
+        univariate_ids,
+        model_type_ids,
+        start_times,
+        end_times,
+        min_values,
+        max_values,
+        values,
+        residuals,
+    );
 
-    for current_index in 0..num_rows {
-        let univariate_id = univariate_ids.value(current_index);
-        let previous_index = *univariate_id_to_previous_index
-            .get(&univariate_id)
-            .unwrap_or(&current_index);
-
-        if can_models_be_merged(
-            previous_index,
-            current_index,
+    if let Some(merge_indices_per_univariate_id) = maybe_merge_indices_per_univariate_id {
+        merge_segments(
+            merge_indices_per_univariate_id,
             univariate_ids,
             model_type_ids,
+            start_times,
+            end_times,
+            timestamps,
             min_values,
             max_values,
             values,
             residuals,
-        ) {
-            indices_to_merge_per_univariate_id
-                .entry(univariate_id)
-                .or_insert_with(Vec::new)
-                .push(Some(current_index));
-
-            can_segments_be_merged = previous_index != current_index;
-        } else {
-            // unwrap() is safe as a segment is guaranteed to match itself.
-            let indices_to_merge = indices_to_merge_per_univariate_id
-                .get_mut(&univariate_id)
-                .unwrap();
-            indices_to_merge.push(None);
-            indices_to_merge.push(Some(current_index));
-        }
-
-        univariate_id_to_previous_index.insert(univariate_id, current_index);
-    }
-
-    // If none of the segments can be merged return the original compressed
-    // segments, otherwise return the smaller set of merged compressed segments.
-    if can_segments_be_merged {
-        let mut merged_compressed_segments = CompressedSegmentBatchBuilder::new(num_rows);
-        let mut index_of_last_segment = 0;
-
-        let mut timestamp_builder = TimestampBuilder::new();
-        for (_, mut indices_to_merge) in indices_to_merge_per_univariate_id {
-            indices_to_merge.push(None);
-            for maybe_index in indices_to_merge {
-                if let Some(index) = maybe_index {
-                    // Merge timestamps.
-                    let start_time = start_times.value(index);
-                    let end_time = end_times.value(index);
-                    let timestamps = timestamps.value(index);
-
-                    timestamps::decompress_all_timestamps(
-                        start_time,
-                        end_time,
-                        timestamps,
-                        &mut timestamp_builder,
-                    );
-
-                    index_of_last_segment = index;
-                } else {
-                    let timestamps = timestamp_builder.finish();
-                    let compressed_timestamps =
-                        timestamps::compress_residual_timestamps(timestamps.values());
-
-                    // Merge segments. The last segment's model is used for the merged
-                    // segment as all of the segments contain the exact same model.
-                    merged_compressed_segments.append_compressed_segment(
-                        univariate_ids.value(index_of_last_segment),
-                        model_type_ids.value(index_of_last_segment),
-                        timestamps.value(0),
-                        timestamps.value(timestamps.len() - 1),
-                        &compressed_timestamps,
-                        min_values.value(index_of_last_segment),
-                        max_values.value(index_of_last_segment),
-                        values.value(index_of_last_segment),
-                        residuals.value(index_of_last_segment),
-                        errors.value(index_of_last_segment),
-                    );
-                }
-            }
-        }
-        Ok(merged_compressed_segments.finish())
+            errors,
+        )
     } else {
         Ok(compressed_segments)
     }
 }
 
+/// Return which segments can be merged together for each `univariate_id`, if any, otherwise
+/// [`None`] is returned. Assumes the arrays are the same length. The segments to be merged together
+/// per `univariate_id` are sequences of `Some(segment_index)` separated by [`None`].
+fn compute_mergeable_segments(
+    univariate_ids: &UInt64Array,
+    model_type_ids: &UInt8Array,
+    start_times: &TimestampArray,
+    end_times: &TimestampArray,
+    min_values: &ValueArray,
+    max_values: &ValueArray,
+    values: &BinaryArray,
+    residuals: &BinaryArray,
+) -> Option<HashMap<u64, Vec<Option<usize>>>> {
+    let mut can_any_segments_be_merged = false;
+    let mut univariate_id_to_previous_index = HashMap::new();
+    let mut merge_indices_per_univariate_id = HashMap::new();
+
+    for current_index in 0..univariate_ids.len() {
+        let univariate_id = univariate_ids.value(current_index);
+        let previous_index = *univariate_id_to_previous_index
+            .get(&univariate_id)
+            .unwrap_or(&current_index);
+
+        if segments_can_be_merged(
+            previous_index,
+            current_index,
+            univariate_ids,
+            model_type_ids,
+            start_times,
+            end_times,
+            min_values,
+            max_values,
+            values,
+            residuals,
+        ) {
+            merge_indices_per_univariate_id
+                .entry(univariate_id)
+                .or_insert_with(Vec::new)
+                .push(Some(current_index));
+
+            // segments_can_be_merged() always returns true if previous_index == current_index, but
+            // fewer segments are only created if there are multiple different segments to merge.
+            can_any_segments_be_merged |= previous_index != current_index;
+        } else {
+            // unwrap() is safe as a segment is guaranteed to match itself.
+            let merge_indices = merge_indices_per_univariate_id
+                .get_mut(&univariate_id)
+                .unwrap();
+
+            merge_indices.push(None);
+            merge_indices.push(Some(current_index));
+        }
+
+        univariate_id_to_previous_index.insert(univariate_id, current_index);
+    }
+
+    // Mark the end of the last sequence of segments for each univariate id.
+    for merge_indices in &mut merge_indices_per_univariate_id.values_mut() {
+        merge_indices.push(None);
+    }
+
+    if can_any_segments_be_merged {
+        Some(merge_indices_per_univariate_id)
+    } else {
+        None
+    }
+}
+
 /// Return [`true`] if the segment at `previous_index` does not store any residuals and the models
 /// at `previous_index` and `current_index` represent values from the same time series, are of the
-/// same type, and are equivalent, otherwise [`false`]. Assumes the arrays are the same length and
-/// that `previous_index` and `current_index` only access values in the arrays.
-fn can_models_be_merged(
+/// same type, and can be merged, otherwise [`false`]. Assumes the arrays are the same length and
+/// that `previous_index` and `current_index` both access values in the arrays.
+fn segments_can_be_merged(
     previous_index: usize,
     current_index: usize,
     univariate_ids: &UInt64Array,
     model_type_ids: &UInt8Array,
+    start_times: &TimestampArray,
+    end_times: &TimestampArray,
     min_values: &ValueArray,
     max_values: &ValueArray,
     values: &BinaryArray,
     residuals: &BinaryArray,
 ) -> bool {
-    // The query pipeline assumes residuals are values located after the values reconstructed by
-    // the main model in the segment, thus residuals at previous_index is currently not supported.
-    if previous_index != current_index && !residuals.value(previous_index).is_empty() {
+    // A segment can always be merged with itself.
+    if previous_index == current_index {
+        return true;
+    }
+
+    // Only segments from the same time series can be merged
+    if univariate_ids.value(previous_index) != univariate_ids.value(current_index) {
         return false;
     }
 
-    // The f32s are converted to u32s with the same bitwise representation as f32
-    // and f64 does not implement std::hash::Hash and thus they cannot be hashed.
-    (
-        univariate_ids.value(previous_index),
+    // The query pipeline assumes residuals are values located after the values reconstructed by
+    // the main model in the segment, thus residuals at previous_index is currently not supported.
+    if !residuals.value(previous_index).is_empty() {
+        return false;
+    }
+
+    models::can_be_merged(
         model_type_ids.value(previous_index),
-        min_values.value(previous_index).to_bits(),
-        max_values.value(previous_index).to_bits(),
+        start_times.value(previous_index),
+        end_times.value(previous_index),
+        min_values.value(previous_index),
+        max_values.value(previous_index),
         values.value(previous_index),
-    ) == (
-        univariate_ids.value(current_index),
         model_type_ids.value(current_index),
-        min_values.value(current_index).to_bits(),
-        max_values.value(current_index).to_bits(),
+        start_times.value(current_index),
+        end_times.value(current_index),
+        min_values.value(current_index),
+        max_values.value(current_index),
         values.value(current_index),
     )
 }
 
+/// Merge compressed segments according to `merge_indices_per_univariate_id`. Assumes the arrays
+/// are the same length.
+fn merge_segments(
+    merge_indices_per_univariate_id: HashMap<u64, Vec<Option<usize>>>,
+    univariate_ids: &UInt64Array,
+    model_type_ids: &UInt8Array,
+    start_times: &TimestampArray,
+    end_times: &TimestampArray,
+    timestamps: &BinaryArray,
+    min_values: &ValueArray,
+    max_values: &ValueArray,
+    values: &BinaryArray,
+    residuals: &BinaryArray,
+    errors: &Float32Array,
+) -> Result<RecordBatch, ModelarDbError> {
+    let mut merged_compressed_segments = CompressedSegmentBatchBuilder::new(univariate_ids.len());
+
+    // merge_indices are sequences of segments to be merged in the form of Some(segment_index)
+    // separated by None, while segment_index is the index of a segment stored in the arrays.
+    for merge_indices in merge_indices_per_univariate_id.values() {
+        let mut start_merge_index = 0;
+        let mut end_merge_index = 0;
+
+        for index in 0..merge_indices.len() {
+            if merge_indices[index].is_some() {
+                end_merge_index = index;
+            } else if start_merge_index == end_merge_index {
+                // unwrap() is safe as the range of index into merge_indices are all Some.
+                let segment_index = merge_indices[start_merge_index].unwrap();
+
+                // This sequence of mergeable segments only contain one segment.
+                merged_compressed_segments.append_compressed_segment(
+                    univariate_ids.value(segment_index),
+                    model_type_ids.value(segment_index),
+                    start_times.value(segment_index),
+                    end_times.value(segment_index),
+                    timestamps.value(segment_index),
+                    min_values.value(segment_index),
+                    max_values.value(segment_index),
+                    values.value(segment_index),
+                    residuals.value(segment_index),
+                    errors.value(segment_index),
+                );
+
+                start_merge_index = end_merge_index + 2;
+            } else {
+                // Merge timestamps and compute the new segment's minimum and maximum value.
+                let mut timestamp_builder = TimestampBuilder::new();
+
+                let mut min_value = f32::MAX;
+                let mut max_value = f32::MIN;
+
+                for maybe_segment_index in merge_indices
+                    .iter()
+                    .take(end_merge_index + 1)
+                    .skip(start_merge_index)
+                {
+                    // unwrap() is safe as the range of index into merge_indices are all Some.
+                    let segment_index = maybe_segment_index.unwrap();
+
+                    timestamps::decompress_all_timestamps(
+                        start_times.value(segment_index),
+                        end_times.value(segment_index),
+                        timestamps.value(segment_index),
+                        &mut timestamp_builder,
+                    );
+
+                    min_value = f32::min(min_value, min_values.value(segment_index));
+                    max_value = f32::max(max_value, max_values.value(segment_index));
+                }
+
+                let timestamps = timestamp_builder.finish();
+                let compressed_timestamps =
+                    timestamps::compress_residual_timestamps(timestamps.values());
+
+                // Merge the models.
+                // unwrap() is safe as the range of index into merge_indices are all Some.
+                let segment_index = merge_indices[start_merge_index].unwrap();
+                let model_type_id = model_type_ids.value(segment_index);
+                let values = values.value(segment_index);
+                let residuals = residuals.value(segment_index);
+                let values = models::merge(model_type_id, min_value, max_value, values);
+
+                // The metadata shared for all segment's are read from the last segment. In
+                // addition, since only the last segment may contain residuals, they are copied.
+                merged_compressed_segments.append_compressed_segment(
+                    univariate_ids.value(segment_index),
+                    model_type_ids.value(segment_index),
+                    timestamps.value(0),
+                    timestamps.value(timestamps.len() - 1),
+                    &compressed_timestamps,
+                    min_value,
+                    max_value,
+                    &values,
+                    residuals,
+                    errors.value(segment_index),
+                );
+
+                start_merge_index = end_merge_index + 2;
+            }
+        }
+    }
+
+    Ok(merged_compressed_segments.finish())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use crate::ErrorBound;
+
     use super::*;
 
-    use arrow::array::UInt8Array;
+    use arrow::array::{UInt64Builder, UInt8Array};
+    use arrow::compute;
     use modelardb_common::schemas::UNCOMPRESSED_SCHEMA;
+    use modelardb_common::types::ValueBuilder;
 
     // Tests for try_merge_segments().
     #[test]
@@ -204,235 +333,244 @@ mod tests {
     fn test_merge_compressed_segments_empty_batch_correct_schema() {
         let merged_record_batch =
             try_merge_segments(RecordBatch::new_empty(COMPRESSED_SCHEMA.0.clone())).unwrap();
+
         assert_eq!(0, merged_record_batch.num_rows())
+    }
+
+    fn compress(
+        batch_size: usize,
+        uncompressed_timestamps: &TimestampArray,
+        uncompressed_values: &ValueArray,
+    ) -> RecordBatch {
+        let mut index = 0;
+        let mut input_batches = vec![];
+
+        while index < uncompressed_timestamps.len() {
+            let compressed_segments = crate::try_compress(
+                1,
+                ErrorBound::try_new(0.0).unwrap(),
+                &uncompressed_timestamps.slice(index, batch_size),
+                &uncompressed_values.slice(index, batch_size),
+            )
+            .unwrap();
+
+            input_batches.push(compressed_segments);
+            index += batch_size;
+        }
+
+        compute::concat_batches(&input_batches[0].schema(), &input_batches).unwrap()
     }
 
     #[test]
     fn test_merge_compressed_segments_batch() {
-        // merge_segments() currently merge segments with equivalent models.
-        let univariate_id = 1;
-        let model_type_id = 1;
-        let values = &[];
-        let residuals = &[];
-        let min_value = 5.0;
-        let max_value = 5.0;
+        // Create uncompressed data points.
+        let uncompressed_timestamps =
+            Arc::new(TimestampArray::from_iter_values((10..8010).step_by(10)));
 
-        // Add a mix of different segments that can be merged into two segments.
-        let mut compressed_record_batch_builder = CompressedSegmentBatchBuilder::new(10);
+        let uncompressed_values = {
+            let mut uncompressed_values_builder = ValueBuilder::new();
+            uncompressed_values_builder.append_slice(&[100.0; 200]);
+            uncompressed_values_builder.append_slice(&[100.0; 200]);
 
-        for start_time in (100..2100).step_by(400) {
-            compressed_record_batch_builder.append_compressed_segment(
-                univariate_id,
-                model_type_id,
-                start_time,
-                start_time + 100,
-                &[],
-                min_value,
-                max_value,
-                values,
-                residuals,
-                0.0,
-            );
-        }
+            uncompressed_values_builder
+                .append_slice(&(0..200).map(|value| value as f32).collect::<Vec<f32>>());
+            uncompressed_values_builder
+                .append_slice(&(200..400).map(|value| value as f32).collect::<Vec<f32>>());
 
-        for start_time in (2500..4500).step_by(400) {
-            compressed_record_batch_builder.append_compressed_segment(
-                univariate_id,
-                model_type_id + 1,
-                start_time + 200,
-                start_time + 300,
-                &[],
-                -min_value,
-                -max_value,
-                values,
-                residuals,
-                10.0,
-            );
-        }
+            Arc::new(uncompressed_values_builder.finish())
+        };
 
-        let compressed_record_batch = compressed_record_batch_builder.finish();
-        let merged_record_batch = try_merge_segments(compressed_record_batch).unwrap();
+        // Compress and merge segments.
+        let compressed_segments = compress(200, &uncompressed_timestamps, &uncompressed_values);
+        let merged_compressed_segments = try_merge_segments(compressed_segments.clone()).unwrap();
 
-        // Extract the columns from the RecordBatch.
+        // Decompress merged segments;
         modelardb_common::arrays!(
-            merged_record_batch,
-            _univariate_ids,
-            _model_type_ids,
+            merged_compressed_segments,
+            univariate_ids,
+            model_type_ids,
             start_times,
             end_times,
             timestamps,
             min_values,
             max_values,
             values,
-            _residuals,
-            errors
+            residuals,
+            _errors
         );
 
-        // Assert that the number of segments are correct.
-        assert_eq!(2, merged_record_batch.num_rows());
+        let mut univariate_id_builder = UInt64Builder::new();
+        let mut timestamp_builder = TimestampBuilder::new();
+        let mut value_builder = ValueBuilder::new();
 
-        // Assert that the timestamps are correct.
-        let mut decompressed_timestamps = TimestampBuilder::with_capacity(10);
-        timestamps::decompress_all_timestamps(
-            start_times.value(0),
-            end_times.value(0),
-            timestamps.value(0),
-            &mut decompressed_timestamps,
-        );
-        assert_eq!(10, decompressed_timestamps.finish().len());
+        for row_index in 0..merged_compressed_segments.num_rows() {
+            crate::grid(
+                univariate_ids.value(row_index),
+                model_type_ids.value(row_index),
+                start_times.value(row_index),
+                end_times.value(row_index),
+                timestamps.value(row_index),
+                min_values.value(row_index),
+                max_values.value(row_index),
+                values.value(row_index),
+                residuals.value(row_index),
+                &mut univariate_id_builder,
+                &mut timestamp_builder,
+                &mut value_builder,
+            );
+        }
 
-        timestamps::decompress_all_timestamps(
-            start_times.value(1),
-            end_times.value(1),
-            timestamps.value(1),
-            &mut decompressed_timestamps,
-        );
-        assert_eq!(10, decompressed_timestamps.finish().len());
+        let decompressed_timestamps = Arc::new(timestamp_builder.finish());
+        let decompressed_values = Arc::new(value_builder.finish());
 
-        // Assert that the models are correct.
-        let (positive, negative) = if start_times.value(0) == 100 {
-            (0, 1)
-        } else {
-            (1, 0)
-        };
-
-        let value: &[u8] = &[];
-        assert_eq!(value, values.value(positive));
-        assert_eq!(min_value, min_values.value(positive));
-        assert_eq!(max_value, max_values.value(positive));
-
-        assert_eq!(value, values.value(negative));
-        assert_eq!(-min_value, min_values.value(negative));
-        assert_eq!(-max_value, max_values.value(negative));
-
-        // Assert that the errors are correct.
-        assert_eq!(0.0, errors.value(positive));
-        assert_eq!(10.0, errors.value(negative));
+        // Assert that the segments were created, were merged, and can be decompressed correctly.
+        assert_eq!(4, compressed_segments.num_rows());
+        assert_eq!(2, merged_compressed_segments.num_rows());
+        assert_eq!(uncompressed_timestamps, decompressed_timestamps);
+        assert_eq!(uncompressed_values, decompressed_values);
     }
 
     // Tests for can_models_be_merged().
     #[test]
-    fn test_equal_models_without_residuals_can_be_merged() {
-        assert!(can_models_be_merged(
+    fn test_equivalent_pmc_mean_models_can_be_merged() {
+        assert!(segments_can_be_merged(
             0,
             1,
             &UInt64Array::from_iter_values([1, 1]),
-            &UInt8Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([models::PMC_MEAN_ID, models::PMC_MEAN_ID]),
+            &TimestampArray::from_iter_values([100, 300]),
+            &TimestampArray::from_iter_values([200, 400]),
             &ValueArray::from_iter_values([1.0, 1.0]),
             &ValueArray::from_iter_values([2.0, 2.0]),
-            &BinaryArray::from_iter_values([[1], [1]]),
+            &BinaryArray::from_iter_values([[], []]),
             &BinaryArray::from_iter_values([[], []])
         ))
     }
 
     #[test]
-    fn test_equal_models_with_residuals_in_second_can_be_merged() {
-        assert!(can_models_be_merged(
+    fn test_different_pmc_mean_models_cannot_be_merged() {
+        assert!(!segments_can_be_merged(
             0,
             1,
             &UInt64Array::from_iter_values([1, 1]),
-            &UInt8Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([models::PMC_MEAN_ID, models::PMC_MEAN_ID]),
+            &TimestampArray::from_iter_values([100, 300]),
+            &TimestampArray::from_iter_values([200, 400]),
+            &ValueArray::from_iter_values([1.0, 1.5]),
+            &ValueArray::from_iter_values([2.0, 2.0]),
+            &BinaryArray::from_iter_values([[], []]),
+            &BinaryArray::from_iter_values([[], []])
+        ))
+    }
+
+    #[test]
+    fn test_equivalent_swing_mean_models_can_be_merged() {
+        assert!(segments_can_be_merged(
+            0,
+            1,
+            &UInt64Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([models::SWING_ID, models::SWING_ID]),
+            &TimestampArray::from_iter_values([100, 300]),
+            &TimestampArray::from_iter_values([200, 400]),
+            &ValueArray::from_iter_values([1.0, 3.0]),
+            &ValueArray::from_iter_values([2.0, 4.0]),
+            &BinaryArray::from_iter_values([[], []]),
+            &BinaryArray::from_iter_values([[], []])
+        ))
+    }
+
+    #[test]
+    fn test_different_swing_models_cannot_be_merged() {
+        assert!(!segments_can_be_merged(
+            0,
+            1,
+            &UInt64Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([models::SWING_ID, models::SWING_ID]),
+            &TimestampArray::from_iter_values([100, 300]),
+            &TimestampArray::from_iter_values([200, 400]),
             &ValueArray::from_iter_values([1.0, 1.0]),
             &ValueArray::from_iter_values([2.0, 2.0]),
-            &BinaryArray::from_iter_values([[1], [1]]),
-            &BinaryArray::from_iter_values([vec![], vec![1]])
+            &BinaryArray::from_iter_values([[], []]),
+            &BinaryArray::from_iter_values([[], []])
         ))
     }
 
     #[test]
     fn test_models_with_different_univariate_ids_cannot_be_merged() {
-        assert!(!can_models_be_merged(
+        assert!(!segments_can_be_merged(
             0,
             1,
             &UInt64Array::from_iter_values([1, 2]),
-            &UInt8Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([models::PMC_MEAN_ID, models::PMC_MEAN_ID]),
+            &TimestampArray::from_iter_values([100, 300]),
+            &TimestampArray::from_iter_values([200, 400]),
             &ValueArray::from_iter_values([1.0, 1.0]),
             &ValueArray::from_iter_values([2.0, 2.0]),
-            &BinaryArray::from_iter_values([[1], [1]]),
+            &BinaryArray::from_iter_values([[], []]),
             &BinaryArray::from_iter_values([[], []])
         ))
     }
 
     #[test]
     fn test_models_with_different_model_types_cannot_be_merged() {
-        assert!(!can_models_be_merged(
+        assert!(!segments_can_be_merged(
             0,
             1,
             &UInt64Array::from_iter_values([1, 1]),
-            &UInt8Array::from_iter_values([1, 2]),
+            &UInt8Array::from_iter_values([models::PMC_MEAN_ID, models::SWING_ID]),
+            &TimestampArray::from_iter_values([100, 300]),
+            &TimestampArray::from_iter_values([200, 400]),
             &ValueArray::from_iter_values([1.0, 1.0]),
             &ValueArray::from_iter_values([2.0, 2.0]),
-            &BinaryArray::from_iter_values([[1], [1]]),
+            &BinaryArray::from_iter_values([[], []]),
             &BinaryArray::from_iter_values([[], []])
         ))
     }
 
     #[test]
-    fn test_models_with_different_min_values_cannot_be_merged() {
-        assert!(!can_models_be_merged(
+    fn test_models_with_residuals_in_first_segment_cannot_be_merged() {
+        assert!(!segments_can_be_merged(
             0,
             1,
             &UInt64Array::from_iter_values([1, 1]),
-            &UInt8Array::from_iter_values([1, 1]),
-            &ValueArray::from_iter_values([1.0, 2.0]),
-            &ValueArray::from_iter_values([2.0, 2.0]),
-            &BinaryArray::from_iter_values([[1], [1]]),
-            &BinaryArray::from_iter_values([[], []])
-        ))
-    }
-
-    #[test]
-    fn test_models_with_different_max_values_cannot_be_merged() {
-        assert!(!can_models_be_merged(
-            0,
-            1,
-            &UInt64Array::from_iter_values([1, 1]),
-            &UInt8Array::from_iter_values([1, 1]),
-            &ValueArray::from_iter_values([1.0, 1.0]),
-            &ValueArray::from_iter_values([2.0, 3.0]),
-            &BinaryArray::from_iter_values([[1], [1]]),
-            &BinaryArray::from_iter_values([[], []])
-        ))
-    }
-
-    #[test]
-    fn test_models_with_different_values_cannot_be_merged() {
-        assert!(!can_models_be_merged(
-            0,
-            1,
-            &UInt64Array::from_iter_values([1, 1]),
-            &UInt8Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([models::PMC_MEAN_ID, models::PMC_MEAN_ID]),
+            &TimestampArray::from_iter_values([100, 300]),
+            &TimestampArray::from_iter_values([200, 400]),
             &ValueArray::from_iter_values([1.0, 1.0]),
             &ValueArray::from_iter_values([2.0, 2.0]),
-            &BinaryArray::from_iter_values([[1], [2]]),
-            &BinaryArray::from_iter_values([[], []])
-        ))
-    }
-
-    #[test]
-    fn test_models_with_residuals_in_first_cannot_be_merged() {
-        assert!(!can_models_be_merged(
-            0,
-            1,
-            &UInt64Array::from_iter_values([1, 1]),
-            &UInt8Array::from_iter_values([1, 1]),
-            &ValueArray::from_iter_values([1.0, 1.0]),
-            &ValueArray::from_iter_values([2.0, 2.0]),
-            &BinaryArray::from_iter_values([[1], [1]]),
+            &BinaryArray::from_iter_values([[], []]),
             &BinaryArray::from_iter_values([&vec![1], &vec![]])
         ))
     }
 
     #[test]
-    fn test_models_with_residuals_in_both_cannot_be_merged() {
-        assert!(!can_models_be_merged(
+    fn test_models_with_residuals_in_second_segment_can_be_merged() {
+        assert!(segments_can_be_merged(
             0,
             1,
             &UInt64Array::from_iter_values([1, 1]),
-            &UInt8Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([models::PMC_MEAN_ID, models::PMC_MEAN_ID]),
+            &TimestampArray::from_iter_values([100, 300]),
+            &TimestampArray::from_iter_values([200, 400]),
             &ValueArray::from_iter_values([1.0, 1.0]),
             &ValueArray::from_iter_values([2.0, 2.0]),
-            &BinaryArray::from_iter_values([[1], [1]]),
+            &BinaryArray::from_iter_values([[], []]),
+            &BinaryArray::from_iter_values([&vec![], &vec![1]])
+        ))
+    }
+
+    #[test]
+    fn test_models_with_residuals_in_both_segments_cannot_be_merged() {
+        assert!(!segments_can_be_merged(
+            0,
+            1,
+            &UInt64Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([models::PMC_MEAN_ID, models::PMC_MEAN_ID]),
+            &TimestampArray::from_iter_values([100, 300]),
+            &TimestampArray::from_iter_values([200, 400]),
+            &ValueArray::from_iter_values([1.0, 1.0]),
+            &ValueArray::from_iter_values([2.0, 2.0]),
+            &BinaryArray::from_iter_values([[], []]),
             &BinaryArray::from_iter_values([[1], [1]])
         ))
     }

--- a/crates/modelardb_compression/src/merge.rs
+++ b/crates/modelardb_compression/src/merge.rs
@@ -281,7 +281,7 @@ fn merge_segments(
 
                 // Merge the models.
                 // unwrap() is safe as the range of index into merge_indices are all Some.
-                let segment_index = merge_indices[start_merge_index].unwrap();
+                let segment_index = merge_indices[end_merge_index].unwrap();
                 let model_type_id = model_type_ids.value(segment_index);
                 let values = values.value(segment_index);
                 let residuals = residuals.value(segment_index);

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-//! Implementation of the model types used for compressing sequences of values models and functions
-//! for efficiently computing aggregates from models of each type. The module itself contains
-//! general functionality used by the model types.
+//! Implementation of the model types used for compressing sequences of values as models and
+//! functions for efficiently computing aggregates from models of each type. The module itself
+//! contains general functionality used by the model types.
 
 pub mod bits;
 pub mod gorilla;

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -208,6 +208,46 @@ impl Swing {
     }
 }
 
+/// Return [`true`] if two time series segment whose values are represented by a model of type Swing
+/// can be merged. Currently, only segments whose models produce a new model with the exact same
+/// slope and intercept when merged can be merged as it is guaranteed to produce the same values.
+pub(crate) fn can_be_merged(
+    segment_one_start_time: Timestamp,
+    segment_one_end_time: Timestamp,
+    segment_one_first_value: f64,
+    segment_one_last_value: f64,
+    segment_two_start_time: Timestamp,
+    segment_two_end_time: Timestamp,
+    segment_two_first_value: f64,
+    segment_two_last_value: f64,
+) -> bool {
+    let (segment_one_slope, segment_one_intercept) = compute_slope_and_intercept(
+        segment_one_start_time,
+        segment_one_first_value,
+        segment_one_end_time,
+        segment_one_last_value,
+    );
+
+    let (segment_two_slope, segment_two_intercept) = compute_slope_and_intercept(
+        segment_two_start_time,
+        segment_two_first_value,
+        segment_two_end_time,
+        segment_two_last_value,
+    );
+
+    let (segment_merged_slope, segment_merged_intercept) = compute_slope_and_intercept(
+        segment_one_start_time,
+        segment_one_first_value,
+        segment_two_end_time,
+        segment_two_last_value,
+    );
+
+    segment_one_slope == segment_merged_slope
+        && segment_one_intercept == segment_merged_intercept
+        && segment_two_slope == segment_merged_slope
+        && segment_two_intercept == segment_merged_intercept
+}
+
 /// Compute the sum of the values for a time series segment whose values are
 /// represented by a model of type Swing.
 pub fn sum(

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -396,6 +396,8 @@ impl CompressedSegmentBuilder {
                 values.extend(max_value.to_le_bytes());
             }
             values
+        } else if !min_value_is_first {
+            vec![0]
         } else {
             vec![]
         }

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -315,8 +315,9 @@ impl CompressedSegmentBuilder {
         gorilla.model()
     }
 
-    /// Encode the information required for [`PMCMean`] model where the `residuals_min_value` and/or
-    /// `residuals_max_value` overwrite the model's `min_value` and/or `max_value` in the segment.
+    /// Encode the information required for a [`PMCMean`] model where the `residuals_min_value`
+    /// and/or `residuals_max_value` overwrite the model's `min_value` and/or `max_value` in the
+    /// segment.
     pub(crate) fn encode_values_for_pmc_mean(
         min_value: Value,
         max_value: Value,

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -263,13 +263,22 @@ impl CompressedSegmentBuilder {
             let (mut residuals, residuals_min_value, residuals_max_value) =
                 self.compress_residuals(error_bound, uncompressed_residuals);
 
-            match model_type_id {
-                PMC_MEAN_ID => {
-                    self.update_values_for_pmc_mean(residuals_min_value, residuals_max_value)
-                }
-                SWING_ID => self.update_values_for_swing(residuals_min_value, residuals_max_value),
+            self.values = match model_type_id {
+                PMC_MEAN_ID => Self::encode_values_for_pmc_mean(
+                    self.min_value,
+                    self.max_value,
+                    residuals_min_value,
+                    residuals_max_value,
+                ),
+                SWING_ID => Self::encode_values_for_swing(
+                    self.min_value,
+                    self.max_value,
+                    self.values.is_empty(),
+                    residuals_min_value,
+                    residuals_max_value,
+                ),
                 _ => panic!("Unknown model type."),
-            }
+            };
 
             self.min_value = Value::min(self.min_value, residuals_min_value);
             self.max_value = Value::max(self.max_value, residuals_max_value);
@@ -306,28 +315,32 @@ impl CompressedSegmentBuilder {
         gorilla.model()
     }
 
-    /// Add information if required for a model of type [`PMCMean`] due to `residuals_min_value` and
-    /// `residuals_max_value` overwriting the model's minimum and maximum values in the segment.
-    fn update_values_for_pmc_mean(
-        &mut self,
+    /// Encode the information required for [`PMCMean`] model where the `residuals_min_value` and/or
+    /// `residuals_max_value` overwrite the model's `min_value` and/or `max_value` in the segment.
+    pub(crate) fn encode_values_for_pmc_mean(
+        min_value: Value,
+        max_value: Value,
         residuals_min_value: Value,
         residuals_max_value: Value,
-    ) {
-        if self.min_value > residuals_min_value {
+    ) -> Vec<u8> {
+        let mut values = vec![];
+
+        if min_value > residuals_min_value {
             // The models minimum is overwritten so another value must be used.
-            if self.max_value >= residuals_max_value {
+            if max_value >= residuals_max_value {
                 // Minimum and maximum is the same for PMC-Mean, so maximum can be used with a flag.
-                self.values.push(1);
+                values.push(1);
             } else {
                 // Minimum and maximum have been overwritten, so the model's value has to be stored.
-                self.values.extend_from_slice(&self.min_value.to_le_bytes());
+                values.extend_from_slice(&min_value.to_le_bytes());
             }
         }
+
+        values
     }
 
     /// Decode the mean value stored for a model of type [`PMCMean`]. For information about how the
-    /// parameter for [`PMCMean`] is encoded, see
-    /// [`CompressedSegmentBuilder::update_values_for_pmc_mean`].
+    /// parameter for [`PMCMean`] is encoded, see [`Self::encode_values_for_pmc_mean`].
     pub(crate) fn decode_values_for_pmc_mean(
         min_value: Value,
         max_value: Value,
@@ -341,50 +354,55 @@ impl CompressedSegmentBuilder {
         }
     }
 
-    /// Add information if required for a model of type [`Swing`] due to `residuals_min_value` and
-    /// `residuals_max_value` overwriting the model's minimum and maximum values in the segment.
-    fn update_values_for_swing(&mut self, residuals_min_value: Value, residuals_max_value: Value) {
-        if residuals_min_value < self.min_value && self.max_value < residuals_max_value {
+    /// Encode the information required for a [`Swing`] model where the `residuals_min_value` and/or
+    /// `residuals_max_value` overwrite the model's `min_value` and/or `max_value` in the segment.
+    pub(crate) fn encode_values_for_swing(
+        min_value: Value,
+        max_value: Value,
+        min_value_is_first: bool,
+        residuals_min_value: Value,
+        residuals_max_value: Value,
+    ) -> Vec<u8> {
+        if residuals_min_value < min_value && max_value < residuals_max_value {
             // Minimum and maximum is overwritten so first and last value are stored.
-            let mut updated_values = Vec::with_capacity(2 * VALUE_SIZE_IN_BYTES as usize);
-            if self.values.is_empty() {
-                updated_values.extend_from_slice(&self.min_value.to_le_bytes());
-                updated_values.extend_from_slice(&self.max_value.to_le_bytes());
+            let mut values = Vec::with_capacity(2 * VALUE_SIZE_IN_BYTES as usize);
+            if min_value_is_first {
+                values.extend_from_slice(&min_value.to_le_bytes());
+                values.extend_from_slice(&max_value.to_le_bytes());
             } else {
-                updated_values.extend_from_slice(&self.max_value.to_le_bytes());
-                updated_values.extend_from_slice(&self.min_value.to_le_bytes());
+                values.extend_from_slice(&max_value.to_le_bytes());
+                values.extend_from_slice(&min_value.to_le_bytes());
             }
-            self.values = updated_values;
-        } else if residuals_min_value < self.min_value {
+            values
+        } else if residuals_min_value < min_value {
             // Minimum is overwritten so a flag is stored for the order and then the models minimum.
-            let mut updated_values = Vec::with_capacity(1 + VALUE_SIZE_IN_BYTES as usize);
-            if self.values.is_empty() {
-                updated_values.push(0);
-                updated_values.extend(self.min_value.to_le_bytes());
+            let mut values = Vec::with_capacity(1 + VALUE_SIZE_IN_BYTES as usize);
+            if min_value_is_first {
+                values.push(0);
+                values.extend(min_value.to_le_bytes());
             } else {
-                updated_values.push(1);
-                updated_values.extend(self.min_value.to_le_bytes());
+                values.push(1);
+                values.extend(min_value.to_le_bytes());
             }
-            self.values = updated_values;
-        } else if self.max_value < residuals_max_value {
+            values
+        } else if max_value < residuals_max_value {
             // Maximum is overwritten so a flag is stored for the order and then the models maximum.
-            let mut updated_values = Vec::with_capacity(1 + VALUE_SIZE_IN_BYTES as usize);
-            if self.values.is_empty() {
-                updated_values.push(2);
-                updated_values.extend(self.max_value.to_le_bytes());
+            let mut values = Vec::with_capacity(1 + VALUE_SIZE_IN_BYTES as usize);
+            if min_value_is_first {
+                values.push(2);
+                values.extend(max_value.to_le_bytes());
             } else {
-                updated_values.push(3);
-                updated_values.extend(self.max_value.to_le_bytes());
+                values.push(3);
+                values.extend(max_value.to_le_bytes());
             }
-            self.values = updated_values;
+            values
+        } else {
+            vec![]
         }
-
-        if self.min_value > residuals_min_value {}
     }
 
-    /// Decode the slope and intercept stored for a model of type [`Swing`]. For information about
-    /// how the parameters for Swing are encoded, see [ModelBuilder::select_swing`] and
-    /// [`CompressedSegmentBuilder ::update_values_for_swing`].
+    /// Decode the first and last value stored for a model of type [`Swing`]. For information about
+    /// how the parameters for Swing are encoded, see [`Self::update_values_for_swing`].
     pub(crate) fn decode_values_for_swing(
         min_value: Value,
         max_value: Value,

--- a/crates/modelardb_server/src/common_test.rs
+++ b/crates/modelardb_server/src/common_test.rs
@@ -29,8 +29,7 @@ use datafusion::execution::context::{SessionConfig, SessionContext, SessionState
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::physical_plan::ExecutionPlan;
 use modelardb_common::schemas::COMPRESSED_SCHEMA;
-use modelardb_common::types::{ArrowTimestamp, ArrowValue};
-use modelardb_common::types::{TimestampArray, ValueArray};
+use modelardb_common::types::{ArrowTimestamp, ArrowValue, TimestampArray, ValueArray};
 use modelardb_compression::ErrorBound;
 use object_store::local::LocalFileSystem;
 use tokio::sync::RwLock;
@@ -43,7 +42,7 @@ use crate::storage::{self, StorageEngine};
 use crate::{optimizer, Context, ServerMode};
 
 /// Expected size of the compressed segments produced in the tests.
-pub const COMPRESSED_SEGMENTS_SIZE: usize = 1399;
+pub const COMPRESSED_SEGMENTS_SIZE: usize = 1335;
 
 /// Number of bytes reserved for uncompressed data in tests.
 pub const UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES: usize = 5 * 1024 * 1024; // 5 MiB
@@ -160,13 +159,13 @@ pub fn compressed_segments_record_batch_with_time(time_ms: i64, offset: f32) -> 
     let max_values = vec![offset + 20.2, offset + 12.2, offset + 34.2];
 
     let univariate_id = UInt64Array::from(vec![1, 2, 3]);
-    let model_type_id = UInt8Array::from(vec![2, 3, 3]);
+    let model_type_id = UInt8Array::from(vec![1, 1, 2]);
     let start_time = TimestampArray::from(start_times);
     let end_time = TimestampArray::from(end_times);
     let timestamps = BinaryArray::from_vec(vec![b"", b"", b""]);
     let min_value = ValueArray::from(min_values);
     let max_value = ValueArray::from(max_values);
-    let values = BinaryArray::from_vec(vec![b"1111", b"1000", b"0000"]);
+    let values = BinaryArray::from_vec(vec![b"", b"", b""]);
     let residuals = BinaryArray::from_vec(vec![b"", b"", b""]);
     let error = Float32Array::from(vec![0.2, 0.5, 0.1]);
 

--- a/crates/modelardb_server/src/storage/data_transfer.rs
+++ b/crates/modelardb_server/src/storage/data_transfer.rs
@@ -249,7 +249,7 @@ mod tests {
 
     const TABLE_NAME: &str = "table";
     const COLUMN_INDEX: u16 = 5;
-    const COMPRESSED_FILE_SIZE: usize = 2342;
+    const COMPRESSED_FILE_SIZE: usize = 2311;
 
     // Tests for path_is_compressed_file().
     #[test]
@@ -397,7 +397,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_data_transferred(vec![apache_parquet_path], target_dir, data_transfer).await;
+        assert_data_transferred(vec![apache_parquet_path], target_dir, data_transfer, 3).await;
     }
 
     #[tokio::test]
@@ -420,7 +420,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_data_transferred(vec![path_1, path_2], target_dir, data_transfer).await;
+        assert_data_transferred(vec![path_1, path_2], target_dir, data_transfer, 4).await;
     }
 
     #[tokio::test]
@@ -436,7 +436,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_data_transferred(vec![apache_parquet_path], target_dir, data_transfer).await;
+        assert_data_transferred(vec![apache_parquet_path], target_dir, data_transfer, 3).await;
     }
 
     #[tokio::test]
@@ -449,7 +449,7 @@ mod tests {
         // Since the max batch size is 1 byte smaller than 3 compressed files, the data should be transferred immediately.
         let (target_dir, data_transfer) = create_data_transfer_component(temp_dir.path()).await;
 
-        assert_data_transferred(vec![path_1, path_2, path_3], target_dir, data_transfer).await;
+        assert_data_transferred(vec![path_1, path_2, path_3], target_dir, data_transfer, 5).await;
     }
 
     #[tokio::test]
@@ -461,7 +461,7 @@ mod tests {
 
         data_transfer.flush().await.unwrap();
 
-        assert_data_transferred(vec![path_1, path_2], target_dir, data_transfer).await;
+        assert_data_transferred(vec![path_1, path_2], target_dir, data_transfer, 4).await;
     }
 
     /// Assert that the files in `paths` are all removed, a file has been created in `target_dir`,
@@ -470,6 +470,7 @@ mod tests {
         paths: Vec<PathBuf>,
         target: TempDir,
         data_transfer: DataTransfer,
+        expected_num_rows: usize,
     ) {
         for path in &paths {
             assert!(!path.exists());
@@ -486,7 +487,7 @@ mod tests {
         let batch = StorageEngine::read_batch_from_apache_parquet_file(target_path.as_path())
             .await
             .unwrap();
-        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(batch.num_rows(), expected_num_rows);
 
         assert_eq!(
             *data_transfer

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -449,16 +449,13 @@ impl UncompressedDataManager {
         let error_bound = in_memory_data_buffer.error_bound();
 
         // unwrap() is safe to use since uncompressed_timestamps and uncompressed_values have the same length.
-        let compressed_segments = modelardb_compression::try_compress(
+        Ok(modelardb_compression::try_compress(
             univariate_id,
             error_bound,
             uncompressed_timestamps,
             uncompressed_values,
         )
-        .unwrap();
-
-        modelardb_compression::try_merge_segments(compressed_segments)
-            .map_err(|error| IOError::new(IOErrorKind::InvalidData, error.to_string()))
+        .unwrap())
     }
 
     /// Spill the first [`UncompressedInMemoryDataBuffer`] in the queue of


### PR DESCRIPTION
This PR changes the code that merges segments to determine if models can be merged based on their decoded coefficients instead of their encoded representation stored in the segments. This is necessary as models with the same encoded representation is not guaranteed to produce the same values while models with the same decoded coefficients are. In addition it removes the attempt to merge segments in newly compressed batches as adjacent segments with equivalent models should never be produced by the compression.