### PR TITLE
Add sorting by time to UncompressedDataBuffer

### DIFF
--- a/crates/modelardb_compression/src/merge.rs
+++ b/crates/modelardb_compression/src/merge.rs
@@ -157,7 +157,7 @@ fn compute_mergeable_segments(
 }
 
 /// Return [`true`] if the segments are from the same time series, the time intervals the segments
-/// represent data for does not overlap due to out of order data points, the segment at
+/// represent data for do not overlap due to out of order data points, the segment at
 /// `previous_index` does not store any residuals, their models are of the same type, and their
 /// models can be merged, otherwise [`false`]. Assumes the arrays are the same length and that
 /// `previous_index` and `current_index` both access values in the arrays.

--- a/crates/modelardb_compression/src/merge.rs
+++ b/crates/modelardb_compression/src/merge.rs
@@ -156,10 +156,11 @@ fn compute_mergeable_segments(
     }
 }
 
-/// Return [`true`] if the segment at `previous_index` does not store any residuals and the models
-/// at `previous_index` and `current_index` represent values from the same time series, are of the
-/// same type, and can be merged, otherwise [`false`]. Assumes the arrays are the same length and
-/// that `previous_index` and `current_index` both access values in the arrays.
+/// Return [`true`] if the segments are from the same time series, the time intervals the segments
+/// represent data for does not overlap due to out of order data points, the segment at
+/// `previous_index` does not store any residuals, their models are of the same type, and their
+/// models can be merged, otherwise [`false`]. Assumes the arrays are the same length and that
+/// `previous_index` and `current_index` both access values in the arrays.
 fn segments_can_be_merged(
     previous_index: usize,
     current_index: usize,
@@ -179,6 +180,14 @@ fn segments_can_be_merged(
 
     // Only segments from the same time series can be merged
     if univariate_ids.value(previous_index) != univariate_ids.value(current_index) {
+        return false;
+    }
+
+    // Segments with overlapping time intervals occurs when data points are being ingested
+    // out-of-order across different batches. Such segments cannot be merged as the query engine
+    // assumes all columns in a model table has the same sort order and it would change the order
+    // for a single column in the table if segments with out-of-order data points are merged.
+    if  end_times.value(previous_index) >= start_times.value(current_index) {
         return false;
     }
 
@@ -504,6 +513,22 @@ mod tests {
             &UInt8Array::from_iter_values([models::PMC_MEAN_ID, models::PMC_MEAN_ID]),
             &TimestampArray::from_iter_values([100, 300]),
             &TimestampArray::from_iter_values([200, 400]),
+            &ValueArray::from_iter_values([1.0, 1.0]),
+            &ValueArray::from_iter_values([2.0, 2.0]),
+            &BinaryArray::from_iter_values([[], []]),
+            &BinaryArray::from_iter_values([[], []])
+        ))
+    }
+
+    #[test]
+    fn test_models_with_overlapping_timestamps_cannot_be_merged() {
+        assert!(!segments_can_be_merged(
+            0,
+            1,
+            &UInt64Array::from_iter_values([1, 1]),
+            &UInt8Array::from_iter_values([models::PMC_MEAN_ID, models::PMC_MEAN_ID]),
+            &TimestampArray::from_iter_values([100, 200]),
+            &TimestampArray::from_iter_values([300, 400]),
             &ValueArray::from_iter_values([1.0, 1.0]),
             &ValueArray::from_iter_values([2.0, 2.0]),
             &BinaryArray::from_iter_values([[], []]),

--- a/crates/modelardb_server/src/storage/uncompressed_data_buffer.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_buffer.rs
@@ -27,6 +27,7 @@ use std::{fmt, fs, mem};
 
 use async_trait::async_trait;
 use datafusion::arrow::array::{Array, ArrayBuilder};
+use datafusion::arrow::compute::{self, SortColumn};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::parquet::errors::ParquetError;
 use modelardb_common::metadata::model_table_metadata::ModelTableMetadata;
@@ -198,14 +199,31 @@ impl fmt::Debug for UncompressedInMemoryDataBuffer {
 
 #[async_trait]
 impl UncompressedDataBuffer for UncompressedInMemoryDataBuffer {
-    /// Finish the array builders and return the data in a structured [`RecordBatch`].
+    /// Finish the array builders and return the data in a [`RecordBatch`] sorted by time.
     async fn record_batch(&mut self) -> Result<RecordBatch, ParquetError> {
-        let timestamps = self.timestamps.finish();
+        // SortColumn requires that the values are in an Arc but this is not needed for take.
+        let timestamps = Arc::new(self.timestamps.finish());
         let values = self.values.finish();
 
+        // sort_to_indices is used instead of lexsort as it is unclear how lexsort sorts multiple
+        // arrays, instead the same combination of sort_to_indices and take used in lexsort is used.
+        // unwrap() is safe as only supported types are sorted and indices cannot be out of bounds.
+        let sort_indices = compute::lexsort_to_indices(
+            &[SortColumn {
+                values: timestamps.clone(),
+                options: None,
+            }],
+            None,
+        )
+        .unwrap();
+
+        let sorted_timestamps = compute::take(&*timestamps, &sort_indices, None).unwrap();
+        let sorted_values = compute::take(&values, &sort_indices, None).unwrap();
+
+        // unwrap() is safe as UNCOMPRESSED_SCHEMA contains timestamps and values.
         Ok(RecordBatch::try_new(
             UNCOMPRESSED_SCHEMA.0.clone(),
-            vec![Arc::new(timestamps), Arc::new(values)],
+            vec![Arc::new(sorted_timestamps), Arc::new(sorted_values)],
         )
         .unwrap())
     }
@@ -330,8 +348,8 @@ impl fmt::Debug for UncompressedOnDiskDataBuffer {
 #[async_trait]
 impl UncompressedDataBuffer for UncompressedOnDiskDataBuffer {
     /// Read the data from the Apache Parquet file, delete the Apache Parquet file, and return the
-    /// data as a [`RecordBatch`]. Return [`ParquetError`] if the Apache Parquet file cannot be read
-    /// or deleted.
+    /// data as a [`RecordBatch`] sorted by time. Return [`ParquetError`] if the Apache Parquet file
+    /// cannot be read or deleted.
     async fn record_batch(&mut self) -> Result<RecordBatch, ParquetError> {
         let record_batch =
             StorageEngine::read_batch_from_apache_parquet_file(self.file_path.as_path()).await?;
@@ -389,6 +407,10 @@ impl UncompressedDataBuffer for UncompressedOnDiskDataBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use proptest::num::u64 as ProptestTimestamp;
+    use proptest::{collection, proptest};
+    use tokio::runtime::Runtime;
 
     use crate::common_test;
 
@@ -516,6 +538,30 @@ mod tests {
         assert_eq!(data.num_rows(), capacity);
     }
 
+    proptest! {
+    #[test]
+    fn test_record_batch_from_in_memory_data_buffer_is_sorted(timestamps in collection::vec(ProptestTimestamp::ANY, 1..50)) {
+        // tokio::test is not supported in proptest! due to proptest-rs/proptest/issues/179
+        let runtime = Runtime::new().unwrap();
+
+        let mut uncompressed_buffer = UncompressedInMemoryDataBuffer::new(
+            UNIVARIATE_ID,
+            common_test::model_table_metadata_arc(),
+            CURRENT_BATCH_INDEX,
+        );
+
+        // u64 is generated and then cast to i64 to ensure only positive values are generated.
+        for timestamp in timestamps {
+            uncompressed_buffer.insert_data(CURRENT_BATCH_INDEX, timestamp as i64, 0.0);
+        }
+
+        let data = runtime.block_on(uncompressed_buffer.record_batch()).unwrap();
+        assert_eq!(data.num_columns(), 2);
+        let timestamps = modelardb_common::array!(data, 0, TimestampArray);
+        assert!(timestamps.values().windows(2).all(|pair| pair[0] <= pair[1]));
+    }
+    }
+
     #[tokio::test]
     async fn test_in_memory_data_buffer_can_spill_not_full_buffer() {
         let mut uncompressed_buffer = UncompressedInMemoryDataBuffer::new(
@@ -607,6 +653,13 @@ mod tests {
             .await
             .unwrap();
 
+        let spilled_buffer_path = temp_dir
+            .path()
+            .join(UNCOMPRESSED_DATA_FOLDER)
+            .join("1")
+            .join("1234567890123.parquet");
+        assert!(spilled_buffer_path.exists());
+
         let data = uncompressed_on_disk_buffer.record_batch().await.unwrap();
 
         assert_eq!(data.num_columns(), 2);
@@ -618,6 +671,43 @@ mod tests {
             .join("1")
             .join("1234567890123.parquet");
         assert!(!spilled_buffer_path.exists());
+    }
+
+    proptest! {
+    #[test] fn test_record_batch_from_on_disk_data_buffer_is_sorted(timestamps in collection::vec(ProptestTimestamp::ANY, 1..50)) {
+        // tokio::test is not supported in proptest! due to proptest-rs/proptest/issues/179
+        let runtime = Runtime::new().unwrap();
+
+        let mut uncompressed_in_memory_buffer = UncompressedInMemoryDataBuffer::new(
+            UNIVARIATE_ID,
+            common_test::model_table_metadata_arc(),
+            CURRENT_BATCH_INDEX,
+        );
+
+        // u64 is generated and then cast to i64 to ensure only positive values are generated.
+        for timestamp in timestamps {
+            uncompressed_in_memory_buffer.insert_data(CURRENT_BATCH_INDEX, timestamp as i64, 0.0);
+        }
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut uncompressed_on_disk_buffer = runtime.block_on(uncompressed_in_memory_buffer
+            .spill_to_apache_parquet(temp_dir.path()))
+            .unwrap();
+
+        let spilled_buffer_folder = temp_dir
+            .path()
+            .join(UNCOMPRESSED_DATA_FOLDER)
+            .join("1");
+
+        assert_eq!(fs::read_dir(&spilled_buffer_folder).unwrap().count(), 1);
+
+        let data = runtime.block_on(uncompressed_on_disk_buffer.record_batch()).unwrap();
+        assert_eq!(data.num_columns(), 2);
+        let timestamps = modelardb_common::array!(data, 0, TimestampArray);
+        assert!(timestamps.values().windows(2).all(|pair| pair[0] <= pair[1]));
+
+        assert_eq!(fs::read_dir(&spilled_buffer_folder).unwrap().count(), 0);
+    }
     }
 
     /// Insert `count` generated data points into `uncompressed_buffer`.


### PR DESCRIPTION
This PR makes `UncompressedDataBuffer.record_batch()` always return a `RecordBatch` sorted by time to support out-of-order data points. As all `FIELD` and `TAG` columns in a `MODEL TABLE` shares the timestamps and each ingested data point must contain a value for all columns (i.e., `NULL` values cannot occur), sorting each `UncompressedDataBuffer` by time should always preserve the global sort order required for query processing.