### PR TITLE
Remove test of debug_assert!() from --release

### DIFF
--- a/crates/modelardb_server/src/storage/compressed_data_buffer.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_buffer.rs
@@ -197,6 +197,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "Cannot save CompressedDataBuffer with no data.")]
     fn test_panic_if_saving_empty_compressed_data_buffer_to_apache_parquet() {
         let mut empty_compressed_data_buffer = CompressedDataBuffer::new();

--- a/crates/modelardb_server/src/storage/uncompressed_data_buffer.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_buffer.rs
@@ -503,6 +503,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "Cannot insert data into full UncompressedInMemoryDataBuffer.")]
     fn test_in_memory_data_buffer_panic_if_inserting_data_point_when_full() {
         let mut uncompressed_buffer = UncompressedInMemoryDataBuffer::new(


### PR DESCRIPTION
This PR makes it possible to run `cargo test` with `--release` in addition development builds by excluding tests that checks for `debug_assert!()` from `--release` builds.