### PR TITLE
Fixed validation of Azure Blob Storage object stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,6 +1922,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tonic",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/modelardb_common/Cargo.toml
+++ b/crates/modelardb_common/Cargo.toml
@@ -27,6 +27,7 @@ object_store = { workspace = true, features = ["aws", "azure"] }
 once_cell.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio-rustls"] }
 tonic.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 futures.workspace = true

--- a/crates/modelardb_common/src/arguments.rs
+++ b/crates/modelardb_common/src/arguments.rs
@@ -129,28 +129,9 @@ impl FromStr for RemoteDataFolderType {
     }
 }
 
-/// Extract the remote data folder type from the arguments and validate that the remote data folder can be
-/// accessed. If the remote data folder cannot be accessed, return the error that occurred as a [`String`].
-pub async fn validate_remote_data_folder_from_argument(
-    argument: &str,
-    remote_data_folder: &Arc<dyn ObjectStore>,
-) -> Result<(), String> {
-    if let Some(split_argument) = argument.split_once("://") {
-        let object_store_type = split_argument.0;
-        let remote_data_folder_type = RemoteDataFolderType::from_str(object_store_type)?;
-
-        validate_remote_data_folder(remote_data_folder_type, remote_data_folder).await
-    } else {
-        Err(format!(
-            "Remote data folder argument '{argument}' is invalid."
-        ))
-    }
-}
-
 /// Validate that the remote data folder can be accessed. If the remote data folder cannot be
 /// accessed, return the error that occurred as a [`String`].
 pub async fn validate_remote_data_folder(
-    remote_data_folder_type: RemoteDataFolderType,
     remote_data_folder: &Arc<dyn ObjectStore>,
 ) -> Result<(), String> {
     let invalid_path = Uuid::new_v4().to_string();
@@ -212,7 +193,7 @@ pub async fn parse_s3_arguments(data: &[u8]) -> Result<Arc<dyn ObjectStore>, Sta
             .map_err(|error| Status::invalid_argument(error.to_string()))?,
     );
 
-    validate_remote_data_folder(RemoteDataFolderType::S3, &s3)
+    validate_remote_data_folder(&s3)
         .await
         .map_err(Status::invalid_argument)?;
 
@@ -239,7 +220,7 @@ pub async fn parse_azure_blob_storage_arguments(
             .map_err(|error| Status::invalid_argument(error.to_string()))?,
     );
 
-    validate_remote_data_folder(RemoteDataFolderType::AzureBlobStorage, &azure_blob_storage)
+    validate_remote_data_folder(&azure_blob_storage)
         .await
         .map_err(Status::invalid_argument)?;
 

--- a/crates/modelardb_common/src/arguments.rs
+++ b/crates/modelardb_common/src/arguments.rs
@@ -18,7 +18,6 @@
 
 use std::env;
 use std::io::Write;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use object_store::{aws::AmazonS3Builder, azure::MicrosoftAzureBuilder, path::Path, ObjectStore};
@@ -104,28 +103,6 @@ pub fn argument_to_connection_info(argument: &str) -> Result<Vec<u8>, String> {
                 .collect())
         }
         _ => Err(REMOTE_DATA_FOLDER_ERROR.to_owned()),
-    }
-}
-
-/// The object stores that are currently supported as remote data folders.
-#[derive(PartialEq, Eq)]
-pub enum RemoteDataFolderType {
-    S3,
-    AzureBlobStorage,
-}
-
-impl FromStr for RemoteDataFolderType {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "s3" => Ok(RemoteDataFolderType::S3),
-            "azureblobstorage" => Ok(RemoteDataFolderType::AzureBlobStorage),
-            _ => Err(format!(
-                "'{}' is not a valid value for RemoteDataFolderType.",
-                value
-            )),
-        }
     }
 }
 

