### PR TITLE
Fixed broken documentation link and made other links local

### DIFF
--- a/crates/modelardb_compression_python/README.md
+++ b/crates/modelardb_compression_python/README.md
@@ -8,7 +8,7 @@ and
 [jhoekx/python-rust-arrow-interop-example](https://github.com/jhoekx/python-rust-arrow-interop-example/blob/master/src/lib.rs).
 
 ## Installation
-1. Install the [dependencies](https://github.com/ModelarData/ModelarDB-RS#installation) required to build ModelarDB's compression library.
+1. Install the [dependencies](/docs/user/README.md#installation) required to build ModelarDB's compression library.
 2. Install and test the Python module using Python:
    * Install: `python3 -m pip install .`
    * Run Tests: `python3 -m unittest`

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -19,11 +19,11 @@ one exists, e.g., the bug report if it is a bugfix, and as a new GitHub issue ot
 ## Structure
 The ModelarDB project consists of the following crates:
 
-- [modelardb_client](https://github.com/ModelarData/ModelarDB-RS/tree/master/crates/modelardb_client) - ModelarDB's command-line client in the form of the binary `modelardb`.
-- [modelardb_common](https://github.com/ModelarData/ModelarDB-RS/tree/master/crates/modelardb_common) - Library providing shared functions, macros, and types for use by the other crates.
-- [modelardb_compression](https://github.com/ModelarData/ModelarDB-RS/tree/master/crates/modelardb_compression) - Library providing lossless and lossy model-based compression of time series.
-- [modelardb_compression_python](https://github.com/ModelarData/ModelarDB-RS/tree/master/crates/modelardb_compression_python) - Python interface for the modelardb_compression crate.
-- [modelardb_server](https://github.com/ModelarData/ModelarDB-RS/tree/master/crates/modelardb_server) - The ModelarDB server in the form of the binary `modelardbd`.
+- [modelardb_client](/crates/modelardb_client) - ModelarDB's command-line client in the form of the binary `modelardb`.
+- [modelardb_common](/crates/modelardb_common) - Library providing shared functions, macros, and types for use by the other crates.
+- [modelardb_compression](/crates/modelardb_compression) - Library providing lossless and lossy model-based compression of time series.
+- [modelardb_compression_python](/crates/modelardb_compression_python) - Python interface for the modelardb_compression crate.
+- [modelardb_server](/crates/modelardb_server) - The ModelarDB server in the form of the binary `modelardbd`.
 
 ## Components
 Each major component in the ModelarDB server is described in detail to support further development of the components

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -262,7 +262,7 @@ It is however ideal to use for experimenting with `modelardbd` or when developin
 
 Downloading [Docker Desktop](https://docs.docker.com/desktop/) is recommended to make maintenance of the created
 containers easier. Once [Docker](https://docs.docker.com/) is set up, the [MinIO](https://min.io/) instance can be
-created by running the services defined in [docker-compose-minio.yml](docker-compose-minio.yml). The services can
+created by running the services defined in [docker-compose-minio.yml](/docker-compose-minio.yml). The services can
 be built and started using the command:
 
 ```shell

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -61,7 +61,7 @@ AWS_ALLOW_HTTP
 
 For example, to use a local instance of [MinIO](https://min.io/), assuming the access key id `KURo1eQeMhDeVsrz` and the
 secret access key `sp7TDyD2ZruJ0VdFHmkacT1Y90PVPF7p` has been created through
-[MinIO's web interface](http://127.0.0.1:9001/access-keys), set the environment variables as follows:
+MinIO's command line tool or web interface, set the environment variables as follows:
 
 ```shell
 AWS_ACCESS_KEY_ID="KURo1eQeMhDeVsrz"
@@ -71,9 +71,8 @@ AWS_ENDPOINT="http://127.0.0.1:9000"
 AWS_ALLOW_HTTP="true"
 ```
 
-Then, assuming a bucket named `wind-turbine` has been created through
-[MinIO's web interface](http://127.0.0.1:9001/buckets), `modelardbd` can be run in edge mode with automatic transfer of
-the ingested time series to the MinIO bucket `wind-turbine`:
+Then, assuming a bucket named `wind-turbine` has been created through MinIO's command line tool or web interface, `modelardbd` 
+can be run in edge mode with automatic transfer of the ingested time series to the MinIO bucket `wind-turbine`:
 
 ```shell
 modelardbd edge path_to_local_data_folder s3://wind-turbine
@@ -271,7 +270,7 @@ docker-compose -p modelardata-minio -f docker-compose-minio.yml up
 
 After the [MinIO](https://min.io/) service is created, a [MinIO](https://min.io/) client is used to initialize
 the development bucket `modelardata`, if it does not already exist. [MinIO](https://min.io/) can be administered through
-its [web interface](http://localhost:9001). The default username and password, `minioadmin`, can be used to log in.
+its [web interface](http://127.0.0.1:9001). The default username and password, `minioadmin`, can be used to log in.
 A separate compose file is used for [MinIO](https://min.io/) so an existing [MinIO](https://min.io/) instance can be
 used when `modelardbd` is deployed using [Docker](https://docker.com/), if necessary.
 


### PR DESCRIPTION
This PR fixes a link in the user documentation that linked to a file in the repository that did not exist. It also makes some links to files in the repository use a local path instead of using the `Github` path. This makes it a bit more future proof since the links will not break if the repository host is moved and it also ensures that we link to the files in the current branch and not always the master branch. 