### PR TITLE
Add integration tests and fix aggregattion

### DIFF
--- a/crates/modelardb_common/src/test/data_generation.rs
+++ b/crates/modelardb_common/src/test/data_generation.rs
@@ -179,9 +179,10 @@ pub fn generate_multivariate_time_series(
             }
         }
 
-        // Finished builders are deleted after the loop to not conflict with the loop.
+        // Builders are deleted after the loop and in reverse order to not change the indices.
         uncompressed_values_builders_to_delete
             .iter()
+            .rev()
             .for_each(|index| {
                 uncompressed_values_builders.swap_remove(*index);
             });

--- a/crates/modelardb_common/src/test/data_generation.rs
+++ b/crates/modelardb_common/src/test/data_generation.rs
@@ -114,11 +114,11 @@ pub fn generate_univariate_time_series(
 }
 
 /// Generate a univariate or multivariate time series with sub-sequences of values with different
-/// [`ValuesStructure`]. The time series will have `field_columns columns containing `length` data
+/// [`ValuesStructure`]. The time series will have `field_columns` columns containing `length` data
 /// points in sequences of `segment_length_range` (except possibly for the last as it may be
 /// truncated to match `length`) and the timestamps will be regular or irregular depending on the
 /// value of `generate_irregular_timestamps`. If `multiply_noise_range` is [`Some`], random values
