### PR TITLE
Fix minor consistency errors in StorageEngine

### DIFF
--- a/crates/modelardb_server/src/storage/compressed_data_buffer.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_buffer.rs
@@ -119,7 +119,7 @@ impl CompressedDataBuffer {
         // end timestamp of the last segment in batch, the minimum value stored in batch, and the
         // maximum value stored in batch as the file name to support efficiently pruning files that
         // only contains data points with timestamps and values that are not relevant for a query.
-        let file_name = storage::create_time_and_value_range_file_name(&batch);
+        let file_name = storage::StorageEngine::create_time_and_value_range_file_name(&batch);
         let file_path = folder_path.join(file_name);
 
         // Specify that the file must be sorted by univariate_id and then by start_time.
@@ -192,7 +192,7 @@ mod tests {
 
         // Data should be saved to a file with the start time, end time, min value, and max value of
         // the compressed segments the file contains as the file name.
-        let file_path = storage::create_time_and_value_range_file_name(&segment);
+        let file_path = storage::StorageEngine::create_time_and_value_range_file_name(&segment);
         assert!(temp_dir.path().join(file_path).exists());
     }
 

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -235,7 +235,7 @@ impl CompressedDataManager {
     /// * A column with `column_index` does not exist.
     /// * The end time is before the start time.
     /// * The max value is smaller than the min value.
-    pub(super) async fn get_saved_compressed_files(
+    pub(super) async fn compressed_files(
         &self,
         table_name: &str,
         column_index: u16,
@@ -729,7 +729,7 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
         let result = data_manager
-            .get_saved_compressed_files(
+            .compressed_files(
                 TABLE_NAME,
                 COLUMN_INDEX,
                 None,
@@ -750,7 +750,7 @@ mod tests {
 
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
-        let result = data_manager.get_saved_compressed_files(
+        let result = data_manager.compressed_files(
             TABLE_NAME,
             COLUMN_INDEX,
             None,
@@ -775,7 +775,7 @@ mod tests {
 
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
-        let result = data_manager.get_saved_compressed_files(
+        let result = data_manager.compressed_files(
             TABLE_NAME,
             COLUMN_INDEX,
             start_time,
@@ -805,7 +805,7 @@ mod tests {
 
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
-        let result = data_manager.get_saved_compressed_files(
+        let result = data_manager.compressed_files(
             TABLE_NAME,
             COLUMN_INDEX,
             None,
@@ -835,7 +835,7 @@ mod tests {
 
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
-        let result = data_manager.get_saved_compressed_files(
+        let result = data_manager.compressed_files(
             TABLE_NAME,
             COLUMN_INDEX,
             None,
@@ -865,7 +865,7 @@ mod tests {
 
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
-        let result = data_manager.get_saved_compressed_files(
+        let result = data_manager.compressed_files(
             TABLE_NAME,
             COLUMN_INDEX,
             None,
@@ -901,7 +901,7 @@ mod tests {
 
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
-        let result = data_manager.get_saved_compressed_files(
+        let result = data_manager.compressed_files(
             TABLE_NAME,
             COLUMN_INDEX,
             start_time,
@@ -944,7 +944,7 @@ mod tests {
 
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
-        let result = data_manager.get_saved_compressed_files(
+        let result = data_manager.compressed_files(
             TABLE_NAME,
             COLUMN_INDEX,
             None,
@@ -1014,7 +1014,7 @@ mod tests {
             .unwrap();
 
         let object_store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
-        let result = data_manager.get_saved_compressed_files(
+        let result = data_manager.compressed_files(
             TABLE_NAME,
             COLUMN_INDEX,
             Some(10),
@@ -1042,7 +1042,7 @@ mod tests {
             .unwrap();
 
         let object_store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new());
-        let result = data_manager.get_saved_compressed_files(
+        let result = data_manager.compressed_files(
             TABLE_NAME,
             COLUMN_INDEX,
             None,
@@ -1076,7 +1076,7 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
         let result = data_manager
-            .get_saved_compressed_files(
+            .compressed_files(
                 TABLE_NAME,
                 COLUMN_INDEX,
                 None,
@@ -1121,7 +1121,7 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
         let result = data_manager
-            .get_saved_compressed_files(
+            .compressed_files(
                 "NO_TABLE",
                 COLUMN_INDEX,
                 None,

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -62,7 +62,7 @@ pub(super) struct CompressedDataManager {
     pub(super) used_compressed_memory_metric: Mutex<Metric>,
     /// Metric for the total used disk space in bytes, updated every time a new compressed file is
     /// saved to disk.
-    pub used_disk_space_metric: Arc<Mutex<Metric>>,
+    pub(super) used_disk_space_metric: Arc<Mutex<Metric>>,
 }
 
 impl CompressedDataManager {

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -1092,8 +1092,9 @@ mod tests {
         assert_eq!(files.len(), 1);
 
         // The file should have the first start time and the last end time as the file name.
-        let file_name =
-            storage::create_time_and_value_range_file_name(&segments.compressed_segments);
+        let file_name = storage::StorageEngine::create_time_and_value_range_file_name(
+            &segments.compressed_segments,
+        );
         let expected_file_path =
             format!("{COMPRESSED_DATA_FOLDER}/{TABLE_NAME}/{COLUMN_INDEX}/{file_name}");
 

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -83,7 +83,8 @@ pub(super) const COMPRESSED_DATA_FOLDER: &str = "compressed";
 pub(super) const QUERY_DATA_FOLDER_SCHEME_WITH_HOST: &str = "query://query";
 
 /// A static UUID for use in tests. It is not in a test utilities module so it can be used both
-/// inside the if cfg(test) block of [`create_time_and_value_range_file_name`] and in test modules.
+/// inside the if cfg(test) block of [`StorageEngine::create_time_and_value_range_file_name`] and in
+/// test modules.
 const TEST_UUID: Uuid = uuid!("44c57d06-333c-4935-8ae3-ed7bc53a08c4");
 
 /// The expected [first four bytes of any Apache Parquet file].
@@ -383,7 +384,7 @@ impl StorageEngine {
         // Retrieve object_metas that represent the relevant files for table_name and column_index.
         let relevant_apache_parquet_files = self
             .compressed_data_manager
-            .get_saved_compressed_files(
+            .compressed_files(
                 table_name,
                 column_index,
                 start_time,

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -83,8 +83,8 @@ pub(super) const COMPRESSED_DATA_FOLDER: &str = "compressed";
 pub(super) const QUERY_DATA_FOLDER_SCHEME_WITH_HOST: &str = "query://query";
 
 /// A static UUID for use in tests. It is not in a test utilities module so it can be used both
-/// inside the if cfg(test) block of [`StorageEngine::create_time_and_value_range_file_name`] and in
-/// test modules.
+/// inside the if cfg(test) block of [`StorageEngine::create_time_and_value_range_file_name()`] and
+/// in test modules.
 const TEST_UUID: Uuid = uuid!("44c57d06-333c-4935-8ae3-ed7bc53a08c4");
 
 /// The expected [first four bytes of any Apache Parquet file].

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -66,7 +66,7 @@ pub(super) struct UncompressedDataManager {
     /// Metric for the amount of ingested data points, updated every time a new batch of data is ingested.
     pub(super) ingested_data_points_metric: Mutex<Metric>,
     /// Metric for the total used disk space in bytes, updated every time uncompressed data is spilled.
-    pub used_disk_space_metric: Arc<Mutex<Metric>>,
+    pub(super) used_disk_space_metric: Arc<Mutex<Metric>>,
 }
 
 impl UncompressedDataManager {


### PR DESCRIPTION
This PR fixes minor consistency errors in `StorageError`. Thus, the PR purposely converts the two functions in `storage/mod.rs` into methods on `StorageEngine` as it required the smallest amount of changes to make the implementation of sub-routines that do not have a `self` parameter consistent in `StorageEngine`.