### PR TITLE
Now always reading the full Apache Parquet file when reading record batches

### DIFF
--- a/crates/modelardb_common/Cargo.toml
+++ b/crates/modelardb_common/Cargo.toml
@@ -31,6 +31,7 @@ once_cell.workspace = true
 rand.workspace = true
 sqlparser.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite", "postgres"] }
+tokio = { workspace = true }
 tonic.workspace = true
 tracing.workspace = true
 uuid.workspace = true

--- a/crates/modelardb_common/src/lib.rs
+++ b/crates/modelardb_common/src/lib.rs
@@ -22,5 +22,6 @@ pub mod metadata;
 pub mod parser;
 pub mod remote;
 pub mod schemas;
+pub mod storage;
 pub mod test;
 pub mod types;

--- a/crates/modelardb_common/src/metadata/mod.rs
+++ b/crates/modelardb_common/src/metadata/mod.rs
@@ -341,7 +341,7 @@ where
     pub async fn mapping_from_hash_to_tags(
         &self,
         model_table_name: &str,
-        tag_column_names: &Vec<&str>,
+        tag_column_names: &[&str],
     ) -> Result<HashMap<u64, Vec<String>>, Error> {
         // Return an empty HashMap if no tag column names are passed to keep the signature simple.
         if tag_column_names.is_empty() {

--- a/crates/modelardb_common/src/parser.rs
+++ b/crates/modelardb_common/src/parser.rs
@@ -135,7 +135,7 @@ impl ModelarDbDialect {
                             sequence_options: None,
                             generation_expr: Some(parser.parse_expr()?),
                             generation_expr_mode: None,
-                            generated_keyword: false
+                            generated_keyword: false,
                         };
                         parser.expect_token(&Token::RParen)?;
 

--- a/crates/modelardb_common/src/storage.rs
+++ b/crates/modelardb_common/src/storage.rs
@@ -15,9 +15,13 @@
 
 //! Utility functions to support reading and writing Apache Parquet files to disk.
 
+use std::ffi::OsStr;
+use std::fs::File;
 use std::io::Write;
+use std::path::Path;
 
 use arrow::array::RecordBatch;
+use arrow::compute;
 use arrow::datatypes::SchemaRef;
 use datafusion::parquet::arrow::async_reader::{AsyncFileReader, ParquetRecordBatchStream};
 use datafusion::parquet::arrow::{ArrowWriter, ParquetRecordBatchStreamBuilder};
@@ -26,6 +30,50 @@ use datafusion::parquet::errors::ParquetError;
 use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
 use datafusion::parquet::format::SortingColumn;
 use futures::StreamExt;
+use tokio::fs::File as TokioFile;
+
+/// Write `batch` to an Apache Parquet file at the location given by `file_path`. `file_path`
+/// must use the extension '.parquet'. Return [`Ok`] if the file was written successfully,
+/// otherwise [`ParquetError`].
+pub fn write_batch_to_apache_parquet_file(
+    batch: &RecordBatch,
+    file_path: &Path,
+    sorting_columns: Option<Vec<SortingColumn>>,
+) -> Result<(), ParquetError> {
+    let error = ParquetError::General(format!(
+        "Apache Parquet file at path '{}' could not be created.",
+        file_path.display()
+    ));
+
+    // Check if the extension of the given path is correct.
+    if file_path.extension().and_then(OsStr::to_str) == Some("parquet") {
+        let file = File::create(file_path).map_err(|_e| error)?;
+        let mut writer = create_apache_arrow_writer(file, batch.schema(), sorting_columns)?;
+        writer.write(batch)?;
+        writer.close()?;
+
+        Ok(())
+    } else {
+        Err(error)
+    }
+}
+
+/// Read all rows from the Apache Parquet file at the location given by `file_path` and return
+/// them as a [`RecordBatch`]. If the file could not be read successfully, [`ParquetError`] is
+/// returned.
+pub async fn read_batch_from_apache_parquet_file(
+    file_path: &Path,
+) -> Result<RecordBatch, ParquetError> {
+    // Create a stream that can be used to read an Apache Parquet file.
+    let file = TokioFile::open(file_path)
+        .await
+        .map_err(|error| ParquetError::General(error.to_string()))?;
+
+    let record_batches = read_batches_from_apache_parquet_file(file).await?;
+    let schema = record_batches[0].schema();
+    compute::concat_batches(&schema, &record_batches)
+        .map_err(|error| ParquetError::General(error.to_string()))
+}
 
 /// Read each batch of data from the Apache Parquet file given by `reader` and return them as a
 /// [`Vec`] of [`RecordBatch`]. If the file could not be read successfully, [`ParquetError`] is
@@ -67,4 +115,108 @@ pub fn create_apache_arrow_writer<W: Write + Send>(
 
     let writer = ArrowWriter::try_new(writer, schema, Some(props))?;
     Ok(writer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use datafusion::arrow::datatypes::{Field, Schema};
+    use tempfile::{self, TempDir};
+
+    use crate::test;
+
+    // Tests for writing and reading Apache Parquet files.
+    #[test]
+    fn test_write_batch_to_apache_parquet_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let batch = test::compressed_segments_record_batch();
+
+        let apache_parquet_path = temp_dir.path().join("test.parquet");
+        write_batch_to_apache_parquet_file(&batch, apache_parquet_path.as_path(), None).unwrap();
+
+        assert!(apache_parquet_path.exists());
+    }
+
+    #[test]
+    fn test_write_empty_batch_to_apache_parquet_file() {
+        let fields: Vec<Field> = vec![];
+        let schema = Schema::new(fields);
+        let batch = RecordBatch::new_empty(Arc::new(schema));
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let apache_parquet_path = temp_dir.path().join("empty.parquet");
+        write_batch_to_apache_parquet_file(&batch, apache_parquet_path.as_path(), None).unwrap();
+
+        assert!(apache_parquet_path.exists());
+    }
+
+    #[test]
+    fn test_write_batch_to_file_with_invalid_extension() {
+        write_to_file_and_assert_failed("test.txt".to_owned());
+    }
+
+    #[test]
+    fn test_write_batch_to_file_with_no_extension() {
+        write_to_file_and_assert_failed("test".to_owned());
+    }
+
+    fn write_to_file_and_assert_failed(file_name: String) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let batch = test::compressed_segments_record_batch();
+
+        let apache_parquet_path = temp_dir.path().join(file_name);
+        let result =
+            write_batch_to_apache_parquet_file(&batch, apache_parquet_path.as_path(), None);
+
+        assert!(result.is_err());
+        assert!(!apache_parquet_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_read_entire_apache_parquet_file() {
+        let file_name = "test.parquet".to_owned();
+        let (_temp_dir, path, batch) = create_apache_parquet_file_in_temp_dir(file_name);
+
+        let result = read_batch_from_apache_parquet_file(path.as_path()).await;
+
+        assert!(result.is_ok());
+        assert_eq!(batch, result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_read_from_non_apache_parquet_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("test.txt");
+        File::create(path.clone()).unwrap();
+
+        let result = read_batch_from_apache_parquet_file(path.as_path());
+
+        assert!(result.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_read_from_non_existent_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("none.parquet");
+        let result = read_batch_from_apache_parquet_file(path.as_path());
+
+        assert!(result.await.is_err());
+    }
+
+    /// Create an Apache Parquet file in the [`tempfile::TempDir`] from a generated [`RecordBatch`].
+    fn create_apache_parquet_file_in_temp_dir(
+        file_name: String,
+    ) -> (TempDir, PathBuf, RecordBatch) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let batch = test::compressed_segments_record_batch();
+
+        let apache_parquet_path = temp_dir.path().join(file_name);
+        write_batch_to_apache_parquet_file(&batch, apache_parquet_path.as_path(), None).unwrap();
+
+        (temp_dir, apache_parquet_path, batch)
+    }
 }

--- a/crates/modelardb_common/src/storage.rs
+++ b/crates/modelardb_common/src/storage.rs
@@ -1,4 +1,4 @@
-/* Copyright 2023 The ModelarDB Contributors
+/* Copyright 2024 The ModelarDB Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/crates/modelardb_common/src/storage.rs
+++ b/crates/modelardb_common/src/storage.rs
@@ -1,0 +1,70 @@
+/* Copyright 2023 The ModelarDB Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Utility functions to support reading and writing Apache Parquet files to disk.
+
+use std::io::Write;
+
+use arrow::array::RecordBatch;
+use arrow::datatypes::SchemaRef;
+use datafusion::parquet::arrow::async_reader::{AsyncFileReader, ParquetRecordBatchStream};
+use datafusion::parquet::arrow::{ArrowWriter, ParquetRecordBatchStreamBuilder};
+use datafusion::parquet::basic::{Compression, Encoding, ZstdLevel};
+use datafusion::parquet::errors::ParquetError;
+use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
+use datafusion::parquet::format::SortingColumn;
+use futures::StreamExt;
+
+/// Read each batch of data from the Apache Parquet file given by `reader` and return them as a
+/// [`Vec`] of [`RecordBatch`]. If the file could not be read successfully, [`ParquetError`] is
+/// returned.
+pub async fn read_batches_from_apache_parquet_file<R>(
+    reader: R,
+) -> Result<Vec<RecordBatch>, ParquetError>
+where
+    R: AsyncFileReader + Send + Unpin + 'static,
+    ParquetRecordBatchStream<R>: StreamExt<Item = Result<RecordBatch, ParquetError>>,
+{
+    let builder = ParquetRecordBatchStreamBuilder::new(reader).await?;
+    let mut stream = builder.build()?;
+
+    let mut record_batches = Vec::new();
+    while let Some(maybe_record_batch) = stream.next().await {
+        let record_batch = maybe_record_batch?;
+        record_batches.push(record_batch);
+    }
+
+    Ok(record_batches)
+}
+
+/// Create an Apache [`ArrowWriter`] that writes to `writer` with a configuration that is optimized
+/// for writing compressed segments. If the writer could not be created return [`ParquetError`].
+pub fn create_apache_arrow_writer<W: Write + Send>(
+    writer: W,
+    schema: SchemaRef,
+    sorting_columns: Option<Vec<SortingColumn>>,
+) -> Result<ArrowWriter<W>, ParquetError> {
+    let props = WriterProperties::builder()
+        .set_encoding(Encoding::PLAIN)
+        .set_compression(Compression::ZSTD(ZstdLevel::default()))
+        .set_dictionary_enabled(false)
+        .set_statistics_enabled(EnabledStatistics::None)
+        .set_bloom_filter_enabled(false)
+        .set_sorting_columns(sorting_columns)
+        .build();
+
+    let writer = ArrowWriter::try_new(writer, schema, Some(props))?;
+    Ok(writer)
+}

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -116,7 +116,7 @@ impl Context {
         let session_config = SessionConfig::new();
         let session_runtime = Arc::new(RuntimeEnv::default());
 
-        // unwrap() is safe as storage::QUERY_DATA_FOLDER_SCHEME_WITH_HOST is a const containing an URL.
+        // unwrap() is safe as QUERY_DATA_FOLDER_SCHEME_WITH_HOST is a const containing a URL.
         let object_store_url = QUERY_DATA_FOLDER_SCHEME_WITH_HOST.try_into().unwrap();
         session_runtime.register_object_store(&object_store_url, query_data_folder);
 

--- a/crates/modelardb_server/src/storage/compressed_data_buffer.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_buffer.rs
@@ -24,15 +24,13 @@ use std::sync::Arc;
 use datafusion::arrow::compute;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::parquet::format::SortingColumn;
-use modelardb_common::metadata;
 use modelardb_common::metadata::compressed_file::CompressedFile;
 use modelardb_common::metadata::model_table_metadata::ModelTableMetadata;
 use modelardb_common::schemas::COMPRESSED_SCHEMA;
+use modelardb_common::{metadata, storage};
 use object_store::path::Path as ObjectStorePath;
 use object_store::ObjectMeta;
 use uuid::Uuid;
-
-use crate::storage::StorageEngine;
 
 /// Compressed segments representing data points from a column in a model table as one
 /// [`RecordBatch`].
@@ -131,12 +129,8 @@ impl CompressedDataBuffer {
             SortingColumn::new(2, false, false),
         ]);
 
-        StorageEngine::write_batch_to_apache_parquet_file(
-            &batch,
-            file_path.as_path(),
-            sorting_columns,
-        )
-        .map_err(|error| IOError::new(Other, error.to_string()))?;
+        storage::write_batch_to_apache_parquet_file(&batch, file_path.as_path(), sorting_columns)
+            .map_err(|error| IOError::new(Other, error.to_string()))?;
 
         let file_metadata = file_path.metadata()?;
 

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-//! Support for managing all compressed data that is inserted into the [`StorageEngine`].
+//! Support for managing all compressed data that is inserted into the
+//! [`StorageEngine`](crate::storage::StorageEngine).
 
 use std::fs;
 use std::io::{Error as IOError, ErrorKind};
@@ -54,7 +55,8 @@ use crate::ClusterMode;
 pub(super) struct CompressedDataManager {
     /// Component that transfers saved compressed data to the remote data folder when it is necessary.
     pub(super) data_transfer: Arc<RwLock<Option<DataTransfer>>>,
-    /// Path to the folder containing all compressed data managed by the [`StorageEngine`].
+    /// Path to the folder containing all compressed data managed by the
+    /// [`StorageEngine`](crate::storage::StorageEngine).
     pub(crate) local_data_folder: PathBuf,
     /// The compressed segments before they are saved to persistent storage. The key is the name of
     /// the table and the index of the column the compressed segments represents data points for so

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -30,6 +30,7 @@ use datafusion::parquet::errors::ParquetError;
 use modelardb_common::errors::ModelarDbError;
 use modelardb_common::metadata::compressed_file::CompressedFile;
 use modelardb_common::metadata::TableMetadataManager;
+use modelardb_common::storage;
 use modelardb_common::types::{Timestamp, Value};
 use object_store::{ObjectMeta, ObjectStore};
 use parquet::arrow::async_reader::ParquetObjectReader;
@@ -469,7 +470,7 @@ impl CompressedDataManager {
         for input_file in input_files {
             let reader = ParquetObjectReader::new(input_data_folder.clone(), input_file.clone());
             record_batches
-                .append(&mut StorageEngine::read_batches_from_apache_parquet_file(reader).await?);
+                .append(&mut storage::read_batches_from_apache_parquet_file(reader).await?);
         }
 
         // Merge the record batches into a single concatenated and merged record batch.
@@ -491,7 +492,7 @@ impl CompressedDataManager {
         // Write the concatenated and merged record batch to the output location.
         let mut buf = vec![].writer();
         let mut apache_arrow_writer =
-            StorageEngine::create_apache_arrow_writer(&mut buf, schema, sorting_columns)?;
+            storage::create_apache_arrow_writer(&mut buf, schema, sorting_columns)?;
         apache_arrow_writer.write(&merged)?;
         apache_arrow_writer.close()?;
 

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -46,7 +46,7 @@ use crate::storage::compressed_data_buffer::{CompressedDataBuffer, CompressedSeg
 use crate::storage::data_transfer::DataTransfer;
 use crate::storage::types::Message;
 use crate::storage::types::{Channels, MemoryPool};
-use crate::storage::{Metric, StorageEngine, COMPRESSED_DATA_FOLDER};
+use crate::storage::{Metric, COMPRESSED_DATA_FOLDER};
 use crate::ClusterMode;
 
 /// Stores data points compressed as models in memory to batch compressed data before saving it to
@@ -129,7 +129,7 @@ impl CompressedDataManager {
         let file_name = format!("{}.parquet", since_the_epoch.as_millis());
         let file_path = local_file_path.join(file_name);
 
-        StorageEngine::write_batch_to_apache_parquet_file(&record_batch, file_path.as_path(), None)
+        storage::write_batch_to_apache_parquet_file(&record_batch, file_path.as_path(), None)
     }
 
     /// Read and process messages received from the

--- a/crates/modelardb_server/src/storage/data_transfer.rs
+++ b/crates/modelardb_server/src/storage/data_transfer.rs
@@ -338,15 +338,13 @@ mod tests {
 
     use arrow_flight::flight_service_client::FlightServiceClient;
     use chrono::Utc;
-    use modelardb_common::metadata;
     use modelardb_common::test;
+    use modelardb_common::{metadata, storage};
     use ringbuf::Rb;
     use tempfile::{self, TempDir};
     use tokio::sync::RwLock;
     use tonic::transport::Channel;
     use uuid::Uuid;
-
-    use crate::storage::StorageEngine;
 
     const COLUMN_INDEX: u16 = 5;
     const COMPRESSED_FILE_SIZE: usize = 2383;
@@ -555,12 +553,8 @@ mod tests {
         let uuid = Uuid::new_v4();
         let batch = test::compressed_segments_record_batch();
         let apache_parquet_path = path.join(format!("{uuid}.parquet"));
-        StorageEngine::write_batch_to_apache_parquet_file(
-            &batch,
-            apache_parquet_path.as_path(),
-            None,
-        )
-        .unwrap();
+        storage::write_batch_to_apache_parquet_file(&batch, apache_parquet_path.as_path(), None)
+            .unwrap();
 
         let object_meta = ObjectMeta {
             location: ObjectStorePath::from(format!("{folder_path}/{uuid}.parquet")),

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -30,30 +30,23 @@ mod uncompressed_data_manager;
 use std::env;
 use std::ffi::OsStr;
 use std::fs::File;
-use std::io::{Error as IOError, ErrorKind, Write};
+use std::io::{Error as IOError, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 
 use datafusion::arrow::array::UInt32Array;
 use datafusion::arrow::compute;
-use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
-use datafusion::parquet::arrow::ArrowWriter;
-use datafusion::parquet::basic::ZstdLevel;
-use datafusion::parquet::basic::{Compression, Encoding};
 use datafusion::parquet::errors::ParquetError;
-use datafusion::parquet::file::properties::{EnabledStatistics, WriterProperties};
 use datafusion::parquet::format::SortingColumn;
-use futures::StreamExt;
 use modelardb_common::errors::ModelarDbError;
 use modelardb_common::metadata::model_table_metadata::ModelTableMetadata;
 use modelardb_common::metadata::TableMetadataManager;
+use modelardb_common::storage;
 use modelardb_common::types::{Timestamp, TimestampArray, Value};
 use object_store::{ObjectMeta, ObjectStore};
 use once_cell::sync::Lazy;
-use parquet::arrow::async_reader::{AsyncFileReader, ParquetRecordBatchStream};
 use sqlx::Sqlite;
 use tokio::fs::File as TokioFile;
 use tokio::runtime::Runtime;
@@ -547,7 +540,7 @@ impl StorageEngine {
         if file_path.extension().and_then(OsStr::to_str) == Some("parquet") {
             let file = File::create(file_path).map_err(|_e| error)?;
             let mut writer =
-                Self::create_apache_arrow_writer(file, batch.schema(), sorting_columns)?;
+                storage::create_apache_arrow_writer(file, batch.schema(), sorting_columns)?;
             writer.write(batch)?;
             writer.close()?;
 
@@ -568,52 +561,10 @@ impl StorageEngine {
             .await
             .map_err(|error| ParquetError::General(error.to_string()))?;
 
-        let record_batches = Self::read_batches_from_apache_parquet_file(file).await?;
+        let record_batches = storage::read_batches_from_apache_parquet_file(file).await?;
         let schema = record_batches[0].schema();
         compute::concat_batches(&schema, &record_batches)
             .map_err(|error| ParquetError::General(error.to_string()))
-    }
-
-    /// Read each batch of data from the Apache Parquet file given by `reader` and return them as a
-    /// [`Vec`] of [`RecordBatch`]. If the file could not be read successfully, [`ParquetError`] is
-    /// returned.
-    async fn read_batches_from_apache_parquet_file<R>(
-        reader: R,
-    ) -> Result<Vec<RecordBatch>, ParquetError>
-    where
-        R: AsyncFileReader + Send + Unpin + 'static,
-        ParquetRecordBatchStream<R>: StreamExt<Item = Result<RecordBatch, ParquetError>>,
-    {
-        let builder = ParquetRecordBatchStreamBuilder::new(reader).await?;
-        let mut stream = builder.build()?;
-
-        let mut record_batches = Vec::new();
-        while let Some(maybe_record_batch) = stream.next().await {
-            let record_batch = maybe_record_batch?;
-            record_batches.push(record_batch);
-        }
-
-        Ok(record_batches)
-    }
-
-    /// Create an Apache ArrowWriter that writes to `writer`. If the writer could not be created
-    /// return [`ParquetError`].
-    fn create_apache_arrow_writer<W: Write + Send>(
-        writer: W,
-        schema: SchemaRef,
-        sorting_columns: Option<Vec<SortingColumn>>,
-    ) -> Result<ArrowWriter<W>, ParquetError> {
-        let props = WriterProperties::builder()
-            .set_encoding(Encoding::PLAIN)
-            .set_compression(Compression::ZSTD(ZstdLevel::default()))
-            .set_dictionary_enabled(false)
-            .set_statistics_enabled(EnabledStatistics::None)
-            .set_bloom_filter_enabled(false)
-            .set_sorting_columns(sorting_columns)
-            .build();
-
-        let writer = ArrowWriter::try_new(writer, schema, Some(props))?;
-        Ok(writer)
     }
 }
 

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -568,15 +568,7 @@ impl StorageEngine {
             .await
             .map_err(|error| ParquetError::General(error.to_string()))?;
 
-        let mut stream = ParquetRecordBatchStreamBuilder::new(file).await?.build()?;
-
-        // Stream the data from the Apache Parquet file into a single record batch.
-        let mut record_batches = Vec::new();
-        while let Some(maybe_record_batch) = stream.next().await {
-            let record_batch = maybe_record_batch?;
-            record_batches.push(record_batch);
-        }
-
+        let record_batches = Self::read_batches_from_apache_parquet_file(file).await?;
         let schema = record_batches[0].schema();
         compute::concat_batches(&schema, &record_batches)
             .map_err(|error| ParquetError::General(error.to_string()))

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -28,27 +28,21 @@ mod uncompressed_data_buffer;
 mod uncompressed_data_manager;
 
 use std::env;
-use std::ffi::OsStr;
-use std::fs::File;
 use std::io::{Error as IOError, ErrorKind};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 
 use datafusion::arrow::array::UInt32Array;
-use datafusion::arrow::compute;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::parquet::errors::ParquetError;
-use datafusion::parquet::format::SortingColumn;
 use modelardb_common::errors::ModelarDbError;
 use modelardb_common::metadata::model_table_metadata::ModelTableMetadata;
 use modelardb_common::metadata::TableMetadataManager;
-use modelardb_common::storage;
 use modelardb_common::types::{Timestamp, TimestampArray, Value};
 use object_store::{ObjectMeta, ObjectStore};
 use once_cell::sync::Lazy;
 use sqlx::Sqlite;
-use tokio::fs::File as TokioFile;
 use tokio::runtime::Runtime;
 use tokio::sync::RwLock;
 use tonic::Status;
@@ -521,170 +515,5 @@ impl StorageEngine {
                 "Storage engine is not configured to transfer data.".to_owned(),
             ))
         }
-    }
-
-    /// Write `batch` to an Apache Parquet file at the location given by `file_path`. `file_path`
-    /// must use the extension '.parquet'. Return [`Ok`] if the file was written successfully,
-    /// otherwise [`ParquetError`].
-    pub(super) fn write_batch_to_apache_parquet_file(
-        batch: &RecordBatch,
-        file_path: &Path,
-        sorting_columns: Option<Vec<SortingColumn>>,
-    ) -> Result<(), ParquetError> {
-        let error = ParquetError::General(format!(
-            "Apache Parquet file at path '{}' could not be created.",
-            file_path.display()
-        ));
-
-        // Check if the extension of the given path is correct.
-        if file_path.extension().and_then(OsStr::to_str) == Some("parquet") {
-            let file = File::create(file_path).map_err(|_e| error)?;
-            let mut writer =
-                storage::create_apache_arrow_writer(file, batch.schema(), sorting_columns)?;
-            writer.write(batch)?;
-            writer.close()?;
-
-            Ok(())
-        } else {
-            Err(error)
-        }
-    }
-
-    /// Read all rows from the Apache Parquet file at the location given by `file_path` and return
-    /// them as a [`RecordBatch`]. If the file could not be read successfully, [`ParquetError`] is
-    /// returned.
-    async fn read_batch_from_apache_parquet_file(
-        file_path: &Path,
-    ) -> Result<RecordBatch, ParquetError> {
-        // Create a stream that can be used to read an Apache Parquet file.
-        let file = TokioFile::open(file_path)
-            .await
-            .map_err(|error| ParquetError::General(error.to_string()))?;
-
-        let record_batches = storage::read_batches_from_apache_parquet_file(file).await?;
-        let schema = record_batches[0].schema();
-        compute::concat_batches(&schema, &record_batches)
-            .map_err(|error| ParquetError::General(error.to_string()))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use std::path::PathBuf;
-    use std::sync::Arc;
-
-    use datafusion::arrow::datatypes::{Field, Schema};
-    use modelardb_common::test;
-    use tempfile::{self, TempDir};
-
-    // Tests for writing and reading Apache Parquet files.
-    #[test]
-    fn test_write_batch_to_apache_parquet_file() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let batch = test::compressed_segments_record_batch();
-
-        let apache_parquet_path = temp_dir.path().join("test.parquet");
-        StorageEngine::write_batch_to_apache_parquet_file(
-            &batch,
-            apache_parquet_path.as_path(),
-            None,
-        )
-        .unwrap();
-
-        assert!(apache_parquet_path.exists());
-    }
-
-    #[test]
-    fn test_write_empty_batch_to_apache_parquet_file() {
-        let fields: Vec<Field> = vec![];
-        let schema = Schema::new(fields);
-        let batch = RecordBatch::new_empty(Arc::new(schema));
-
-        let temp_dir = tempfile::tempdir().unwrap();
-        let apache_parquet_path = temp_dir.path().join("empty.parquet");
-        StorageEngine::write_batch_to_apache_parquet_file(
-            &batch,
-            apache_parquet_path.as_path(),
-            None,
-        )
-        .unwrap();
-
-        assert!(apache_parquet_path.exists());
-    }
-
-    #[test]
-    fn test_write_batch_to_file_with_invalid_extension() {
-        write_to_file_and_assert_failed("test.txt".to_owned());
-    }
-
-    #[test]
-    fn test_write_batch_to_file_with_no_extension() {
-        write_to_file_and_assert_failed("test".to_owned());
-    }
-
-    fn write_to_file_and_assert_failed(file_name: String) {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let batch = test::compressed_segments_record_batch();
-
-        let apache_parquet_path = temp_dir.path().join(file_name);
-        let result = StorageEngine::write_batch_to_apache_parquet_file(
-            &batch,
-            apache_parquet_path.as_path(),
-            None,
-        );
-
-        assert!(result.is_err());
-        assert!(!apache_parquet_path.exists());
-    }
-
-    #[tokio::test]
-    async fn test_read_entire_apache_parquet_file() {
-        let file_name = "test.parquet".to_owned();
-        let (_temp_dir, path, batch) = create_apache_parquet_file_in_temp_dir(file_name);
-
-        let result = StorageEngine::read_batch_from_apache_parquet_file(path.as_path()).await;
-
-        assert!(result.is_ok());
-        assert_eq!(batch, result.unwrap());
-    }
-
-    #[tokio::test]
-    async fn test_read_from_non_apache_parquet_file() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let path = temp_dir.path().join("test.txt");
-        File::create(path.clone()).unwrap();
-
-        let result = StorageEngine::read_batch_from_apache_parquet_file(path.as_path());
-
-        assert!(result.await.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_read_from_non_existent_path() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let path = temp_dir.path().join("none.parquet");
-        let result = StorageEngine::read_batch_from_apache_parquet_file(path.as_path());
-
-        assert!(result.await.is_err());
-    }
-
-    /// Create an Apache Parquet file in the [`tempfile::TempDir`] from a generated [`RecordBatch`].
-    fn create_apache_parquet_file_in_temp_dir(
-        file_name: String,
-    ) -> (TempDir, PathBuf, RecordBatch) {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let batch = test::compressed_segments_record_batch();
-
-        let apache_parquet_path = temp_dir.path().join(file_name);
-        StorageEngine::write_batch_to_apache_parquet_file(
-            &batch,
-            apache_parquet_path.as_path(),
-            None,
-        )
-        .unwrap();
-
-        (temp_dir, apache_parquet_path, batch)
     }
 }


### PR DESCRIPTION
This PR fixes a bug that caused Apache Parquet files to not always be read fully. We now loop over the batches in the file until the entire file is read. Duplicated code between `merge_compressed_apache_parquet_files` and `read_batch_from_apache_parquet_file` has been removed using a utility function and the read/write functions and the utility functions have been moved to `modelardb_common` so they can be used everywhere (including Library). 

Since the read/write Parquet functions have been moved, the storage engine now no longer has any associated functions and now only has methods.

It should be noted that reading batches in the Apache Parquet files using concurrency was researched but due to issues with the batches getting read out of order and therefore resulting in an out of order combined record batch, it was dropped. 