### PR TITLE
Edge nodes no longer have access to the remote metadata database

### DIFF
--- a/crates/modelardb_compression/src/models/gorilla.rs
+++ b/crates/modelardb_compression/src/models/gorilla.rs
@@ -439,7 +439,7 @@ mod tests {
             &mut univariate_id_builder,
             &[100],
             &mut value_builder,
-            maybe_model_last_value
+            maybe_model_last_value,
         );
 
         let univariate_ids = univariate_id_builder.finish();

--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -625,7 +625,7 @@ impl FlightService for FlightServiceHandler {
             let (mode, _offset_data) = decode_argument(offset_data)?;
 
             let server_mode = ServerMode::from_str(mode).map_err(Status::invalid_argument)?;
-            let node = Node::new(url.to_string(), server_mode);
+            let node = Node::new(url.to_string(), server_mode.clone());
 
             // Use the metadata manager to persist the node to the metadata database.
             self.context
@@ -650,8 +650,10 @@ impl FlightService for FlightServiceHandler {
             let remote_data_folder = self.context.remote_data_folder.read().await;
             response_body.append(&mut remote_data_folder.connection_info().clone());
 
-            let remote_metadata_manager = &self.context.remote_metadata_manager;
-            response_body.append(&mut remote_metadata_manager.connection_info().clone());
+            if server_mode == ServerMode::Cloud {
+                let remote_metadata_manager = &self.context.remote_metadata_manager;
+                response_body.append(&mut remote_metadata_manager.connection_info().clone());
+            }
 
             // Return the key for the manager, the connection info for the remote object store, and
             // if the node is a cloud node, the connection info for the metadata database.

--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -571,7 +571,7 @@ impl FlightService for FlightServiceHandler {
                 )))
             }
         } else if action.r#type == "UpdateRemoteObjectStore" {
