### PR TITLE
Collect relevant metrics in GridStream

### DIFF
--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -31,3 +31,4 @@ pub use models::grid;
 pub use models::is_value_within_error_bound;
 pub use models::len;
 pub use models::sum;
+pub use models::timestamps::are_compressed_timestamps_regular;

--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -29,6 +29,7 @@ pub use compression::try_compress;
 pub use merge::try_merge_segments;
 pub use models::grid;
 pub use models::is_value_within_error_bound;
+pub use models::{MODEL_TYPE_COUNT, MODEL_TYPE_NAMES};
 pub use models::len;
 pub use models::sum;
 pub use models::timestamps::are_compressed_timestamps_regular;

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -32,9 +32,9 @@ use modelardb_common::types::{
 
 use crate::types::CompressedSegmentBuilder;
 
-/// Unique ids for each model type. Constant values are used instead of an enum
-/// so the stored model type ids can be used in match expressions without being
-/// converted to an enum first.
+/// Unique ids for each model type. Constant values are used instead of an enum so the stored model
+/// type ids can be used in match expressions without being converted to an enum first. Any changes
+/// to the ids must be reflected in all statement matching on them and in [`GridStreamMetrics`].
 pub const PMC_MEAN_ID: u8 = 0;
 pub const SWING_ID: u8 = 1;
 pub const GORILLA_ID: u8 = 2;

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -34,7 +34,7 @@ use crate::types::CompressedSegmentBuilder;
 
 /// Unique ids for each model type. Constant values are used instead of an enum so the stored model
 /// type ids can be used in match expressions without being converted to an enum first. Any changes
-/// to the ids must be reflected in all statement matching on them and in [`GridStreamMetrics`].
+/// to the ids must be reflected in all statements matching on them and in [`GridStreamMetrics`].
 pub const PMC_MEAN_ID: u8 = 0;
 pub const SWING_ID: u8 = 1;
 pub const GORILLA_ID: u8 = 2;

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -34,10 +34,16 @@ use crate::types::CompressedSegmentBuilder;
 
 /// Unique ids for each model type. Constant values are used instead of an enum so the stored model
 /// type ids can be used in match expressions without being converted to an enum first. Any changes
-/// to the ids must be reflected in all statements matching on them and in [`GridStreamMetrics`].
+/// to the ids must be reflected in all statements matching on them.
 pub const PMC_MEAN_ID: u8 = 0;
 pub const SWING_ID: u8 = 1;
 pub const GORILLA_ID: u8 = 2;
+
+// Number of implemented model types. It is usize instead of u8 as it is used as an array length.
+pub const MODEL_TYPE_COUNT: usize = 3;
+
+// Mapping of model type ids to names.
+pub const MODEL_TYPE_NAMES: [&str; MODEL_TYPE_COUNT] = ["pmc_mean", "swing", "gorilla"];
 
 /// Size of [`Value`] in bytes.
 pub(super) const VALUE_SIZE_IN_BYTES: u8 = mem::size_of::<Value>() as u8;

--- a/crates/modelardb_server/src/query/grid_exec.rs
+++ b/crates/modelardb_server/src/query/grid_exec.rs
@@ -318,7 +318,7 @@ impl GridStream {
                 model_type_ids.value(row_index),
                 univariate_id_builder.len() - length_before,
                 !residuals.value(row_index).is_empty(),
-                modelardb_compression::are_compressed_timestamps_regular(&timestamps.values()),
+                modelardb_compression::are_compressed_timestamps_regular(timestamps.values()),
             );
         }
 


### PR DESCRIPTION
This PR makes `GridStream` collect relevant metrics that is shown when `EXPLAIN ANALYZE` is used. Are there any other metrics that are efficient to compute and relevant to add?