--- a/crates/modelardb_common/src/arguments.rs
+++ b/crates/modelardb_common/src/arguments.rs
@@ -111,6 +111,7 @@ pub fn argument_to_connection_info(argument: &str) -> Result<Vec<u8>, String> {
 pub async fn validate_remote_data_folder(
     remote_data_folder: &Arc<dyn ObjectStore>,
 ) -> Result<(), String> {
+    // Use an UUID for the path to minimize the chance of the path existing in the object store.
     let invalid_path = Uuid::new_v4().to_string();
 
     // Check that the connection is valid by attempting to retrieve a file that does not exist.

--- a/crates/modelardb_manager/src/main.rs
+++ b/crates/modelardb_manager/src/main.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use modelardb_common::arguments::{
     argument_to_connection_info, argument_to_remote_object_store, collect_command_line_arguments,
-    validate_remote_data_folder_from_argument,
+    validate_remote_data_folder,
 };
 use once_cell::sync::Lazy;
 use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
@@ -76,11 +76,7 @@ fn main() -> Result<(), String> {
 
     let context = runtime.block_on(async {
         let (connection, remote_data_folder) = parse_command_line_arguments(&arguments).await?;
-        validate_remote_data_folder_from_argument(
-            arguments.get(1).unwrap(),
-            remote_data_folder.object_store(),
-        )
-        .await?;
+        validate_remote_data_folder(remote_data_folder.object_store()).await?;
 
         let metadata_manager = MetadataManager::try_new(connection)
             .await

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -114,14 +114,9 @@ fn main() -> Result<(), String> {
     let (server_mode, cluster_mode, data_folders) =
         runtime.block_on(parse_command_line_arguments(&arguments))?;
 
-    // TODO: Check if the remote data folder can be validated without the remote data folder type.
-    //       If not possible, extract the remote data folder type when parsing the arguments.
-    // If a remote data folder was provided, check that it can be accessed. If the cluster mode is
-    // "MultiNode" we assume the remote object store was validated by the manager.
-    if cluster_mode != ClusterMode::MultiNode {
-        if let Some(remote_data_folder) = &data_folders.remote_data_folder {
-            runtime.block_on(async { validate_remote_data_folder(remote_data_folder).await })?;
-        }
+    // If a remote data folder was provided, check that it can be accessed.
+    if let Some(remote_data_folder) = &data_folders.remote_data_folder {
+        runtime.block_on(async { validate_remote_data_folder(remote_data_folder).await })?;
     }
 
     // Create the components for the Context.

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -37,7 +37,7 @@ use datafusion::execution::context::{SessionConfig, SessionContext, SessionState
 use datafusion::execution::runtime_env::RuntimeEnv;
 use modelardb_common::arguments::{
     argument_to_remote_object_store, collect_command_line_arguments, encode_argument,
-    parse_object_store_arguments, validate_remote_data_folder_from_argument,
+    parse_object_store_arguments, validate_remote_data_folder,
 };
 use modelardb_common::types::{ClusterMode, ServerMode};
 use object_store::{local::LocalFileSystem, ObjectStore};
@@ -120,13 +120,7 @@ fn main() -> Result<(), String> {
     // "MultiNode" we assume the remote object store was validated by the manager.
     if cluster_mode != ClusterMode::MultiNode {
         if let Some(remote_data_folder) = &data_folders.remote_data_folder {
-            runtime.block_on(async {
-                validate_remote_data_folder_from_argument(
-                    arguments.get(2).unwrap(),
-                    remote_data_folder,
-                )
-                .await
-            })?;
+            runtime.block_on(async { validate_remote_data_folder(remote_data_folder).await })?;
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug that made it possible to start the server with an Azure Blob Storage object store with valid connection information but an invalid container name. Object stores are now only seen as valid if the connection information is correct and the container/bucket exists. 

Since it is no longer necessary to pass the remote data folder type, the struct has been removed as well as the corresponding utility function. Furthermore, since the interface is simpler, the server now also validates the object store it receives from the manager if started in `MultiNode` mode. 