-/// will be generated in the [``Range<f32>``] and multiplied with each value in the sequences with
+/// will be generated in the [`Range<f32>`] and multiplied with each value in the sequences with
 /// constant and linear values. Sequences with random values are generated in the range specified as
 /// `random_value_range`.
 pub fn generate_multivariate_time_series(

--- a/crates/modelardb_compression/src/compression.rs
+++ b/crates/modelardb_compression/src/compression.rs
@@ -686,13 +686,14 @@ mod tests {
         generate_irregular_timestamps: bool,
         multiply_noise_range: Option<Range<f32>>,
     ) {
-        let (uncompressed_timestamps, uncompressed_values) = data_generation::generate_time_series(
-            1000 * TRY_COMPRESS_TEST_LENGTH,
-            TRY_COMPRESS_TEST_LENGTH..10 * TRY_COMPRESS_TEST_LENGTH + 1,
-            generate_irregular_timestamps,
-            multiply_noise_range,
-            100.0..200.0,
-        );
+        let (uncompressed_timestamps, uncompressed_values) =
+            data_generation::generate_univariate_time_series(
+                1000 * TRY_COMPRESS_TEST_LENGTH,
+                TRY_COMPRESS_TEST_LENGTH..10 * TRY_COMPRESS_TEST_LENGTH + 1,
+                generate_irregular_timestamps,
+                multiply_noise_range,
+                100.0..200.0,
+            );
 
         let compressed_record_batch =
             compress_time_series(&uncompressed_timestamps, &uncompressed_values, error_bound);

--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -27,6 +27,7 @@ mod types;
 // Re-export the few functions and types users are meant to use.
 pub use compression::try_compress;
 pub use merge::try_merge_segments;
+pub use models::is_value_within_error_bound;
 pub use models::grid;
 pub use models::len;
 pub use models::sum;

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -46,7 +46,7 @@ pub(super) const VALUE_SIZE_IN_BYTES: u8 = mem::size_of::<Value>() as u8;
 pub(super) const VALUE_SIZE_IN_BITS: u8 = 8 * VALUE_SIZE_IN_BYTES;
 
 /// Determine if `approximate_value` is within `error_bound` of `real_value`.
-pub(super) fn is_value_within_error_bound(
+pub fn is_value_within_error_bound(
     error_bound: ErrorBound,
     real_value: Value,
     approximate_value: Value,
@@ -264,7 +264,12 @@ pub fn sum(
     if residuals.is_empty() {
         model_sum
     } else {
-        model_sum + gorilla::sum(residuals_length, residuals, Some(model_last_value))
+        let residuals_sum = gorilla::sum(
+            residuals_length - 1,
+            &residuals[..residuals.len() - 1],
+            Some(model_last_value),
+        );
+        model_sum + residuals_sum
     }
 }
 

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -265,7 +265,7 @@ pub fn sum(
         let first = slope * start_time as f64 + intercept;
         let last = slope * end_time as f64 + intercept;
         let average = (first + last) / 2.0;
-        let length = models::len(start_time, end_time, timestamps);
+        let length = models::len(start_time, end_time, timestamps) - residuals_length;
         (average * length as f64) as Value
     } else {
         let mut timestamp_builder = TimestampBuilder::new();

--- a/crates/modelardb_server/src/optimizer/model_simple_aggregates.rs
+++ b/crates/modelardb_server/src/optimizer/model_simple_aggregates.rs
@@ -726,6 +726,7 @@ impl PhysicalExpr for ModelSumPhysicalExpr {
             let min_value = min_values.value(row_index);
             let max_value = max_values.value(row_index);
             let values = values.value(row_index);
+            let residuals = residuals.value(row_index);
 
             sum += modelardb_compression::sum(
                 model_type_id,
@@ -735,7 +736,7 @@ impl PhysicalExpr for ModelSumPhysicalExpr {
                 min_value,
                 max_value,
                 values,
-                residuals.values(),
+                residuals,
             ) as f64;
         }
 
@@ -869,6 +870,7 @@ impl PhysicalExpr for ModelAvgPhysicalExpr {
             let min_value = min_values.value(row_index);
             let max_value = max_values.value(row_index);
             let values = values.value(row_index);
+            let residuals = residuals.value(row_index);
 
             sum += modelardb_compression::sum(
                 model_type_id,
@@ -878,7 +880,7 @@ impl PhysicalExpr for ModelAvgPhysicalExpr {
                 min_value,
                 max_value,
                 values,
-                residuals.values(),
+                residuals,
             );
 
             count += modelardb_compression::len(start_time, end_time, timestamps);

--- a/crates/modelardb_server/src/storage/types.rs
+++ b/crates/modelardb_server/src/storage/types.rs
@@ -514,10 +514,13 @@ mod tests {
     #[test]
     fn test_append_to_metric() {
         let mut metric = Metric::new();
-        let since_the_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-        let timestamp = since_the_epoch.as_millis() as Timestamp;
 
         metric.append(30, false);
+
+        // timestamp is measured just before metric.append() to minimize the change that enough time
+        // has passed that the timestamp written to metric is different than what the test expects.
+        let since_the_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        let timestamp = since_the_epoch.as_millis() as Timestamp;
         metric.append(30, false);
 
         assert_eq!(metric.timestamps.pop_iter().last(), Some(timestamp));

--- a/crates/modelardb_server/src/storage/types.rs
+++ b/crates/modelardb_server/src/storage/types.rs
@@ -517,7 +517,7 @@ mod tests {
 
         metric.append(30, false);
 
-        // timestamp is measured just before metric.append() to minimize the change that enough time
+        // timestamp is measured just before metric.append() to minimize the chance that enough time
         // has passed that the timestamp written to metric is different than what the test expects.
         let since_the_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
         let timestamp = since_the_epoch.as_millis() as Timestamp;

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -211,21 +211,21 @@ impl TestContext {
     fn create_table(&mut self, table_name: &str, table_type: TableType) {
         let cmd = match table_type {
             TableType::NormalTable => {
-                format!("CREATE TABLE {table_name}(timestamp TIMESTAMP, field_one REAL, field_two REAL, metadata TEXT)")
+                format!("CREATE TABLE {table_name}(timestamp TIMESTAMP,
+                         field_one REAL, field_two REAL, metadata TEXT)")
             }
             TableType::ModelTable => {
-                format!(
-                "CREATE MODEL TABLE {table_name}(timestamp TIMESTAMP, field_one FIELD, field_two FIELD, tag TAG)"
-            )
+                format!("CREATE MODEL TABLE {table_name}(timestamp TIMESTAMP,
+                         field_one FIELD, field_two FIELD, tag TAG)")
             }
             TableType::ModelTableNoTag => {
-                format!("CREATE MODEL TABLE {table_name}(timestamp TIMESTAMP, field_one FIELD, field_two FIELD)")
+                format!("CREATE MODEL TABLE {table_name}(timestamp TIMESTAMP,
+                         field_one FIELD, field_two FIELD)")
             }
             TableType::ModelTableAsField => {
-                format!(
-                    "CREATE MODEL TABLE {table_name}(timestamp TIMESTAMP,
-                 generated FIELD AS (field_one + CAST(37.0 AS REAL)), field_one FIELD, field_two FIELD)"
-                )
+                format!("CREATE MODEL TABLE {table_name}(timestamp TIMESTAMP,
+                         generated FIELD AS (field_one + CAST(37.0 AS REAL)),
+                         field_one FIELD, field_two FIELD)")
             }
         };
 

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -874,7 +874,7 @@ fn assert_ne_query_plans_and_eq_result(segment_query: String, error_bound: f32) 
     ingest_time_series_and_flush_data(&mut test_context, &[time_series], TableType::ModelTable);
 
     // The predicate will guarantee that all data points will be included in the query but will
-    // prevents the optimizer from rewriting the query due to its presence in segment_query.
+    // prevent the optimizer from rewriting the query due to its presence in segment_query.
     let data_point_query = format!("{segment_query} WHERE timestamp >= 0::TIMESTAMP");
 
     let data_point_query_plans = test_context


### PR DESCRIPTION
This PR makes the integrations tests more realistic by creating multiple `FIELD` columns for each table and adds support for generating multivariate time series to be ingested into them. In addition, all simple aggregates are now tested and additional asserts have been added to ensure one query is actually executed on data points and one query is executed on segments. These tests found a few issues regarding the implementation of `SUM()` on segments which have been fixed.