### PR TITLE
Optimize Apache Parquet page and row group sizes

### DIFF
--- a/crates/modelardb_common/src/storage.rs
+++ b/crates/modelardb_common/src/storage.rs
@@ -105,6 +105,8 @@ pub fn create_apache_arrow_writer<W: Write + Send>(
     sorting_columns: Option<Vec<SortingColumn>>,
 ) -> Result<ArrowWriter<W>, ParquetError> {
     let props = WriterProperties::builder()
+        .set_data_page_size_limit(16384)
+        .set_max_row_group_size(65536)
         .set_encoding(Encoding::PLAIN)
         .set_compression(Compression::ZSTD(ZstdLevel::default()))
         .set_dictionary_enabled(false)

--- a/crates/modelardb_server/src/storage/uncompressed_data_buffer.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_buffer.rs
@@ -625,7 +625,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(uncompressed_on_disk_buffer.disk_size(), 722)
+        assert_eq!(uncompressed_on_disk_buffer.disk_size(), 3135)
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR changes the `data page` size and `row group` size for [Apache Parquet](https://parquet.apache.org/docs/file-format/) files storing compressed segments containing metadata and models based on the results below. The `data page` size is reduced from [1,048,576](https://arrow.apache.org/rust/parquet/file/properties/constant.DEFAULT_PAGE_SIZE.html) to 16,384 and the `row group` size is reduced from [1,048,576](https://arrow.apache.org/rust/parquet/file/properties/constant.DEFAULT_MAX_ROW_GROUP_SIZE.html) to 65,536. These values provided the best trade-off between ingestion time, compaction time, query time for different query types, and the amount of storage required according to an extensive search performed by [Evaluate-ModelarDB-Changes](https://github.com/ModelarData/Utilities/tree/main/Evaluate-ModelarDB-Changes) using a real-life data set. The following tables shows the set of nondominated results as computed by this [Python script](https://github.com/matthewjwoodruff/pareto.py). The raw and nondominated results are also available as [raw_results.json](https://github.com/ModelarData/ModelarDB-RS/files/14323785/raw_results.json) and [nondominated_results.xlsx](https://github.com/ModelarData/ModelarDB-RS/files/14323786/nondominated_results.xlsx). When performing the review please evaluate the other nondominated results to verify the chosen configuration is preferable.

| Changes                                                                                                                                                                                                                                                                                                                                                                                | ingestion_time_in_seconds | compaction_time_in_seconds | data_folder_size_in_kib | limit.sql_in_seconds | small.sql_in_seconds | aggregate.sql_in_seconds |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------|----------------------------|-------------------------|----------------------|----------------------|--------------------------|
| .set_data_page_size_limit(1048576).set_max_row_group_size(1048576).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false) | 228.994436740875          | 40.3001601696014           | 4953460                 | 12.1563234329224     | 8.34433102607727     | 427.391568660736         |
| .set_data_page_size_limit(1048576).set_max_row_group_size(262144).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)  | 228.943277597427          | 40.7498915195465           | 4953504                 | 13.1385042667389     | 7.81478118896484     | 417.167997598648         |
| .set_data_page_size_limit(1048576).set_max_row_group_size(262144).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Chunk).set_bloom_filter_enabled(false) | 228.597663640976          | 41.1904897689819           | 4953572                 | 13.8616178035736     | 7.70810461044312     | 417.972361087799         |
| .set_data_page_size_limit(1048576).set_max_row_group_size(65536).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Chunk).set_bloom_filter_enabled(false)  | 228.594524860382          | 41.0196833610535           | 4955728                 | 13.1810266971588     | 6.40735840797424     | 404.566633939743         |
| .set_data_page_size_limit(262144).set_max_row_group_size(1048576).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)  | 228.746279478073          | 39.0495908260345           | 4956464                 | 12.7226433753967     | 7.19691109657288     | 426.398828029633         |
| .set_data_page_size_limit(262144).set_max_row_group_size(65536).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)    | 227.089833021164          | 40.061126947403            | 4956548                 | 12.9735960960388     | 5.85796499252319     | 404.8855240345           |
| .set_data_page_size_limit(65536).set_max_row_group_size(262144).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)    | 228.004113197327          | 39.4984166622162           | 4962048                 | 13.2867114543915     | 5.88729119300842     | 420.59637761116          |
| .set_data_page_size_limit(65536).set_max_row_group_size(262144).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Chunk).set_bloom_filter_enabled(false)   | 226.051465749741          | 39.9005236625671           | 4962132                 | 13.0639662742615     | 6.37289929389954     | 417.578035831451         |
| .set_data_page_size_limit(16384).set_max_row_group_size(65536).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)     | 227.956977128983          | 39.7422523498535           | 4964464                 | 12.5884346961975     | 5.73712372779846     | 404.627885818481         |
| .set_data_page_size_limit(16384).set_max_row_group_size(16384).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)     | 226.017246007919          | 40.782114982605            | 4964748                 | 10.1193025112152     | 5.3654625415802      | 413.128850221634         |
| .set_data_page_size_limit(65536).set_max_row_group_size(1048576).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Page).set_bloom_filter_enabled(false)   | 225.892803430557          | 40.3332180976868           | 5014844                 | 12.3536858558655     | 5.89641857147217     | 428.403596162796         |
| .set_data_page_size_limit(262144).set_max_row_group_size(1024).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::default())).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Chunk).set_bloom_filter_enabled(false)    | 224.96809720993           | 41.9097461700439           | 5085032                 | 16.7225739955902     | 8.01261591911316     | 413.714525699616         |
| .set_data_page_size_limit(16384).set_max_row_group_size(1024).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(true).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                     | 228.343667984009          | 35.3997569084168           | 5736532                 | 11.43306183815       | 5.02680563926697     | 399.362020492554         |
| .set_data_page_size_limit(65536).set_max_row_group_size(1024).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(true).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                     | 232.98787856102           | 34.8899493217468           | 5736532                 | 11.2485625743866     | 4.97013854980469     | 399.679676294327         |
| .set_data_page_size_limit(262144).set_max_row_group_size(1024).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(true).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                    | 231.196294307709          | 34.7679901123047           | 5736536                 | 11.4432411193848     | 5.00317931175232     | 398.053984880447         |
| .set_data_page_size_limit(1048576).set_max_row_group_size(1024).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(true).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                   | 229.908777713776          | 34.7482645511627           | 5736540                 | 11.2144939899445     | 5.08625054359436     | 398.790223121643         |
| .set_data_page_size_limit(1048576).set_max_row_group_size(262144).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                | 229.053389787674          | 25.2171537876129           | 5809628                 | 13.5592052936554     | 3.05169272422791     | 413.93158864975          |
| .set_data_page_size_limit(1048576).set_max_row_group_size(1048576).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                               | 229.047750234604          | 25.2397201061249           | 5809636                 | 13.3496284484863     | 3.77830934524536     | 418.992087602615         |
| .set_data_page_size_limit(1048576).set_max_row_group_size(1048576).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Chunk).set_bloom_filter_enabled(false)                              | 228.336185455322          | 25.8195645809174           | 5809672                 | 14.1999518871307     | 4.19010734558106     | 418.530548810959         |
| .set_data_page_size_limit(1048576).set_max_row_group_size(65536).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                 | 228.1650390625            | 25.5754389762878           | 5809736                 | 14.7394976615906     | 2.56636261940002     | 404.063692331314         |
| .set_data_page_size_limit(262144).set_max_row_group_size(262144).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                 | 227.155477285385          | 25.3842191696167           | 5809744                 | 20.7335147857666     | 3.31214714050293     | 413.347561836243         |
| .set_data_page_size_limit(262144).set_max_row_group_size(65536).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                  | 226.889439344406          | 25.2633416652679           | 5809812                 | 14.8208436965942     | 2.52854156494141     | 403.882900953293         |
| .set_data_page_size_limit(65536).set_max_row_group_size(1048576).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                 | 228.903959751129          | 25.1649899482727           | 5810004                 | 13.0952627658844     | 3.11246514320374     | 420.270182132721         |
| .set_data_page_size_limit(65536).set_max_row_group_size(262144).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                  | 227.8708589077            | 24.8329010009766           | 5810016                 | 13.4672403335571     | 2.82011675834656     | 414.862942218781         |
| .set_data_page_size_limit(1048576).set_max_row_group_size(4096).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                  | 227.959302663803          | 24.6332838535309           | 5811508                 | 8.90871024131775     | 2.65580534934998     | 395.793493509293         |
| .set_data_page_size_limit(65536).set_max_row_group_size(4096).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::None).set_bloom_filter_enabled(false)                                    | 227.687649488449          | 24.6746022701263           | 5811696                 | 9.20427894592285     | 2.65888166427612     | 397.679639101028         |
| .set_data_page_size_limit(65536).set_max_row_group_size(1024).set_encoding(datafusion::parquet::basic::Encoding::PLAIN).set_compression(datafusion::parquet::basic::Compression::UNCOMPRESSED).set_dictionary_enabled(false).set_statistics_enabled(datafusion::parquet::file::properties::EnabledStatistics::Chunk).set_bloom_filter_enabled(false)                                   | 226.567846775055          | 26.6244564056397           | 5928980                 | 15.5737581253052     | 5.56194019317627     | 387.47216463089          |