### PR TITLE
New integration tests for existing actions

### DIFF
--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -427,11 +427,11 @@ impl TestContext {
             .block_on(async { self.client.do_action(Request::new(action)).await })
     }
 
-    /// Retrieve the response of the action with the name `action` and convert it into an Apache
-    /// Arrow record batch.
-    fn retrieve_action_record_batch(&mut self, action: &str) -> RecordBatch {
+    /// Retrieve the response of the action with the type `action_type` and convert it into an
+    /// Apache Arrow record batch.
+    fn retrieve_action_record_batch(&mut self, action_type: &str) -> RecordBatch {
         let action = Action {
-            r#type: action.to_owned(),
+            r#type: action_type.to_owned(),
             body: Bytes::new(),
         };
 


### PR DESCRIPTION
This PR adds a few integration tests to the actions `CollectMetrics` and `UpdateConfiguration`/`GetConfiguration`. These actions were previously not tested properly since the actions return the response in raw bytes and we were not able to find a method to read these bytes into a record batch. 

This PR adds a method to do this and adds a few tests that use this method to finally test the actions. 