### PR TITLE
Prevent timestamp compression from overflowing

### DIFF
--- a/crates/modelardb_common/src/test/data_generation.rs
+++ b/crates/modelardb_common/src/test/data_generation.rs
@@ -198,15 +198,14 @@ pub fn generate_timestamps(length: usize, irregular: bool) -> TimestampArray {
     if irregular {
         let mut std_rng = create_random_number_generator();
         let mut timestamps = TimestampBuilder::with_capacity(length);
-        let mut previous_timestamp: i64 = 0;
+        let mut next_timestamp: i64 = 0;
         for _ in 0..length {
-            let next_timestamp = (std_rng.sample(Uniform::from(10..20))) + previous_timestamp;
             timestamps.append_value(next_timestamp);
-            previous_timestamp = next_timestamp;
+            next_timestamp += std_rng.sample(Uniform::from(100..200));
         }
         timestamps.finish()
     } else {
-        TimestampArray::from_iter_values((100..(length + 1) as i64 * 100).step_by(100))
+        TimestampArray::from_iter_values((0..length as i64 * 100).step_by(100))
     }
 }
 

--- a/crates/modelardb_compression/src/models/bits.rs
+++ b/crates/modelardb_compression/src/models/bits.rs
@@ -53,7 +53,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read the next `number_of_bits` bits from the [`BitReader`]. Assumes that
-    /// `number_of_bits` is less than or equal to 32.
+    /// `number_of_bits` is less than or equal to 64.
     pub fn read_bits(&mut self, number_of_bits: u8) -> u64 {
         debug_assert!(
             number_of_bits <= 64,

--- a/crates/modelardb_compression/src/models/bits.rs
+++ b/crates/modelardb_compression/src/models/bits.rs
@@ -54,10 +54,10 @@ impl<'a> BitReader<'a> {
 
     /// Read the next `number_of_bits` bits from the [`BitReader`]. Assumes that
     /// `number_of_bits` is less than or equal to 32.
-    pub fn read_bits(&mut self, number_of_bits: u8) -> u32 {
+    pub fn read_bits(&mut self, number_of_bits: u8) -> u64 {
         debug_assert!(
-            number_of_bits <= 32,
-            "The number of bits to read must be less than or equal to 32."
+            number_of_bits <= 64,
+            "The number of bits to read must be less than or equal to 64."
         );
 
         let mut value = 0;
@@ -74,7 +74,7 @@ impl<'a> BitReader<'a> {
             value = (value << 1) | bit;
         }
         self.next_bit = end_bit;
-        value as u32
+        value
     }
 }
 
@@ -108,7 +108,7 @@ impl BitVecBuilder {
     }
 
     /// Append `number_of_bits` from `bits` to the [`BitVecBuilder`].
-    pub fn append_bits(&mut self, bits: u32, number_of_bits: u8) {
+    pub fn append_bits(&mut self, bits: u64, number_of_bits: u8) {
         let mut number_of_bits = number_of_bits;
 
         while number_of_bits > 0 {
@@ -120,7 +120,7 @@ impl BitVecBuilder {
             } else {
                 // Write the remaining number_of_bits bits from bits to self.current_byte.
                 let shift = self.remaining_bits - number_of_bits;
-                let mask = (u8::MAX >> (8 - self.remaining_bits)) as u32;
+                let mask = (u8::MAX >> (8 - self.remaining_bits)) as u64;
                 self.current_byte |= ((bits << shift) & mask) as u8;
                 number_of_bits
             };
@@ -163,7 +163,7 @@ impl BitVecBuilder {
     pub fn finish_with_one_bits(mut self) -> Vec<u8> {
         if self.remaining_bits != 8 {
             let remaining_bits_to_set = 2_u8.pow(self.remaining_bits as u32) - 1;
-            self.append_bits(remaining_bits_to_set as u32, self.remaining_bits);
+            self.append_bits(remaining_bits_to_set as u64, self.remaining_bits);
         }
         self.finish()
     }

--- a/crates/modelardb_compression/src/models/timestamps.rs
+++ b/crates/modelardb_compression/src/models/timestamps.rs
@@ -116,9 +116,7 @@ fn compress_irregular_residual_timestamps(uncompressed_timestamps: &[Timestamp])
         let delta_of_delta = delta - last_delta;
 
         match delta_of_delta {
-            0 => {
-                compressed_timestamps.append_a_zero_bit()
-            },
+            0 => compressed_timestamps.append_a_zero_bit(),
             -63..=64 => {
                 compressed_timestamps.append_bits(0b10, 2);
                 compressed_timestamps.append_bits(delta_of_delta as u64, 7);
@@ -296,7 +294,7 @@ mod tests {
 
     // Tests for compress_residual_timestamps() and decompress_all_timestamps().
     #[test]
-    fn compress_timestamps_for_time_series_with_zero_one_or_two_timestamps() {
+    fn test_compress_timestamps_for_time_series_with_zero_one_or_two_timestamps() {
         let mut uncompressed_timestamps_builder = TimestampBuilder::with_capacity(3);
 
         uncompressed_timestamps_builder.append_slice(&[]);
@@ -313,98 +311,117 @@ mod tests {
     }
 
     #[test]
-    fn compress_and_decompress_timestamps_for_a_regular_time_series() {
-        compress_and_decompress_timestamps_for_a_time_series(&[
-            1579701905500,
-            1579701905600,
-            1579701905700,
-            1579701905800,
-            1579701905900,
-        ], Some(1));
+    fn test_compress_and_decompress_timestamps_for_a_regular_time_series() {
+        compress_and_decompress_timestamps_for_a_time_series(
+            &[
+                1579701905500,
+                1579701905600,
+                1579701905700,
+                1579701905800,
+                1579701905900,
+            ],
+            Some(1),
+        );
     }
 
     #[test]
-    fn compress_and_decompress_timestamps_for_an_irregular_time_series() {
-        compress_and_decompress_timestamps_for_a_time_series(&[
-            1579694400057,
-            1579694400197,
-            1579694400353,
-            1579694400493,
-            1579694400650,
-        ], Some(4));
+    fn test_compress_and_decompress_timestamps_for_an_irregular_time_series() {
+        compress_and_decompress_timestamps_for_a_time_series(
+            &[
+                1579694400057,
+                1579694400197,
+                1579694400353,
+                1579694400493,
+                1579694400650,
+            ],
+            Some(4),
+        );
     }
 
     #[test]
-    fn compress_and_decompress_bucket_sized_1_timestamps_for_an_irregular_time_series() {
-        compress_and_decompress_timestamps_for_a_time_series(&[
-            100,
-            100, // 0
-            200
-        ], Some(1));
+    fn test_compress_and_decompress_bucket_sized_1_timestamps_for_an_irregular_time_series() {
+        compress_and_decompress_timestamps_for_a_time_series(
+            &[
+                100, 100, // 0
+                200,
+            ],
+            Some(1),
+        );
     }
 
     #[test]
-    fn compress_and_decompress_bucket_sized_7_timestamps_for_an_irregular_time_series() {
-        compress_and_decompress_timestamps_for_a_time_series(&[
-            100,
-             37, // -63
-             38, //  64
-            200
-        ], Some(3));
+    fn test_compress_and_decompress_bucket_sized_7_timestamps_for_an_irregular_time_series() {
+        compress_and_decompress_timestamps_for_a_time_series(
+            &[
+                100, 37, // -63
+                38, //  64
+                200,
+            ],
+            Some(3),
+        );
     }
 
     #[test]
-    fn compress_and_decompress_bucket_sized_9_timestamps_for_an_irregular_time_series() {
-        compress_and_decompress_timestamps_for_a_time_series(&[
-            500,
-            245, // -255
-            246, //  256
-            500
-        ], Some(4));
+    fn test_compress_and_decompress_bucket_sized_9_timestamps_for_an_irregular_time_series() {
+        compress_and_decompress_timestamps_for_a_time_series(
+            &[
+                500, 245, // -255
+                246, //  256
+                500,
+            ],
+            Some(4),
+        );
     }
 
     #[test]
-    fn compress_and_decompress_fourth_bucket_12_sized_timestamps_for_an_irregular_time_series() {
-        compress_and_decompress_timestamps_for_a_time_series(&[
-            5000,
-            2953, // -2047
-            2954, //  2048
-            5000
-        ], Some(5));
+    fn test_compress_and_decompress_bucket_sized_12_timestamps_for_an_irregular_time_series() {
+        compress_and_decompress_timestamps_for_a_time_series(
+            &[
+                5000, 2953, // -2047
+                2954, //  2048
+                5000,
+            ],
+            Some(5),
+        );
     }
 
     #[test]
-    fn compress_and_decompress_fourth_bucket_32_sized_timestamps_for_an_irregular_time_series() {
-        compress_and_decompress_timestamps_for_a_time_series(&[
-            5000000000,
-            2852516353, // -2147483647
-            2852516354, //  2147483648
-            5000000000
-        ], Some(10));
+    fn test_compress_and_decompress_bucket_sized_32_timestamps_for_an_irregular_time_series() {
+        compress_and_decompress_timestamps_for_a_time_series(
+            &[
+                5000000000, 2852516353, // -2147483647
+                2852516354, //  2147483648
+                5000000000,
+            ],
+            Some(10),
+        );
     }
 
     #[test]
-    fn compress_and_decompress_timestamps_for_a_generated_regular_time_series() {
+    fn test_compress_and_decompress_timestamps_for_a_generated_regular_time_series() {
         let timestamps = generate_timestamps(1000, false);
         compress_and_decompress_timestamps_for_a_time_series(timestamps.values(), None);
     }
 
     #[test]
-    fn compress_and_decompress_timestamps_for_a_generated_irregular_time_series() {
+    fn test_compress_and_decompress_timestamps_for_a_generated_irregular_time_series() {
         let timestamps = generate_timestamps(1000, true);
         compress_and_decompress_timestamps_for_a_time_series(timestamps.values(), None);
     }
 
     proptest! {
     #[test]
-    fn compress_and_decompress_timestamps_for_a_random_irregular_time_series(timestamps in collection::vec(ProptestTimestamp::ANY, 1..50)) {
+    fn test_compress_and_decompress_timestamps_for_a_random_irregular_time_series(timestamps in collection::vec(ProptestTimestamp::ANY, 1..50)) {
         let mut timestamps = timestamps.iter().map(|ts| ts.abs()).collect::<Vec<i64>>();
         timestamps.sort();
         compress_and_decompress_timestamps_for_a_time_series(&timestamps, None);
         }
     }
 
-    fn compress_and_decompress_timestamps_for_a_time_series(uncompressed_timestamps: &[Timestamp], maybe_known_size: Option<usize>) {
+    fn compress_and_decompress_timestamps_for_a_time_series(
+        uncompressed_timestamps: &[Timestamp],
+        maybe_known_size: Option<usize>,
+    ) {
         let mut uncompressed_timestamps_builder =
             TimestampBuilder::with_capacity(uncompressed_timestamps.len());
         uncompressed_timestamps_builder.append_slice(uncompressed_timestamps);

--- a/crates/modelardb_compression/src/models/timestamps.rs
+++ b/crates/modelardb_compression/src/models/timestamps.rs
@@ -107,15 +107,11 @@ fn compress_irregular_residual_timestamps(uncompressed_timestamps: &[Timestamp])
     let mut compressed_timestamps = BitVecBuilder::new();
     compressed_timestamps.append_a_one_bit();
 
-    // Store the second timestamp as a delta using 24 bits.
-    let mut last_delta = uncompressed_timestamps[1] - uncompressed_timestamps[0];
-    compressed_timestamps.append_bits(last_delta as u32, 24); // 24-bit delta is max four hours.
-
-    // Encode the timestamps from the third timestamp to the second to last.
-    // A delta-of-delta is computed and then encoded in buckets of different
-    // sizes. Assumes that the delta-of-delta can fit in at most 32 bits.
-    let mut last_timestamp = uncompressed_timestamps[1];
-    for timestamp in &uncompressed_timestamps[2..uncompressed_timestamps.len() - 1] {
+    // Encode the timestamps from the second timestamp to the second to last. A delta-of-delta is
+    // computed and then encoded in buckets. Zero is used as the delta for the first delta-of-delta.
+    let mut last_timestamp = uncompressed_timestamps[0];
+    let mut last_delta = 0;
+    for timestamp in &uncompressed_timestamps[1..uncompressed_timestamps.len() - 1] {
         let delta = timestamp - last_timestamp;
         let delta_of_delta = delta - last_delta;
 
@@ -123,19 +119,23 @@ fn compress_irregular_residual_timestamps(uncompressed_timestamps: &[Timestamp])
             0 => compressed_timestamps.append_a_zero_bit(),
             -63..=64 => {
                 compressed_timestamps.append_bits(0b10, 2);
-                compressed_timestamps.append_bits(delta_of_delta as u32, 7);
+                compressed_timestamps.append_bits(delta_of_delta as u64, 7);
             }
             -255..=256 => {
                 compressed_timestamps.append_bits(0b110, 3);
-                compressed_timestamps.append_bits(delta_of_delta as u32, 9);
+                compressed_timestamps.append_bits(delta_of_delta as u64, 9);
             }
             -2047..=2048 => {
                 compressed_timestamps.append_bits(0b1110, 4);
-                compressed_timestamps.append_bits(delta_of_delta as u32, 12);
+                compressed_timestamps.append_bits(delta_of_delta as u64, 12);
+            }
+            -2147483647..=2147483648 => {
+                compressed_timestamps.append_bits(0b11110, 5);
+                compressed_timestamps.append_bits(delta_of_delta as u64, 32);
             }
             _ => {
-                compressed_timestamps.append_bits(0b1111, 4);
-                compressed_timestamps.append_bits(delta_of_delta as u32, 32);
+                compressed_timestamps.append_bits(0b11111, 5);
+                compressed_timestamps.append_bits(delta_of_delta as u64, 64);
             }
         }
         last_delta = delta;
@@ -231,16 +231,13 @@ fn decompress_all_irregular_timestamps(
     let mut bits = BitReader::try_new(residual_timestamps).unwrap();
     bits.read_bit();
 
-    // Decompress the second timestamp stored as a delta in 24 bits.
-    let mut last_delta = bits.read_bits(24);
-    let mut timestamp = start_time + last_delta as i64;
-    timestamp_builder.append_value(timestamp);
-
-    // Decompress the remaining residual timestamps.
+    // Decompress the residual timestamps.
+    let mut last_delta = 0;
+    let mut timestamp = start_time;
     while !bits.is_empty() {
-        // Read the next flag with the value of 0, 10, 110, 1110, or 1111.
+        // Read the next flag with the value of 0, 10, 110, 1110, 11110, or 11111.
         let mut leading_one_bits = 0;
-        while leading_one_bits < 4 && !bits.is_empty() && bits.read_bit() {
+        while leading_one_bits < 5 && !bits.is_empty() && bits.read_bit() {
             leading_one_bits += 1;
         }
 
@@ -256,7 +253,8 @@ fn decompress_all_irregular_timestamps(
             1 => read_decode_and_compute_delta(&mut bits, 7, last_delta),  // Flag is 10.
             2 => read_decode_and_compute_delta(&mut bits, 9, last_delta),  // Flag is 110.
             3 => read_decode_and_compute_delta(&mut bits, 12, last_delta), // Flag is 1110.
-            4 => last_delta + bits.read_bits(32),                          // Flag is 1111.
+            4 => read_decode_and_compute_delta(&mut bits, 32, last_delta), // Flag is 11110.
+            5 => read_decode_and_compute_delta(&mut bits, 64, last_delta), // Flag is 11111.
             _ => panic!("Unknown timestamp encoding with {leading_one_bits} leading one bits."),
         };
 
@@ -275,10 +273,10 @@ fn decompress_all_irregular_timestamps(
 /// Jerome Froelich] under MIT.
 ///
 /// [code published by Jerome Froelich]: https://github.com/jeromefroe/tsz-rs
-fn read_decode_and_compute_delta(bits: &mut BitReader, bits_to_read: u8, last_delta: u32) -> u32 {
+fn read_decode_and_compute_delta(bits: &mut BitReader, bits_to_read: u8, last_delta: u64) -> u64 {
     let encoded_delta_of_delta = bits.read_bits(bits_to_read);
     let delta_of_delta = if encoded_delta_of_delta > (1 << (bits_to_read - 1)) {
-        encoded_delta_of_delta | (u32::MAX << bits_to_read)
+        encoded_delta_of_delta | (u128::MAX << bits_to_read) as u64
     } else {
         encoded_delta_of_delta
     };
@@ -289,6 +287,10 @@ fn read_decode_and_compute_delta(bits: &mut BitReader, bits_to_read: u8, last_de
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use modelardb_common::test::data_generation::generate_timestamps;
+    use proptest::num::i64 as ProptestTimestamp;
+    use proptest::{collection, proptest};
 
     // Tests for compress_residual_timestamps() and decompress_all_timestamps().
     #[test]
@@ -330,6 +332,27 @@ mod tests {
         ]);
     }
 
+    #[test]
+    fn compress_and_decompress_timestamps_for_a_generated_regular_time_series() {
+        let timestamps = generate_timestamps(1000, false);
+        compress_and_decompress_timestamps_for_a_time_series(timestamps.values());
+    }
+
+    #[test]
+    fn compress_and_decompress_timestamps_for_a_generated_irregular_time_series() {
+        let timestamps = generate_timestamps(1000, true);
+        compress_and_decompress_timestamps_for_a_time_series(timestamps.values());
+    }
+
+    proptest! {
+    #[test]
+    fn compress_and_decompress_timestamps_for_a_random_irregular_time_series(timestamps in collection::vec(ProptestTimestamp::ANY, 1..50)) {
+        let mut timestamps = timestamps.iter().map(|ts| ts.abs()).collect::<Vec<i64>>();
+        timestamps.sort();
+        compress_and_decompress_timestamps_for_a_time_series(&timestamps);
+        }
+    }
+
     fn compress_and_decompress_timestamps_for_a_time_series(uncompressed_timestamps: &[Timestamp]) {
         let mut uncompressed_timestamps_builder =
             TimestampBuilder::with_capacity(uncompressed_timestamps.len());
@@ -337,7 +360,9 @@ mod tests {
         let uncompressed_timestamps = uncompressed_timestamps_builder.finish();
 
         let compressed = compress_residual_timestamps(uncompressed_timestamps.values());
-        assert!(!compressed.is_empty());
+        assert!(uncompressed_timestamps.len() <= 2 || !compressed.is_empty());
+        assert!(uncompressed_timestamps.len() > 2 || compressed.is_empty());
+
         let mut decompressed_timestamps = TimestampBuilder::with_capacity(10);
         decompress_all_timestamps(
             uncompressed_timestamps.value(0),

--- a/crates/modelardb_compression/src/models/timestamps.rs
+++ b/crates/modelardb_compression/src/models/timestamps.rs
@@ -251,7 +251,7 @@ fn decompress_all_irregular_timestamps(
         }
 
         let delta = match leading_one_bits {
-            0 => last_delta,                                                             // Flag is 0.
+            0 => last_delta,                                               // Flag is 0.
             1 => read_decode_and_compute_delta(&mut bits, 7, last_delta),  // Flag is 10.
             2 => read_decode_and_compute_delta(&mut bits, 9, last_delta),  // Flag is 110.
             3 => read_decode_and_compute_delta(&mut bits, 12, last_delta), // Flag is 1110.


### PR DESCRIPTION
This PR modifies the Gorilla-based timestamp compression so it store all residual timestamps as a bit prefix which indicates a size and a delta-of-delta. This allows all residual timestamps to be stored using an appropriate number of bites without the possibility of overflow which could happen when using 14 bits for the first residual timestamp as described in the Gorilla paper. In addition it simplifies the code to store the first residual timestamp as a delta-of-delta like all the other timestamp instead of a delta like in the Gorilla paper. To compute a delta-of-delta for the second timestamp a hard coded second delta with the value zero is used. 