-            let object_store = parse_object_store_arguments(&action.body).await?;
+            let (object_store, _offset_data) = parse_object_store_arguments(&action.body).await?;
 
             // Create a new remote data folder and update it in the context.
             let mut remote_data_folder = self.context.remote_data_folder.write().await;

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -170,11 +170,13 @@ mod tests {
     use std::path::Path;
     use std::sync::Arc;
 
+    use arrow_flight::flight_service_client::FlightServiceClient;
+    use modelardb_common::metadata;
     use modelardb_common::types::ServerMode;
-    use modelardb_common::{metadata, test};
     use object_store::local::LocalFileSystem;
     use tokio::runtime::Runtime;
     use tokio::sync::RwLock;
+    use tonic::transport::Channel;
     use uuid::Uuid;
 
     use crate::manager::Manager;
@@ -254,11 +256,13 @@ mod tests {
             .await
             .unwrap();
 
-        let (lazy_metadata_manager, lazy_flight_client) = test::lazy_connections();
+        let channel = Channel::builder("grpc://server:9999".parse().unwrap()).connect_lazy();
+        let lazy_flight_client = FlightServiceClient::new(channel);
+
         let manager = Manager::new(
             Arc::new(RwLock::new(lazy_flight_client)),
             Uuid::new_v4().to_string(),
-            Arc::new(lazy_metadata_manager),
+            None,
         );
 
         let configuration_manager = Arc::new(RwLock::new(ConfigurationManager::new(

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -30,9 +30,11 @@ use std::sync::Arc;
 use std::{env, fs};
 
 use modelardb_common::arguments::{collect_command_line_arguments, validate_remote_data_folder};
+use modelardb_common::metadata::TableMetadataManager;
 use modelardb_common::types::ServerMode;
 use object_store::{local::LocalFileSystem, ObjectStore};
 use once_cell::sync::Lazy;
+use sqlx::Postgres;
 use tokio::runtime::Runtime;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -52,6 +54,17 @@ pub static PORT: Lazy<u16> =
 pub enum ClusterMode {
     SingleNode,
     MultiNode(Manager),
+}
+
+impl ClusterMode {
+    /// Return the optional remote table metadata manager from the manager interface if the cluster
+    /// mode is `MultiNode`, otherwise return [`None`].
+    fn remote_table_metadata_manager(&self) -> Option<Arc<TableMetadataManager<Postgres>>> {
+        match self {
+            ClusterMode::SingleNode => None,
+            ClusterMode::MultiNode(manager) => manager.table_metadata_manager.clone(),
+        }
+    }
 }
 
 /// Folders for storing metadata and Apache Parquet files.

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -59,10 +59,10 @@ pub enum ClusterMode {
 impl ClusterMode {
     /// Return the optional remote table metadata manager from the manager interface if the cluster
     /// mode is `MultiNode`, otherwise return [`None`].
-    fn remote_table_metadata_manager(&self) -> Option<Arc<TableMetadataManager<Postgres>>> {
+    fn remote_table_metadata_manager(&self) -> &Option<Arc<TableMetadataManager<Postgres>>> {
         match self {
-            ClusterMode::SingleNode => None,
-            ClusterMode::MultiNode(manager) => manager.table_metadata_manager.clone(),
+            ClusterMode::SingleNode => &None,
+            ClusterMode::MultiNode(manager) => &manager.table_metadata_manager,
         }
     }
 }

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -320,7 +320,6 @@ impl PartialEq for Manager {
 mod tests {
     use super::*;
 
-    use modelardb_common::test;
     use uuid::Uuid;
 
     const UNRESTRICTED_ACTIONS: [&str; 5] = [
@@ -389,12 +388,13 @@ mod tests {
     }
 
     fn create_manager() -> Manager {
-        let (lazy_metadata_manager, lazy_flight_client) = test::lazy_connections();
+        let channel = Channel::builder("grpc://server:9999".parse().unwrap()).connect_lazy();
+        let lazy_flight_client = FlightServiceClient::new(channel);
 
         Manager::new(
             Arc::new(RwLock::new(lazy_flight_client)),
             Uuid::new_v4().to_string(),
-            Arc::new(lazy_metadata_manager),
+            None,
         )
     }
 }

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -99,7 +99,7 @@ impl Manager {
         let message = do_action_and_extract_result(&flight_client, action).await?;
 
         // Extract the key, the connection information for the remote object store, and if the node
-        // is cloud node, the connection information for the metadata database, from the response.
+        // is a cloud node, the connection information for the metadata database, from the response.
         let (key, offset_data) = arguments::decode_argument(&message.body)
             .map_err(|error| ModelarDbError::ImplementationError(error.to_string()))?;
 

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -50,7 +50,8 @@ pub struct Manager {
     /// Key received from the manager when registering, used to validate future requests that are
     /// only allowed to come from the manager.
     key: String,
-    /// Metadata for the tables and model tables in the remote data folder.
+    /// Metadata for the tables and model tables in the remote data folder. Note that only cloud
+    /// nodes have access to the remote metadata database.
     pub(crate) table_metadata_manager: Option<Arc<TableMetadataManager<Postgres>>>,
 }
 

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -115,7 +115,7 @@ impl Manager {
             Arc::new(table_metadata_manager),
         );
 
-        let remote_object_store = arguments::parse_object_store_arguments(offset_data)
+        let (remote_object_store, _offset_data) = arguments::parse_object_store_arguments(offset_data)
             .await
             .map_err(|error| ModelarDbError::ImplementationError(error.to_string()))?;
 

--- a/crates/modelardb_server/src/query/mod.rs
+++ b/crates/modelardb_server/src/query/mod.rs
@@ -490,8 +490,11 @@ impl TableProvider for ModelTable {
             &configuration_manager.server_mode,
             &configuration_manager.cluster_mode,
         ) {
+            // unwrap() is safe since cloud nodes always have access to the remote metadata database.
             manager
                 .table_metadata_manager
+                .clone()
+                .unwrap()
                 .mapping_from_hash_to_tags(table_name, &stored_tag_columns_in_projection)
                 .await
         } else {

--- a/crates/modelardb_server/src/query/mod.rs
+++ b/crates/modelardb_server/src/query/mod.rs
@@ -56,8 +56,7 @@ use crate::context::Context;
 use crate::query::generated_as_exec::{ColumnToGenerate, GeneratedAsExec};
 use crate::query::grid_exec::GridExec;
 use crate::query::sorted_join_exec::{SortedJoinColumnType, SortedJoinExec};
-use crate::storage;
-use crate::storage::StorageEngine;
+use crate::storage::{self, StorageEngine};
 
 /// The global sort order [`ParquetExec`] guarantees for the segments it produces and that
 /// [`GridExec`] requires for the segments its receives as its input. It is guaranteed by

--- a/crates/modelardb_server/src/query/mod.rs
+++ b/crates/modelardb_server/src/query/mod.rs
@@ -47,7 +47,7 @@ use datafusion::physical_plan::expressions::{Column, PhysicalSortExpr};
 use datafusion::physical_plan::{ExecutionPlan, PhysicalExpr, Statistics};
 use modelardb_common::metadata::model_table_metadata::ModelTableMetadata;
 use modelardb_common::schemas::{COMPRESSED_SCHEMA, QUERY_SCHEMA};
-use modelardb_common::types::{ArrowTimestamp, ArrowValue, ServerMode};
+use modelardb_common::types::{ArrowTimestamp, ArrowValue};
 use object_store::ObjectStore;
 use once_cell::sync::Lazy;
 use tokio::sync::RwLockWriteGuard;
@@ -56,8 +56,8 @@ use crate::context::Context;
 use crate::query::generated_as_exec::{ColumnToGenerate, GeneratedAsExec};
 use crate::query::grid_exec::GridExec;
 use crate::query::sorted_join_exec::{SortedJoinColumnType, SortedJoinExec};
+use crate::storage;
 use crate::storage::StorageEngine;
-use crate::{storage, ClusterMode};
 
 /// The global sort order [`ParquetExec`] guarantees for the segments it produces and that
 /// [`GridExec`] requires for the segments its receives as its input. It is guaranteed by
@@ -215,7 +215,6 @@ impl ModelTable {
                 None,
                 None,
                 None,
-                &configuration_manager.server_mode,
                 &configuration_manager.cluster_mode,
                 query_object_store,
             )
@@ -486,15 +485,11 @@ impl TableProvider for ModelTable {
         // Compute a mapping from hashes to the requested tag values in the requested order. If the
         // server is a cloud node, use the table metadata manager for the remote metadata database.
         let configuration_manager = self.context.configuration_manager.read().await;
-        let hash_to_tags = if let (ServerMode::Cloud, ClusterMode::MultiNode(manager)) = (
-            &configuration_manager.server_mode,
-            &configuration_manager.cluster_mode,
-        ) {
-            // unwrap() is safe since cloud nodes always have access to the remote metadata database.
-            manager
-                .table_metadata_manager
-                .clone()
-                .unwrap()
+        let hash_to_tags = if let Some(table_metadata_manager) = &configuration_manager
+            .cluster_mode
+            .remote_table_metadata_manager()
+        {
+            table_metadata_manager
                 .mapping_from_hash_to_tags(table_name, &stored_tag_columns_in_projection)
                 .await
         } else {

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -548,7 +548,8 @@ impl FlightService for FlightServiceHandler {
                 ));
             }
 
-            let (object_store, _offset_data) = arguments::parse_object_store_arguments(&action.body).await?;
+            let (object_store, _offset_data) =
+                arguments::parse_object_store_arguments(&action.body).await?;
 
             // Update the object store used for data transfers.
             let mut storage_engine = self.context.storage_engine.write().await;

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -548,7 +548,7 @@ impl FlightService for FlightServiceHandler {
                 ));
             }
 
-            let object_store = arguments::parse_object_store_arguments(&action.body).await?;
+            let (object_store, _offset_data) = arguments::parse_object_store_arguments(&action.body).await?;
 
             // Update the object store used for data transfers.
             let mut storage_engine = self.context.storage_engine.write().await;

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -266,8 +266,11 @@ impl CompressedDataManager {
         let relevant_object_metas = if let (ServerMode::Cloud, ClusterMode::MultiNode(manager)) =
             (server_mode, cluster_mode)
         {
+            // unwrap() is safe since cloud nodes always have access to the remote metadata database.
             manager
                 .table_metadata_manager
+                .clone()
+                .unwrap()
                 .compressed_files(
                     table_name,
                     column_index.into(),
@@ -311,8 +314,11 @@ impl CompressedDataManager {
             if let (ServerMode::Cloud, ClusterMode::MultiNode(manager)) =
                 (server_mode, cluster_mode)
             {
+                // unwrap() is safe since cloud nodes always have access to the remote metadata database.
                 manager
                     .table_metadata_manager
+                    .clone()
+                    .unwrap()
                     .replace_compressed_files(
                         table_name,
                         column_index.into(),

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -31,7 +31,7 @@ use futures::StreamExt;
 use modelardb_common::errors::ModelarDbError;
 use modelardb_common::metadata::compressed_file::CompressedFile;
 use modelardb_common::metadata::TableMetadataManager;
-use modelardb_common::types::{ServerMode, Timestamp, Value};
+use modelardb_common::types::{Timestamp, Value};
 use object_store::{ObjectMeta, ObjectStore};
 use parquet::arrow::async_reader::ParquetObjectReader;
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
@@ -257,42 +257,36 @@ impl CompressedDataManager {
         end_time: Option<Timestamp>,
         min_value: Option<Value>,
         max_value: Option<Value>,
-        server_mode: &ServerMode,
         cluster_mode: &ClusterMode,
         query_data_folder: &Arc<dyn ObjectStore>,
     ) -> Result<Vec<ObjectMeta>, ModelarDbError> {
         // Retrieve the metadata of all files that fit the given arguments. If the server is a cloud
         // node, use the table metadata manager for the remote metadata database.
-        let relevant_object_metas = if let (ServerMode::Cloud, ClusterMode::MultiNode(manager)) =
-            (server_mode, cluster_mode)
-        {
-            // unwrap() is safe since cloud nodes always have access to the remote metadata database.
-            manager
-                .table_metadata_manager
-                .clone()
-                .unwrap()
-                .compressed_files(
-                    table_name,
-                    column_index.into(),
-                    start_time,
-                    end_time,
-                    min_value,
-                    max_value,
-                )
-                .await
-        } else {
-            self.table_metadata_manager
-                .compressed_files(
-                    table_name,
-                    column_index.into(),
-                    start_time,
-                    end_time,
-                    min_value,
-                    max_value,
-                )
-                .await
-        }
-        .map_err(|error| ModelarDbError::DataRetrievalError(error.to_string()))?;
+        let relevant_object_metas =
+            if let Some(table_metadata_manager) = cluster_mode.remote_table_metadata_manager() {
+                table_metadata_manager
+                    .compressed_files(
+                        table_name,
+                        column_index.into(),
+                        start_time,
+                        end_time,
+                        min_value,
+                        max_value,
+                    )
+                    .await
+            } else {
+                self.table_metadata_manager
+                    .compressed_files(
+                        table_name,
+                        column_index.into(),
+                        start_time,
+                        end_time,
+                        min_value,
+                        max_value,
+                    )
+                    .await
+            }
+            .map_err(|error| ModelarDbError::DataRetrievalError(error.to_string()))?;
 
         // Merge the compressed Apache Parquet files if multiple are retrieved to ensure order.
         if relevant_object_metas.len() > 1 {
@@ -311,14 +305,8 @@ impl CompressedDataManager {
 
             // Replace the merged files in the metadata database. If the server is a cloud node,
             // use the table metadata manager for the remote metadata database.
-            if let (ServerMode::Cloud, ClusterMode::MultiNode(manager)) =
-                (server_mode, cluster_mode)
-            {
-                // unwrap() is safe since cloud nodes always have access to the remote metadata database.
-                manager
-                    .table_metadata_manager
-                    .clone()
-                    .unwrap()
+            if let Some(table_metadata_manager) = cluster_mode.remote_table_metadata_manager() {
+                table_metadata_manager
                     .replace_compressed_files(
                         table_name,
                         column_index.into(),

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -795,7 +795,6 @@ mod tests {
                 None,
                 None,
                 None,
-                &ServerMode::Edge,
                 &ClusterMode::SingleNode,
                 &object_store,
             )
@@ -818,7 +817,6 @@ mod tests {
             None,
             None,
             None,
-            &ServerMode::Edge,
             &ClusterMode::SingleNode,
             &object_store,
         );

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -49,7 +49,7 @@ use futures::StreamExt;
 use modelardb_common::errors::ModelarDbError;
 use modelardb_common::metadata::model_table_metadata::ModelTableMetadata;
 use modelardb_common::metadata::TableMetadataManager;
-use modelardb_common::types::{ServerMode, Timestamp, TimestampArray, Value};
+use modelardb_common::types::{Timestamp, TimestampArray, Value};
 use object_store::{ObjectMeta, ObjectStore};
 use once_cell::sync::Lazy;
 use sqlx::Sqlite;
@@ -377,7 +377,6 @@ impl StorageEngine {
         end_time: Option<Timestamp>,
         min_value: Option<Value>,
         max_value: Option<Value>,
-        server_mode: &ServerMode,
         cluster_mode: &ClusterMode,
         query_data_folder: &Arc<dyn ObjectStore>,
     ) -> Result<Vec<ObjectMeta>, ModelarDbError> {
@@ -389,7 +388,6 @@ impl StorageEngine {
                 end_time,
                 min_value,
                 max_value,
-                server_mode,
                 cluster_mode,
                 query_data_folder,
             )


### PR DESCRIPTION
For simplicity, access to the remote metadata database was handled in the same way for both cloud nodes and edge nodes which meant both technically had access to it. However, edge nodes never used this access since the local metadata database is used for querying and transfer of metadata is handled through the manager. 

To make the system both more secure (connection information is no longer transferred if not necessary) and more scalable (fewer connections to the remote metadata database) access has been removed for edge nodes. 