### PR TITLE
Add support for an absolute error bound

### DIFF
--- a/crates/modelardb_common/src/metadata/mod.rs
+++ b/crates/modelardb_common/src/metadata/mod.rs
@@ -148,8 +148,8 @@ where
     /// * The model_table_metadata table contains the main metadata for model tables.
     /// * The model_table_hash_table_name contains a mapping from each tag hash to the name of the
     /// model table that contains the time series with that tag hash.
-    /// * The model_table_field_columns table contains the name, index, error bound value, if error
-    /// bound is relative, and generation expression of the field columns in each model table.
+    /// * The model_table_field_columns table contains the name, index, error bound value, whether
+    /// error bound is relative, and generation expression of the field columns in each model table.
     /// If the tables exist or were created, return [`Ok`], otherwise return [`Error`].
     pub async fn create_metadata_database_tables(&self) -> Result<(), Error> {
         let strict = self.metadata_database_type.strict();

--- a/crates/modelardb_common/src/metadata/model_table_metadata.rs
+++ b/crates/modelardb_common/src/metadata/model_table_metadata.rs
@@ -190,6 +190,8 @@ mod test {
 
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
 
+    use crate::test::ERROR_BOUND_ZERO;
+
     // Tests for ModelTableMetadata.
     #[test]
     fn test_can_create_model_table_metadata() {
@@ -259,7 +261,7 @@ mod test {
         ModelTableMetadata::try_new(
             "table_name".to_owned(),
             Arc::new(query_schema),
-            vec![ErrorBound::try_new_absolute(0.0).unwrap()],
+            vec![ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap()],
             vec![None],
         )
     }
@@ -332,13 +334,13 @@ mod test {
                 Field::new("temperature", ArrowValue::DATA_TYPE, false),
             ])),
             vec![
-                ErrorBound::try_new_absolute(0.0).unwrap(),
-                ErrorBound::try_new_absolute(0.0).unwrap(),
-                ErrorBound::try_new_relative(0.0).unwrap(),
-                ErrorBound::try_new_absolute(0.0).unwrap(),
-                ErrorBound::try_new_absolute(0.0).unwrap(),
-                ErrorBound::try_new_relative(0.0).unwrap(),
-                ErrorBound::try_new_relative(0.0).unwrap(),
+                ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+                ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+                ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+                ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+                ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+                ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+                ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             ],
             vec![None, None, None, None, None, None, None],
         )
@@ -352,9 +354,9 @@ mod test {
             .collect::<Vec<Field>>();
 
         let error_bounds = vec![
-            ErrorBound::try_new_absolute(0.0).unwrap(),
-            ErrorBound::try_new_absolute(0.0).unwrap(),
-            ErrorBound::try_new_relative(0.0).unwrap(),
+            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
         ];
 
         let generated_columns = vec![None, None, None];

--- a/crates/modelardb_common/src/metadata/model_table_metadata.rs
+++ b/crates/modelardb_common/src/metadata/model_table_metadata.rs
@@ -259,7 +259,7 @@ mod test {
         ModelTableMetadata::try_new(
             "table_name".to_owned(),
             Arc::new(query_schema),
-            vec![ErrorBound::try_new(0.0).unwrap()],
+            vec![ErrorBound::try_new_relative(0.0).unwrap()],
             vec![None],
         )
     }
@@ -332,13 +332,13 @@ mod test {
                 Field::new("temperature", ArrowValue::DATA_TYPE, false),
             ])),
             vec![
-                ErrorBound::try_new(0.0).unwrap(),
-                ErrorBound::try_new(0.0).unwrap(),
-                ErrorBound::try_new(0.0).unwrap(),
-                ErrorBound::try_new(0.0).unwrap(),
-                ErrorBound::try_new(0.0).unwrap(),
-                ErrorBound::try_new(0.0).unwrap(),
-                ErrorBound::try_new(0.0).unwrap(),
+                ErrorBound::try_new_relative(0.0).unwrap(),
+                ErrorBound::try_new_relative(0.0).unwrap(),
+                ErrorBound::try_new_relative(0.0).unwrap(),
+                ErrorBound::try_new_relative(0.0).unwrap(),
+                ErrorBound::try_new_relative(0.0).unwrap(),
+                ErrorBound::try_new_relative(0.0).unwrap(),
+                ErrorBound::try_new_relative(0.0).unwrap(),
             ],
             vec![None, None, None, None, None, None, None],
         )
@@ -352,9 +352,9 @@ mod test {
             .collect::<Vec<Field>>();
 
         let error_bounds = vec![
-            ErrorBound::try_new(0.0).unwrap(),
-            ErrorBound::try_new(0.0).unwrap(),
-            ErrorBound::try_new(0.0).unwrap(),
+            ErrorBound::try_new_relative(0.0).unwrap(),
+            ErrorBound::try_new_relative(0.0).unwrap(),
+            ErrorBound::try_new_relative(0.0).unwrap(),
         ];
 
         let generated_columns = vec![None, None, None];

--- a/crates/modelardb_common/src/metadata/model_table_metadata.rs
+++ b/crates/modelardb_common/src/metadata/model_table_metadata.rs
@@ -259,7 +259,7 @@ mod test {
         ModelTableMetadata::try_new(
             "table_name".to_owned(),
             Arc::new(query_schema),
-            vec![ErrorBound::try_new_relative(0.0).unwrap()],
+            vec![ErrorBound::try_new_absolute(0.0).unwrap()],
             vec![None],
         )
     }
@@ -332,11 +332,11 @@ mod test {
                 Field::new("temperature", ArrowValue::DATA_TYPE, false),
             ])),
             vec![
+                ErrorBound::try_new_absolute(0.0).unwrap(),
+                ErrorBound::try_new_absolute(0.0).unwrap(),
                 ErrorBound::try_new_relative(0.0).unwrap(),
-                ErrorBound::try_new_relative(0.0).unwrap(),
-                ErrorBound::try_new_relative(0.0).unwrap(),
-                ErrorBound::try_new_relative(0.0).unwrap(),
-                ErrorBound::try_new_relative(0.0).unwrap(),
+                ErrorBound::try_new_absolute(0.0).unwrap(),
+                ErrorBound::try_new_absolute(0.0).unwrap(),
                 ErrorBound::try_new_relative(0.0).unwrap(),
                 ErrorBound::try_new_relative(0.0).unwrap(),
             ],
@@ -352,8 +352,8 @@ mod test {
             .collect::<Vec<Field>>();
 
         let error_bounds = vec![
-            ErrorBound::try_new_relative(0.0).unwrap(),
-            ErrorBound::try_new_relative(0.0).unwrap(),
+            ErrorBound::try_new_absolute(0.0).unwrap(),
+            ErrorBound::try_new_absolute(0.0).unwrap(),
             ErrorBound::try_new_relative(0.0).unwrap(),
         ];
 

--- a/crates/modelardb_common/src/parser.rs
+++ b/crates/modelardb_common/src/parser.rs
@@ -894,7 +894,8 @@ mod tests {
     fn test_tokenize_and_parse_create_model_table_without_model() {
         // Track if sqlparser at some point can parse fields/tags without ModelarDbDialect.
         assert!(tokenize_and_parse_sql(
-              "CREATE TABLE table_name(timestamp TIMESTAMP, field FIELD, field_one FIELD(10.5), field_two FIELD(1%), tag TAG)",
+            "CREATE TABLE table_name(timestamp TIMESTAMP, field FIELD, field_one FIELD(10.5),
+                                     field_two FIELD(1%), tag TAG)",
         )
         .is_err());
     }

--- a/crates/modelardb_common/src/parser.rs
+++ b/crates/modelardb_common/src/parser.rs
@@ -119,14 +119,14 @@ impl ModelarDbDialect {
                         // An error bound is given for the field column.
                         parser.expect_token(&Token::LParen)?;
                         let error_bound = self.parse_positive_literal_f32(parser)?;
-                        let relative = parser.consume_token(&Token::Mod);
+                        let is_relative = parser.consume_token(&Token::Mod);
                         parser.expect_token(&Token::RParen)?;
 
                         // The error bound is zero by default so there is no need to store zero.
                         if error_bound > 0.0 {
                             options.push(Self::new_error_bound_column_option_def(
                                 error_bound,
-                                relative,
+                                is_relative,
                             ));
                         }
                     } else if let Token::Word(_) = parser.peek_nth_token(0).token {
@@ -220,14 +220,14 @@ impl ModelarDbDialect {
     }
 
     /// Create a new [`ColumnOptionDef`] with the provided `error_bound`.
-    fn new_error_bound_column_option_def(error_bound: f32, relative: bool) -> ColumnOptionDef {
+    fn new_error_bound_column_option_def(error_bound: f32, is_relative: bool) -> ColumnOptionDef {
         // An error bound column option does not exist so ColumnOption::DialectSpecific and
         // Token::Number is used. Token::Number's bool should be the number when cast to a bool.
         ColumnOptionDef {
             name: None,
             option: ColumnOption::DialectSpecific(vec![Token::Number(
                 error_bound.to_string(),
-                relative,
+                is_relative,
             )]),
         }
     }
@@ -556,9 +556,9 @@ fn column_defs_to_model_table_query_schema(
                 for column_option_def in column_def.options {
                     match column_option_def.option {
                         ColumnOption::DialectSpecific(dialect_specific_tokens) => {
-                            let (error_bound, relative) =
+                            let (error_bound, is_relative) =
                                 tokens_to_error_bound(&dialect_specific_tokens)?;
-                            let suffix = if relative { "%" } else { "" };
+                            let suffix = if is_relative { "%" } else { "" };
                             metadata
                                 .insert("Error Bound".to_owned(), error_bound.to_string() + suffix);
                         }
@@ -607,17 +607,17 @@ fn extract_error_bounds_for_all_columns(
 
     for column_def in column_defs {
         let mut error_bound_value = 0.0;
-        let mut relative = false;
+        let mut is_relative = false;
 
         for column_def_option in &column_def.options {
             if let ColumnOption::DialectSpecific(dialect_specific_tokens) =
                 &column_def_option.option
             {
-                (error_bound_value, relative) = tokens_to_error_bound(dialect_specific_tokens)?;
+                (error_bound_value, is_relative) = tokens_to_error_bound(dialect_specific_tokens)?;
             }
         }
 
-        let error_bound = if !relative {
+        let error_bound = if !is_relative {
             ErrorBound::try_new_absolute(error_bound_value)
         } else {
             ErrorBound::try_new_relative(error_bound_value)
@@ -631,8 +631,8 @@ fn extract_error_bounds_for_all_columns(
 }
 
 /// Return the value of an error bound and a [`bool`] indicating if it is relative if it is the only
-/// token in `dialect_specific_tokens`, otherwise [`ParseError`] is returned. Assumes the tokens has
-/// been extracted from a [`ColumnOption::DialectSpecific`].
+/// token in `dialect_specific_tokens`, otherwise [`ParserError`] is returned. Assumes the tokens
+/// have been extracted from a [`ColumnOption::DialectSpecific`].
 fn tokens_to_error_bound(dialect_specific_tokens: &[Token]) -> Result<(f32, bool), ParserError> {
     if dialect_specific_tokens.len() != 1 {
         return Err(ParserError::ParserError(
@@ -640,11 +640,11 @@ fn tokens_to_error_bound(dialect_specific_tokens: &[Token]) -> Result<(f32, bool
         ));
     }
 
-    if let Token::Number(error_bound_string, relative) = &dialect_specific_tokens[0] {
+    if let Token::Number(error_bound_string, is_relative) = &dialect_specific_tokens[0] {
         let error_bound_value = error_bound_string
             .parse::<f32>()
             .map_err(|_error| ParserError::ParserError("Error bound is not a float".to_owned()))?;
-        Ok((error_bound_value, *relative))
+        Ok((error_bound_value, *is_relative))
     } else {
         Err(ParserError::ParserError(
             "Dialect specific tokens must be an error bound.".to_owned(),
@@ -844,8 +844,8 @@ mod tests {
     ) -> Vec<ColumnOptionDef> {
         let mut column_option_defs = vec![];
 
-        if let Some((error_bound, relative)) = maybe_error_bound {
-            let dialect_specific_tokens = vec![Token::Number(error_bound.to_string(), relative)];
+        if let Some((error_bound, is_relative)) = maybe_error_bound {
+            let dialect_specific_tokens = vec![Token::Number(error_bound.to_string(), is_relative)];
             let error_bound = ColumnOptionDef {
                 name: None,
                 option: ColumnOption::DialectSpecific(dialect_specific_tokens),

--- a/crates/modelardb_common/src/test/data_generation.rs
+++ b/crates/modelardb_common/src/test/data_generation.rs
@@ -128,8 +128,8 @@ pub fn generate_univariate_time_series(
 /// points in sequences of `segment_length_range` (except possibly for the last as it may be
 /// truncated to match `length`) and the timestamps will be regular or irregular depending on the
 /// value of `generate_irregular_timestamps`. If `add_noise_range` is [`Some`], random values will
-/// be generated in the [`Range<f32>`] and multiplied with each value in the sequences with constant
-/// and linear values. Sequences with random values are generated in the range specified as
+/// be generated in the [`Range<f32>`] and added to each value in the sequences with constant and
+/// linear values. Sequences with random values are generated in the range specified as
 /// `random_value_range`.
 pub fn generate_multivariate_time_series(
     length: usize,

--- a/crates/modelardb_common/src/test/mod.rs
+++ b/crates/modelardb_common/src/test/mod.rs
@@ -46,6 +46,24 @@ pub const UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES: usize = 5 * 1024 * 1024; // 5 M
 /// Number of bytes reserved for compressed data in tests.
 pub const COMPRESSED_RESERVED_MEMORY_IN_BYTES: usize = 5 * 1024 * 1024; // 5 MiB
 
+/// Named error bound with the value 0.0 to make tests more readable.
+pub const ERROR_BOUND_ZERO: f32 = 0.0;
+
+/// Named error bound with the value 1.0 to make tests more readable.
+pub const ERROR_BOUND_ONE: f32 = 1.0;
+
+/// Named error bound with the value 5.0 to make tests more readable.
+pub const ERROR_BOUND_FIVE: f32 = 5.0;
+
+/// Named error bound with the value 10.0 to make tests more readable.
+pub const ERROR_BOUND_TEN: f32 = 10.0;
+
+/// Named error bound with the value f32::MAX to make tests more readable.
+pub const ERROR_BOUND_ABSOLUTE_MAX: f32 = f32::MAX;
+
+/// Named error bound with the value 100.0 to make tests more readable.
+pub const ERROR_BOUND_RELATIVE_MAX: f32 = 100.0;
+
 /// SQL to create a table with a timestamp column and two floating point columns.
 pub const TABLE_SQL: &str =
     "CREATE TABLE table_name(timestamp TIMESTAMP, values REAL, metadata REAL)";
@@ -68,10 +86,10 @@ pub fn model_table_metadata() -> ModelTableMetadata {
     ]));
 
     let error_bounds = vec![
-        ErrorBound::try_new_absolute(0.0).unwrap(),
-        ErrorBound::try_new_absolute(1.0).unwrap(),
-        ErrorBound::try_new_relative(5.0).unwrap(),
-        ErrorBound::try_new_relative(0.0).unwrap(),
+        ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+        ErrorBound::try_new_absolute(ERROR_BOUND_ONE).unwrap(),
+        ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
+        ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
     ];
 
     let generated_columns = vec![None, None, None, None];

--- a/crates/modelardb_common/src/test/mod.rs
+++ b/crates/modelardb_common/src/test/mod.rs
@@ -68,8 +68,8 @@ pub fn model_table_metadata() -> ModelTableMetadata {
     ]));
 
     let error_bounds = vec![
-        ErrorBound::try_new_relative(0.0).unwrap(),
-        ErrorBound::try_new_relative(1.0).unwrap(),
+        ErrorBound::try_new_absolute(0.0).unwrap(),
+        ErrorBound::try_new_absolute(1.0).unwrap(),
         ErrorBound::try_new_relative(5.0).unwrap(),
         ErrorBound::try_new_relative(0.0).unwrap(),
     ];

--- a/crates/modelardb_common/src/test/mod.rs
+++ b/crates/modelardb_common/src/test/mod.rs
@@ -68,10 +68,10 @@ pub fn model_table_metadata() -> ModelTableMetadata {
     ]));
 
     let error_bounds = vec![
-        ErrorBound::try_new(0.0).unwrap(),
-        ErrorBound::try_new(1.0).unwrap(),
-        ErrorBound::try_new(5.0).unwrap(),
-        ErrorBound::try_new(0.0).unwrap(),
+        ErrorBound::try_new_relative(0.0).unwrap(),
+        ErrorBound::try_new_relative(1.0).unwrap(),
+        ErrorBound::try_new_relative(5.0).unwrap(),
+        ErrorBound::try_new_relative(0.0).unwrap(),
     ];
 
     let generated_columns = vec![None, None, None, None];

--- a/crates/modelardb_common/src/types.rs
+++ b/crates/modelardb_common/src/types.rs
@@ -84,7 +84,7 @@ impl ErrorBound {
     pub fn try_new_absolute(value: f32) -> Result<Self, ModelarDbError> {
         if !value.is_finite() || value < 0.0 {
             Err(ModelarDbError::CompressionError(
-                "An absolute error bounds must be a finite value..".to_owned(),
+                "An absolute error bound must be a positive finite value.".to_owned(),
             ))
         } else {
             Ok(Self::Absolute(value))
@@ -96,7 +96,7 @@ impl ErrorBound {
     pub fn try_new_relative(percentage: f32) -> Result<Self, ModelarDbError> {
         if !(0.0..=100.0).contains(&percentage) {
             Err(ModelarDbError::CompressionError(
-                "An relative error bound must be a value from 0.0% to 100.0%.".to_owned(),
+                "A relative error bound must be a value from 0.0% to 100.0%.".to_owned(),
             ))
         } else {
             Ok(Self::Relative(percentage))
@@ -139,10 +139,12 @@ mod tests {
     use proptest::num;
     use proptest::proptest;
 
+    use crate::test::ERROR_BOUND_ZERO;
+
     // Tests for ErrorBound.
     #[test]
     fn test_absolute_error_bound_can_be_zero() {
-        assert!(ErrorBound::try_new_absolute(0.0).is_ok())
+        assert!(ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).is_ok())
     }
 
     proptest! {
@@ -174,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_relative_error_bound_can_be_zero() {
-        assert!(ErrorBound::try_new_relative(0.0).is_ok())
+        assert!(ErrorBound::try_new_relative(ERROR_BOUND_ZERO).is_ok())
     }
 
     proptest! {

--- a/crates/modelardb_compression/src/compression.rs
+++ b/crates/modelardb_compression/src/compression.rs
@@ -266,9 +266,9 @@ mod tests {
     };
     use modelardb_common::array;
     use modelardb_common::test::data_generation::{self, ValuesStructure};
+    use modelardb_common::test::{ERROR_BOUND_FIVE, ERROR_BOUND_ZERO};
     use modelardb_common::types::{TimestampBuilder, ValueBuilder};
 
-    use crate::tests::{ERROR_BOUND_FIVE, ERROR_BOUND_ZERO};
     use crate::{models, MODEL_TYPE_NAMES};
 
     const UNIVARIATE_ID: u64 = 1;
@@ -277,7 +277,7 @@ mod tests {
 
     // Tests for try_compress().
     #[test]
-    fn test_try_compress_absolute_empty_time_series() {
+    fn test_try_compress_empty_time_series_within_absolute_error_bound_zero() {
         let compressed_record_batch = try_compress(
             UNIVARIATE_ID,
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
@@ -289,7 +289,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_empty_time_series() {
+    fn test_try_compress_empty_time_series_within_relative_error_bound_zero() {
         let compressed_record_batch = try_compress(
             UNIVARIATE_ID,
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
@@ -301,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_regular_constant_time_series() {
+    fn test_try_compress_regular_constant_time_series_within_absolute_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::Constant(None),
@@ -311,7 +311,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_regular_constant_time_series() {
+    fn test_try_compress_regular_constant_time_series_within_relative_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::Constant(None),
@@ -321,7 +321,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_irregular_constant_time_series() {
+    fn test_try_compress_irregular_constant_time_series_within_absolute_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::Constant(None),
@@ -331,7 +331,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_irregular_constant_time_series() {
+    fn test_try_compress_irregular_constant_time_series_within_relative_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::Constant(None),
@@ -341,7 +341,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_regular_almost_constant_time_series() {
+    fn test_try_compress_regular_almost_constant_time_series_within_absolute_error_bound_five() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::Random(9.8..10.2),
@@ -351,7 +351,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_regular_almost_constant_time_series() {
+    fn test_try_compress_regular_almost_constant_time_series_within_relative_error_bound_five() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::Random(9.8..10.2),
@@ -361,7 +361,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_irregular_almost_constant_time_series() {
+    fn test_try_compress_irregular_almost_constant_time_series_within_absolute_error_bound_five() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::Random(9.8..10.2),
@@ -371,7 +371,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_irregular_almost_constant_time_series() {
+    fn test_try_compress_irregular_almost_constant_time_serie_within_relative_error_bound_five() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::Random(9.8..10.2),
@@ -381,7 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_regular_linear_time_series() {
+    fn test_try_compress_regular_linear_time_series_within_absolute_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::Linear(None),
@@ -391,7 +391,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_regular_linear_time_series() {
+    fn test_try_compress_regular_linear_time_series_within_relative_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::Linear(None),
@@ -401,7 +401,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_irregular_linear_time_series() {
+    fn test_try_compress_irregular_linear_time_series_within_absolute_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::Linear(None),
@@ -411,7 +411,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relatively_irregular_linear_time_series() {
+    fn test_try_compress_irregular_linear_time_series_within_relative_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::Linear(None),
@@ -421,7 +421,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_regular_almost_linear_time_series() {
+    fn test_try_compress_regular_almost_linear_time_series_within_absolute_error_bound_five() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::Linear(ADD_NOISE_RANGE),
@@ -431,7 +431,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_regular_almost_linear_time_series() {
+    fn test_try_compress_regular_almost_linear_time_series_within_relative_error_bound_five() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::Linear(ADD_NOISE_RANGE),
@@ -441,7 +441,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_irregular_almost_linear_time_series() {
+    fn test_try_compress_irregular_almost_linear_time_series_within_absolute_error_bound_five() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::Linear(ADD_NOISE_RANGE),
@@ -451,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_irregular_almost_linear_time_series() {
+    fn test_try_compress_irregular_almost_linear_time_series_within_relative_error_bound_five() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::Linear(ADD_NOISE_RANGE),
@@ -461,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_regular_random_time_series() {
+    fn test_try_compress_regular_random_time_series_within_absolute_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::largest_random_without_overflow(),
@@ -471,7 +471,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_regular_random_time_series() {
+    fn test_try_compress_regular_random_time_series_within_relative_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::largest_random_without_overflow(),
@@ -481,7 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_irregular_random_time_series() {
+    fn test_try_compress_irregular_random_time_series_within_absolute_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::largest_random_without_overflow(),
@@ -491,7 +491,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_irregular_random_time_series() {
+    fn test_try_compress_irregular_random_time_series_within_relative_error_bound_zero() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::largest_random_without_overflow(),
@@ -528,7 +528,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_regular_random_linear_constant_time_series() {
+    fn test_try_compress_regular_random_linear_constant_time_series_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -538,7 +539,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_regular_random_linear_constant_time_series() {
+    fn test_try_compress_regular_random_linear_constant_time_series_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -548,7 +550,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_irregular_random_linear_constant_time_series() {
+    fn test_try_compress_irregular_random_linear_constant_time_series_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -558,7 +561,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_irregular_random_linear_constant_time_series() {
+    fn test_try_compress_irregular_random_linear_constant_time_series_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -568,7 +572,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_regular_constant_linear_random_time_series() {
+    fn test_try_compress_regular_constant_linear_random_time_series_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -578,7 +583,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_regular_constant_linear_random_time_series() {
+    fn test_try_compress_regular_constant_linear_random_time_series_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -588,7 +594,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_irregular_constant_linear_random_time_series() {
+    fn test_try_compress_irregular_constant_linear_random_time_series_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -598,7 +605,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relativ_irregular_constant_linear_random_time_series() {
+    fn test_try_compress_irregular_constant_linear_random_time_series_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -691,7 +699,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_regular_synthetic_time_series_without_noise_lossless() {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -700,7 +709,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_regular_synthetic_time_series_without_noise_lossless() {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -709,7 +719,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_regular_synthetic_time_series_without_noise_lossy() {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_absolute_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
             false,
@@ -718,7 +729,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_regular_synthetic_time_series_without_noise_lossy() {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_relative_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             false,
@@ -727,7 +739,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_regular_synthetic_time_series_with_noise_lossless() {
+    fn test_try_compress_regular_synthetic_time_series_with_noise_within_absolute_error_bound_zero()
+    {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -736,7 +749,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_regular_synthetic_time_series_with_noise_lossless() {
+    fn test_try_compress_regular_synthetic_time_series_with_noise_within_relative_error_bound_zero()
+    {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -745,7 +759,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_regular_synthetic_time_series_with_noise_lossy() {
+    fn test_try_compress_regular_synthetic_time_series_with_noise_within_absolute_error_bound_five()
+    {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
             false,
@@ -754,7 +769,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_regular_synthetic_time_series_with_noise_lossy() {
+    fn test_try_compress_regular_synthetic_time_series_with_noise_within_relative_error_bound_five()
+    {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             false,
@@ -763,7 +779,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_irregular_synthetic_time_series_without_noise_lossless() {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -772,7 +789,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_irregular_synthetic_time_series_without_noise_lossless() {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -781,7 +799,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_irregular_synthetic_time_series_without_noise_lossy() {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_absolute_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
             true,
@@ -790,7 +809,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_irregular_synthetic_time_series_without_noise_lossy() {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_relative_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             true,
@@ -799,7 +819,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_irregular_synthetic_time_series_with_noise_lossless() {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -808,7 +829,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_irregular_synthetic_time_series_with_noise_lossless() {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -817,7 +839,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_absolute_irregular_synthetic_time_series_with_noise_lossy() {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_absolute_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
             true,
@@ -826,7 +849,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_relative_irregular_synthetic_time_series_with_noise_lossy() {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_relative_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             true,
@@ -929,7 +953,7 @@ mod tests {
 
             assert!(
                 models::is_value_within_error_bound(error_bound, real_value, approximate_value),
-                "{approximate_value} from {model_type_name} is outside {error_bound:?} of {real_value}",
+                "{approximate_value} from {model_type_name} is outside {error_bound:?} of {real_value}.",
             );
         }
     }
@@ -937,7 +961,7 @@ mod tests {
     // Tests for compress_and_store_residuals_in_a_separate_segment().
     #[test]
     fn test_compress_and_store_residuals_in_a_separate_segment() {
-        let error_bound = ErrorBound::try_new_relative(0.0).unwrap();
+        let error_bound = ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap();
         let uncompressed_timestamps = TimestampArray::from_iter_values((100..=500).step_by(100));
         let uncompressed_values = ValueArray::from(vec![73.0, 37.0, 37.0, 37.0, 73.0]);
         let mut compressed_segment_batch_builder = CompressedSegmentBatchBuilder::new(1);

--- a/crates/modelardb_compression/src/compression.rs
+++ b/crates/modelardb_compression/src/compression.rs
@@ -711,7 +711,7 @@ mod tests {
         uncompressed_values: &ValueArray,
         error_bound: f32,
     ) -> RecordBatch {
-        let error_bound = ErrorBound::try_new(error_bound).unwrap();
+        let error_bound = ErrorBound::try_new_relative(error_bound).unwrap();
         try_compress(1, error_bound, uncompressed_timestamps, uncompressed_values).unwrap()
     }
 
@@ -765,7 +765,7 @@ mod tests {
         if error_bound == 0.0 {
             assert_eq!(uncompressed_values, &decompressed_values);
         } else {
-            let error_bound = ErrorBound::try_new(error_bound).unwrap();
+            let error_bound = ErrorBound::try_new_relative(error_bound).unwrap();
             for index in 0..uncompressed_values.len() {
                 let real_value = uncompressed_values.value(index);
                 let approximate_value = decompressed_values.value(index);
@@ -781,7 +781,7 @@ mod tests {
     // Tests for compress_and_store_residuals_in_a_separate_segment().
     #[test]
     fn test_compress_and_store_residuals_in_a_separate_segment() {
-        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let error_bound = ErrorBound::try_new_relative(0.0).unwrap();
         let uncompressed_timestamps = TimestampArray::from_iter_values((100..=500).step_by(100));
         let uncompressed_values = ValueArray::from(vec![73.0, 37.0, 37.0, 37.0, 73.0]);
         let mut compressed_segment_batch_builder = CompressedSegmentBatchBuilder::new(1);

--- a/crates/modelardb_compression/src/compression.rs
+++ b/crates/modelardb_compression/src/compression.rs
@@ -268,11 +268,10 @@ mod tests {
     use modelardb_common::test::data_generation::{self, ValuesStructure};
     use modelardb_common::types::{TimestampBuilder, ValueBuilder};
 
+    use crate::tests::{ERROR_BOUND_FIVE, ERROR_BOUND_ZERO};
     use crate::{models, MODEL_TYPE_NAMES};
 
     const UNIVARIATE_ID: u64 = 1;
-    const ERROR_BOUND_ZERO: f32 = 0.0;
-    const ERROR_BOUND_FIVE: f32 = 5.0;
     const ADD_NOISE_RANGE: Option<Range<f32>> = Some(1.0..1.05);
     const TRY_COMPRESS_TEST_LENGTH: usize = 50;
 

--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -33,13 +33,3 @@ pub use models::len;
 pub use models::sum;
 pub use models::timestamps::are_compressed_timestamps_regular;
 pub use models::{MODEL_TYPE_COUNT, MODEL_TYPE_NAMES};
-
-// Named error bound values to make tests more readable.
-#[cfg(test)]
-mod tests {
-    pub(crate) const ERROR_BOUND_ZERO: f32 = 0.0;
-    pub(crate) const ERROR_BOUND_FIVE: f32 = 5.0;
-    pub(crate) const ERROR_BOUND_TEN: f32 = 10.0;
-    pub(crate) const ERROR_BOUND_ABSOLUTE_MAX: f32 = f32::MAX;
-    pub(crate) const ERROR_BOUND_RELATIVE_MAX: f32 = 100.0;
-}

--- a/crates/modelardb_compression/src/lib.rs
+++ b/crates/modelardb_compression/src/lib.rs
@@ -33,3 +33,13 @@ pub use models::len;
 pub use models::sum;
 pub use models::timestamps::are_compressed_timestamps_regular;
 pub use models::{MODEL_TYPE_COUNT, MODEL_TYPE_NAMES};
+
+// Named error bound values to make tests more readable.
+#[cfg(test)]
+mod tests {
+    pub(crate) const ERROR_BOUND_ZERO: f32 = 0.0;
+    pub(crate) const ERROR_BOUND_FIVE: f32 = 5.0;
+    pub(crate) const ERROR_BOUND_TEN: f32 = 10.0;
+    pub(crate) const ERROR_BOUND_ABSOLUTE_MAX: f32 = f32::MAX;
+    pub(crate) const ERROR_BOUND_RELATIVE_MAX: f32 = 100.0;
+}

--- a/crates/modelardb_compression/src/merge.rs
+++ b/crates/modelardb_compression/src/merge.rs
@@ -426,7 +426,7 @@ mod tests {
         while index < uncompressed_timestamps.len() {
             let compressed_segments = crate::try_compress(
                 1,
-                ErrorBound::try_new(0.0).unwrap(),
+                ErrorBound::try_new_relative(0.0).unwrap(),
                 &uncompressed_timestamps.slice(index, batch_size),
                 &uncompressed_values.slice(index, batch_size),
             )

--- a/crates/modelardb_compression/src/merge.rs
+++ b/crates/modelardb_compression/src/merge.rs
@@ -330,6 +330,7 @@ mod tests {
     use arrow::array::{UInt64Builder, UInt8Array};
     use arrow::compute;
     use modelardb_common::schemas::UNCOMPRESSED_SCHEMA;
+    use modelardb_common::test::ERROR_BOUND_ZERO;
     use modelardb_common::types::{ErrorBound, ValueBuilder};
 
     // Tests for try_merge_segments().
@@ -426,7 +427,7 @@ mod tests {
         while index < uncompressed_timestamps.len() {
             let compressed_segments = crate::try_compress(
                 1,
-                ErrorBound::try_new_relative(0.0).unwrap(),
+                ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
                 &uncompressed_timestamps.slice(index, batch_size),
                 &uncompressed_values.slice(index, batch_size),
             )

--- a/crates/modelardb_compression/src/models/gorilla.rs
+++ b/crates/modelardb_compression/src/models/gorilla.rs
@@ -278,14 +278,14 @@ mod tests {
     // Tests for Gorilla.
     #[test]
     fn test_empty_sequence() {
-        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let error_bound = ErrorBound::try_new_relative(0.0).unwrap();
         assert!(Gorilla::new(error_bound).model().0.is_empty());
     }
 
     proptest! {
     #[test]
     fn test_append_single_value(value in ProptestValue::ANY) {
-        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let error_bound = ErrorBound::try_new_relative(0.0).unwrap();
         let mut model_type = Gorilla::new(error_bound);
 
         model_type.compress_values(&[value]);
@@ -297,7 +297,7 @@ mod tests {
 
     #[test]
     fn test_append_repeated_values(value in ProptestValue::ANY) {
-        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let error_bound = ErrorBound::try_new_relative(0.0).unwrap();
         let mut model_type = Gorilla::new(error_bound);
 
         model_type.compress_values(&[value, value]);
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_append_different_values_with_leading_zero_bits() {
-        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let error_bound = ErrorBound::try_new_relative(0.0).unwrap();
         let mut model_type = Gorilla::new(error_bound);
 
         model_type.compress_values(&[37.0, 73.0]);
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_append_different_values_without_leading_zero_bits() {
-        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let error_bound = ErrorBound::try_new_relative(0.0).unwrap();
         let mut model_type = Gorilla::new(error_bound);
 
         model_type.compress_values(&[37.0, 71.0, 73.0]);
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_append_values_within_error_bound() {
-        let error_bound = ErrorBound::try_new(10.0).unwrap();
+        let error_bound = ErrorBound::try_new_relative(10.0).unwrap();
         let mut model_type = Gorilla::new(error_bound);
 
         model_type.compress_values(&[10.0]);
@@ -455,7 +455,7 @@ mod tests {
         values: &[Value],
         maybe_model_last_value: Option<Value>,
     ) -> Vec<u8> {
-        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let error_bound = ErrorBound::try_new_relative(0.0).unwrap();
         let mut model_type = Gorilla::new(error_bound);
         if let Some(model_last_value) = maybe_model_last_value {
             model_type.compress_values_without_first(values, model_last_value);

--- a/crates/modelardb_compression/src/models/gorilla.rs
+++ b/crates/modelardb_compression/src/models/gorilla.rs
@@ -274,9 +274,7 @@ mod tests {
     use proptest::{bool, collection, prop_assert, prop_assert_eq, prop_assume, proptest};
 
     use crate::models;
-
-    const ERROR_BOUND_ZERO: f32 = 0.0;
-    const ERROR_BOUND_TEN: f32 = 10.0;
+    use crate::tests::{ERROR_BOUND_TEN, ERROR_BOUND_ZERO};
 
     // Tests for Gorilla.
     #[test]
@@ -515,7 +513,7 @@ mod tests {
     }
 
     fn test_grid_with_error_bound(error_bound: ErrorBound, values: &[Value]) {
-        let compressed_values = compress_values_using_gorilla(error_bound, &values, None);
+        let compressed_values = compress_values_using_gorilla(error_bound, values, None);
 
         let mut univariate_id_builder = UnivariateIdBuilder::with_capacity(values.len());
         let timestamps: Vec<Timestamp> = (1..=values.len() as i64).step_by(1).collect();
@@ -543,7 +541,7 @@ mod tests {
         assert!(timestamps
             .windows(2)
             .all(|window| window[1] - window[0] == 1));
-        assert!(slice_of_value_equal(values_array.values(), &values));
+        assert!(slice_of_value_equal(values_array.values(), values));
     }
 
     #[test]

--- a/crates/modelardb_compression/src/models/gorilla.rs
+++ b/crates/modelardb_compression/src/models/gorilla.rs
@@ -270,11 +270,11 @@ pub fn grid(
 mod tests {
     use super::*;
 
+    use modelardb_common::test::{ERROR_BOUND_TEN, ERROR_BOUND_ZERO};
     use proptest::num::f32 as ProptestValue;
     use proptest::{bool, collection, prop_assert, prop_assert_eq, prop_assume, proptest};
 
     use crate::models;
-    use crate::tests::{ERROR_BOUND_TEN, ERROR_BOUND_ZERO};
 
     // Tests for Gorilla.
     #[test]
@@ -388,13 +388,13 @@ mod tests {
     }
 
     #[test]
-    fn test_append_values_within_error_bound_with_absolute_error_bound_zero() {
+    fn test_append_values_within_error_bound_with_absolute_error_bound_ten() {
         test_append_values_within_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_TEN).unwrap(),
         );
     }
     #[test]
-    fn test_append_values_within_error_bound_with_relative_error_bound_zero() {
+    fn test_append_values_within_error_bound_with_relative_error_bound_ten() {
         test_append_values_within_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_TEN).unwrap(),
         );
@@ -425,7 +425,7 @@ mod tests {
     // Tests for sum().
     proptest! {
     #[test]
-    fn test_sum_with_absolute_error_bound(values in collection::vec(ProptestValue::ANY, 0..50)) {
+    fn test_sum_with_absolute_error_bound_zero(values in collection::vec(ProptestValue::ANY, 0..50)) {
         prop_assume!(!values.is_empty());
         let expected_sum = values.iter().sum::<f32>();
         let compressed_values = compress_values_using_gorilla(
@@ -436,7 +436,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_with_relative_error_bound(values in collection::vec(ProptestValue::ANY, 0..50)) {
+    fn test_sum_with_relative_error_bound_zero(values in collection::vec(ProptestValue::ANY, 0..50)) {
         prop_assume!(!values.is_empty());
         let expected_sum = values.iter().sum::<f32>();
         let compressed_values = compress_values_using_gorilla(
@@ -448,7 +448,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_model_single_value_with_absolute_error_bound() {
+    fn test_sum_model_single_value_with_absolute_error_bound_zero() {
         let compressed_values = compress_values_using_gorilla(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             &[37.0],
@@ -459,7 +459,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_model_single_value_with_relative_error_bound() {
+    fn test_sum_model_single_value_with_relative_error_bound_zero() {
         let compressed_values = compress_values_using_gorilla(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             &[37.0],
@@ -470,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_residuals_single_value_with_absolute_error_bound() {
+    fn test_sum_residuals_single_value_with_absolute_error_bound_zero() {
         let maybe_model_last_value = Some(37.0);
         let compressed_values = compress_values_using_gorilla(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
@@ -482,7 +482,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sum_residuals_single_value_with_relative_error_bound() {
+    fn test_sum_residuals_single_value_with_relative_error_bound_zero() {
         let maybe_model_last_value = Some(37.0);
         let compressed_values = compress_values_using_gorilla(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
@@ -496,23 +496,23 @@ mod tests {
     // Tests for grid().
     proptest! {
     #[test]
-    fn test_grid_with_absolute_error_bound(values in collection::vec(ProptestValue::ANY, 0..50)) {
+    fn test_grid_with_absolute_error_bound_zero(values in collection::vec(ProptestValue::ANY, 0..50)) {
         prop_assume!(!values.is_empty());
-        test_grid_with_error_bound(
+        assert_grid_with_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             &values);
     }
 
     #[test]
-    fn test_grid_with_relative_error_bound(values in collection::vec(ProptestValue::ANY, 0..50)) {
+    fn test_grid_with_relative_error_bound_zero(values in collection::vec(ProptestValue::ANY, 0..50)) {
         prop_assume!(!values.is_empty());
-        test_grid_with_error_bound(
+        assert_grid_with_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             &values);
     }
     }
 
-    fn test_grid_with_error_bound(error_bound: ErrorBound, values: &[Value]) {
+    fn assert_grid_with_error_bound(error_bound: ErrorBound, values: &[Value]) {
         let compressed_values = compress_values_using_gorilla(error_bound, values, None);
 
         let mut univariate_id_builder = UnivariateIdBuilder::with_capacity(values.len());
@@ -545,7 +545,7 @@ mod tests {
     }
 
     #[test]
-    fn test_grid_model_single_value_with_absolute_error_bound() {
+    fn test_grid_model_single_value_with_absolute_error_bound_zero() {
         assert_grid_single(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             None,
@@ -553,7 +553,7 @@ mod tests {
     }
 
     #[test]
-    fn test_grid_model_single_value_with_relative_error_bound() {
+    fn test_grid_model_single_value_with_relative_error_bound_zero() {
         assert_grid_single(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             None,
@@ -561,7 +561,7 @@ mod tests {
     }
 
     #[test]
-    fn test_grid_residuals_single_value_with_absolute_error_bound() {
+    fn test_grid_residuals_single_value_with_absolute_error_bound_zero() {
         assert_grid_single(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             Some(37.0),
@@ -569,7 +569,7 @@ mod tests {
     }
 
     #[test]
-    fn test_grid_residuals_single_value_with_relative_error_bound() {
+    fn test_grid_residuals_single_value_with_relative_error_bound_zero() {
         assert_grid_single(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             Some(37.0),

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -39,10 +39,10 @@ pub const PMC_MEAN_ID: u8 = 0;
 pub const SWING_ID: u8 = 1;
 pub const GORILLA_ID: u8 = 2;
 
-// Number of implemented model types. It is usize instead of u8 as it is used as an array length.
+/// Number of implemented model types. It is usize instead of u8 as it is used as an array length.
 pub const MODEL_TYPE_COUNT: usize = 3;
 
-// Mapping of model type ids to names.
+/// Mapping of model type ids to names.
 pub const MODEL_TYPE_NAMES: [&str; MODEL_TYPE_COUNT] = ["pmc_mean", "swing", "gorilla"];
 
 /// Size of [`Value`] in bytes.
@@ -60,7 +60,7 @@ pub fn is_value_within_error_bound(
     match error_bound {
         ErrorBound::Absolute(error_bound) => {
             Value::abs(real_value - approximate_value) <= error_bound
-        },
+        }
         ErrorBound::Relative(error_bound) => {
             // Needed because result becomes NAN and approximate_value is rejected
             // if approximate_value and real_value are zero, and because NAN != NAN.
@@ -78,9 +78,7 @@ pub fn is_value_within_error_bound(
 /// Compute the maximum allowed deviation from `value` within `error bound`.
 pub fn maximum_allowed_deviation(error_bound: ErrorBound, value: f64) -> f64 {
     match error_bound {
-        ErrorBound::Absolute(error_bound) => {
-            error_bound as f64
-        },
+        ErrorBound::Absolute(error_bound) => error_bound as f64,
         ErrorBound::Relative(error_bound) => {
             // The error bound in percentage is divided by 100.1 instead of 100.0 to ensure the
             // deviation is below the error bound despite calculations being a bit inaccurate.

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -417,6 +417,10 @@ fn residuals_length(residuals: &[u8]) -> usize {
 mod tests {
     use super::*;
 
+    use modelardb_common::test::{
+        ERROR_BOUND_ABSOLUTE_MAX, ERROR_BOUND_ONE, ERROR_BOUND_RELATIVE_MAX, ERROR_BOUND_TEN,
+        ERROR_BOUND_ZERO,
+    };
     use proptest::num;
     use proptest::num::f32 as ProptestValue;
     use proptest::{prop_assert, prop_assume, proptest};
@@ -424,57 +428,113 @@ mod tests {
     // Tests for is_value_within_error_bound().
     proptest! {
     #[test]
-    fn test_same_value_is_always_within_error_bound(value in ProptestValue::ANY) {
-        prop_assert!(is_value_within_error_bound(ErrorBound::try_new_relative(0.0).unwrap(), value, value));
+    fn test_same_value_is_always_within_absolute_error_bound(value in ProptestValue::ANY) {
+        prop_assert!(is_value_within_error_bound(ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(), value, value));
     }
 
     #[test]
-    fn test_other_value_is_never_within_error_bound_of_positive_infinity(value in ProptestValue::ANY) {
+    fn test_same_value_is_always_within_relative_error_bound(value in ProptestValue::ANY) {
+        prop_assert!(is_value_within_error_bound(ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(), value, value));
+    }
+
+    #[test]
+    fn test_other_value_is_never_within_absolute_error_bound_of_positive_infinity(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
         prop_assert!(!is_value_within_error_bound(
-            ErrorBound::try_new_relative(100.0).unwrap(), Value::INFINITY, value));
+            ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap(), Value::INFINITY, value));
     }
 
     #[test]
-    fn test_other_value_is_never_within_error_bound_of_negative_infinity(value in ProptestValue::ANY) {
-        prop_assume!(value != Value::NEG_INFINITY);
-        prop_assert!(!is_value_within_error_bound(
-            ErrorBound::try_new_relative(100.0).unwrap(), Value::NEG_INFINITY, value));
-    }
-
-    #[test]
-    fn test_other_value_is_never_within_error_bound_of_nan(value in ProptestValue::ANY) {
-        prop_assume!(!value.is_nan());
-        prop_assert!(!is_value_within_error_bound(
-            ErrorBound::try_new_relative(100.0).unwrap(), Value::NAN, value));
-    }
-
-    #[test]
-    fn test_positive_infinity_is_never_within_error_bound_of_other_value(value in ProptestValue::ANY) {
+    fn test_other_value_is_never_within_relative_error_bound_of_positive_infinity(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
         prop_assert!(!is_value_within_error_bound(
-            ErrorBound::try_new_relative(100.0).unwrap(), value, Value::INFINITY));
+            ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap(), Value::INFINITY, value));
     }
 
     #[test]
-    fn test_negative_infinity_is_never_within_error_bound_of_other_value(value in ProptestValue::ANY) {
+    fn test_other_value_is_never_within_absolute_error_bound_of_negative_infinity(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
         prop_assert!(!is_value_within_error_bound(
-            ErrorBound::try_new_relative(100.0).unwrap(), value, Value::NEG_INFINITY));
+            ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap(), Value::NEG_INFINITY, value));
     }
 
     #[test]
-    fn test_nan_is_never_within_error_bound_of_other_value(value in ProptestValue::ANY) {
+    fn test_other_value_is_never_within_relative_error_bound_of_negative_infinity(value in ProptestValue::ANY) {
+        prop_assume!(value != Value::NEG_INFINITY);
+        prop_assert!(!is_value_within_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap(), Value::NEG_INFINITY, value));
+    }
+
+    #[test]
+    fn test_other_value_is_never_within_absolute_error_bound_of_nan(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
         prop_assert!(!is_value_within_error_bound(
-            ErrorBound::try_new_relative(100.0).unwrap(), value, Value::NAN));
+            ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap(), Value::NAN, value));
+    }
+
+    #[test]
+    fn test_other_value_is_never_within_relative_error_bound_of_nan(value in ProptestValue::ANY) {
+        prop_assume!(!value.is_nan());
+        prop_assert!(!is_value_within_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap(), Value::NAN, value));
+    }
+
+    #[test]
+    fn test_positive_infinity_is_never_within_absolute_error_bound_of_other_value(value in ProptestValue::ANY) {
+        prop_assume!(value != Value::INFINITY);
+        prop_assert!(!is_value_within_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap(), value, Value::INFINITY));
+    }
+
+    #[test]
+    fn test_positive_infinity_is_never_within_relative_error_bound_of_other_value(value in ProptestValue::ANY) {
+        prop_assume!(value != Value::INFINITY);
+        prop_assert!(!is_value_within_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap(), value, Value::INFINITY));
+    }
+
+    #[test]
+    fn test_negative_infinity_is_never_within_absolute_error_bound_of_other_value(value in ProptestValue::ANY) {
+        prop_assume!(value != Value::NEG_INFINITY);
+        prop_assert!(!is_value_within_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap(), value, Value::NEG_INFINITY));
+    }
+
+    #[test]
+    fn test_negative_infinity_is_never_within_relative_error_bound_of_other_value(value in ProptestValue::ANY) {
+        prop_assume!(value != Value::NEG_INFINITY);
+        prop_assert!(!is_value_within_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap(), value, Value::NEG_INFINITY));
+    }
+
+    #[test]
+    fn test_nan_is_never_within_absolute_error_bound_of_other_value(value in ProptestValue::ANY) {
+        prop_assume!(!value.is_nan());
+        prop_assert!(!is_value_within_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap(), value, Value::NAN));
+    }
+
+    #[test]
+    fn test_nan_is_never_within_relative_error_bound_of_other_value(value in ProptestValue::ANY) {
+        prop_assume!(!value.is_nan());
+        prop_assert!(!is_value_within_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap(), value, Value::NAN));
     }
     }
 
     #[test]
-    fn test_different_value_is_within_non_zero_error_bound() {
+    fn test_different_value_is_within_non_zero_absolute_error_bound() {
         assert!(is_value_within_error_bound(
-            ErrorBound::try_new_relative(10.0).unwrap(),
+            ErrorBound::try_new_absolute(ERROR_BOUND_ONE).unwrap(),
+            10.0,
+            11.0
+        ));
+    }
+
+    #[test]
+    fn test_different_value_is_within_non_zero_relative_error_bound() {
+        assert!(is_value_within_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_TEN).unwrap(),
             10.0,
             11.0
         ));

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -68,6 +68,13 @@ pub fn is_value_within_error_bound(
     }
 }
 
+/// Compute the maximum allowed deviation from `value` within `error bound`.
+pub fn maximum_allowed_deviation(error_bound: ErrorBound, value: f64) -> f64 {
+    // The error bound in percentage is divided by 100.1 instead of 100.0 to ensure the deviation is
+    // below the error bound despite calculations with floating-point values being a bit inaccurate.
+    f64::abs(value * (error_bound.0 as f64 / 100.1))
+}
+
 /// Returns true if `v1` and `v2` are equivalent or both values are NAN.
 fn equal_or_nan(v1: f64, v2: f64) -> bool {
     v1 == v2 || (v1.is_nan() && v2.is_nan())

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -59,11 +59,16 @@ pub fn is_value_within_error_bound(
 ) -> bool {
     match error_bound {
         ErrorBound::Absolute(error_bound) => {
-            Value::abs(real_value - approximate_value) <= error_bound
+            // Needed to allow +INFINITY, -INFINITY, and NAN values to be stored lossless.
+            if equal_or_nan(real_value as f64, approximate_value as f64) {
+                true
+            } else {
+                Value::abs(real_value - approximate_value) <= error_bound
+            }
         }
         ErrorBound::Relative(error_bound) => {
-            // Needed because result becomes NAN and approximate_value is rejected
-            // if approximate_value and real_value are zero, and because NAN != NAN.
+            // Needed because result becomes NAN and approximate_value is rejected if
+            // approximate_value and real_value are zero, and because NAN != NAN.
             if equal_or_nan(real_value as f64, approximate_value as f64) {
                 true
             } else {

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -77,13 +77,10 @@ pub fn is_value_within_error_bound(
 
 /// Compute the maximum allowed deviation from `value` within `error bound`.
 pub fn maximum_allowed_deviation(error_bound: ErrorBound, value: f64) -> f64 {
+    // The allowed deviation is lower than the bound to account for inaccurate floating point math.
     match error_bound {
-        ErrorBound::Absolute(error_bound) => error_bound as f64,
-        ErrorBound::Relative(error_bound) => {
-            // The error bound in percentage is divided by 100.1 instead of 100.0 to ensure the
-            // deviation is below the error bound despite calculations being a bit inaccurate.
-            f64::abs(value * (error_bound as f64 / 100.1))
-        }
+        ErrorBound::Absolute(error_bound) => error_bound as f64 * 0.99,
+        ErrorBound::Relative(error_bound) => f64::abs(value * (error_bound as f64 / 100.1)),
     }
 }
 

--- a/crates/modelardb_compression/src/models/pmc_mean.rs
+++ b/crates/modelardb_compression/src/models/pmc_mean.rs
@@ -132,17 +132,17 @@ mod tests {
     proptest! {
     #[test]
     fn test_can_fit_sequence_of_finite_value_with_absolute_error_bound_zero(value in ProptestValue::ANY) {
-        can_fit_sequence_of_value(ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(), value)
+        can_fit_sequence_of_value_within_error_bound(ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(), value)
     }
 
     fn test_can_fit_sequence_of_finite_value_with_relative_error_bound_zero(value in ProptestValue::ANY) {
-        can_fit_sequence_of_value(ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(), value)
+        can_fit_sequence_of_value_within_error_bound(ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(), value)
     }
     }
 
     #[test]
     fn test_can_fit_sequence_of_positive_infinity_with_absolute_error_bound_zero() {
-        can_fit_sequence_of_value(
+        can_fit_sequence_of_value_within_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             Value::INFINITY,
         )
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_can_fit_sequence_of_positive_infinity_with_relative_error_bound_zero() {
-        can_fit_sequence_of_value(
+        can_fit_sequence_of_value_within_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             Value::INFINITY,
         )
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_can_fit_sequence_of_negative_infinity_with_absolute_error_bound_zero() {
-        can_fit_sequence_of_value(
+        can_fit_sequence_of_value_within_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             Value::NEG_INFINITY,
         )
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn test_can_fit_sequence_of_negative_infinity_with_relative_error_bound_zero() {
-        can_fit_sequence_of_value(
+        can_fit_sequence_of_value_within_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             Value::NEG_INFINITY,
         )
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn test_can_fit_sequence_of_nans_with_absolute_error_bound_zero() {
-        can_fit_sequence_of_value(
+        can_fit_sequence_of_value_within_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             Value::NAN,
         )
@@ -182,13 +182,13 @@ mod tests {
 
     #[test]
     fn test_can_fit_sequence_of_nans_with_relative_error_bound_zero() {
-        can_fit_sequence_of_value(
+        can_fit_sequence_of_value_within_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             Value::NAN,
         )
     }
 
-    fn can_fit_sequence_of_value(error_bound: ErrorBound, value: Value) {
+    fn can_fit_sequence_of_value_within_error_bound(error_bound: ErrorBound, value: Value) {
         let mut model_type = PMCMean::new(error_bound);
         for _ in 0..5 {
             assert!(model_type.fit_value(value));

--- a/crates/modelardb_compression/src/models/pmc_mean.rs
+++ b/crates/modelardb_compression/src/models/pmc_mean.rs
@@ -147,7 +147,7 @@ mod tests {
     }
 
     fn can_fit_sequence_of_value_with_error_bound_zero(value: Value) {
-        let error_bound_zero = ErrorBound::try_new(0.0).unwrap();
+        let error_bound_zero = ErrorBound::try_new_relative(0.0).unwrap();
         let mut model_type = PMCMean::new(error_bound_zero);
         for _ in 0..5 {
             assert!(model_type.fit_value(value));
@@ -163,14 +163,14 @@ mod tests {
     proptest! {
     #[test]
     fn test_can_fit_one_value(value in ProptestValue::ANY) {
-        let error_bound_zero = ErrorBound::try_new(0.0).unwrap();
+        let error_bound_zero = ErrorBound::try_new_relative(0.0).unwrap();
         prop_assert!(PMCMean::new(error_bound_zero).fit_value(value));
     }
 
     #[test]
     fn test_cannot_fit_other_value_and_positive_infinity(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
         prop_assert!(model_type.fit_value(value));
         prop_assert!(!model_type.fit_value(Value::INFINITY));
@@ -179,7 +179,7 @@ mod tests {
     #[test]
     fn test_cannot_fit_other_value_and_negative_infinity(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
         prop_assert!(model_type.fit_value(value));
         prop_assert!(!model_type.fit_value(Value::NEG_INFINITY));
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn test_cannot_fit_other_value_and_nan(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
         prop_assert!(model_type.fit_value(value));
         prop_assert!(!model_type.fit_value(Value::NAN));
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn test_cannot_fit_positive_infinity_and_other_value(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
         prop_assert!(model_type.fit_value(Value::INFINITY));
         prop_assert!(!model_type.fit_value(value));
@@ -206,7 +206,7 @@ mod tests {
     #[test]
     fn test_cannot_fit_negative_infinity_and_other_value(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
         prop_assert!(model_type.fit_value(Value::NEG_INFINITY));
         prop_assert!(!model_type.fit_value(value));
@@ -215,7 +215,7 @@ mod tests {
     #[test]
     fn test_cannot_fit_nan_and_other_value(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
         prop_assert!(model_type.fit_value(Value::NAN));
         prop_assert!(!model_type.fit_value(value));
@@ -224,7 +224,7 @@ mod tests {
 
     #[test]
     fn test_cannot_fit_sequence_of_different_values_with_error_bound_zero() {
-        let error_bound_zero = ErrorBound::try_new(0.0).unwrap();
+        let error_bound_zero = ErrorBound::try_new_relative(0.0).unwrap();
         assert!(!fit_sequence_of_different_values_with_error_bound(
             error_bound_zero
         ))
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_can_fit_sequence_of_different_values_with_error_bound_five() {
-        let error_bound_five = ErrorBound::try_new(5.0).unwrap();
+        let error_bound_five = ErrorBound::try_new_relative(5.0).unwrap();
         assert!(fit_sequence_of_different_values_with_error_bound(
             error_bound_five
         ))

--- a/crates/modelardb_compression/src/models/pmc_mean.rs
+++ b/crates/modelardb_compression/src/models/pmc_mean.rs
@@ -120,12 +120,11 @@ pub fn grid(
 mod tests {
     use super::*;
 
-    use proptest::num::f32 as ProptestValue;
-    use proptest::{prop_assert, prop_assume, proptest};
-
-    use crate::tests::{
+    use modelardb_common::test::{
         ERROR_BOUND_ABSOLUTE_MAX, ERROR_BOUND_FIVE, ERROR_BOUND_RELATIVE_MAX, ERROR_BOUND_ZERO,
     };
+    use proptest::num::f32 as ProptestValue;
+    use proptest::{prop_assert, prop_assume, proptest};
 
     // Tests for PMCMean.
     proptest! {
@@ -134,6 +133,7 @@ mod tests {
         can_fit_sequence_of_value_within_error_bound(ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(), value)
     }
 
+    #[test]
     fn test_can_fit_sequence_of_finite_value_with_relative_error_bound_zero(value in ProptestValue::ANY) {
         can_fit_sequence_of_value_within_error_bound(ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(), value)
     }
@@ -202,19 +202,19 @@ mod tests {
 
     proptest! {
     #[test]
-    fn test_can_fit_one_value_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_can_fit_one_value_with_absolute_error_bound_zero(value in ProptestValue::ANY) {
         let error_bound_zero = ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap();
         prop_assert!(PMCMean::new(error_bound_zero).fit_value(value));
     }
 
     #[test]
-    fn test_can_fit_one_value_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_can_fit_one_value_with_relative_error_bound_zero(value in ProptestValue::ANY) {
         let error_bound_zero = ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap();
         prop_assert!(PMCMean::new(error_bound_zero).fit_value(value));
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_positive_infinity_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_positive_infinity_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -223,7 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_positive_infinity_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_positive_infinity_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -232,7 +232,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_negative_infinity_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_negative_infinity_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -241,7 +241,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_negative_infinity_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_negative_infinity_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -250,7 +250,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_nan_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_nan_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -259,7 +259,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_nan_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_nan_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -268,7 +268,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_positive_infinity_and_other_value_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_positive_infinity_and_other_value_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -277,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_positive_infinity_and_other_value_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_positive_infinity_and_other_value_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -286,7 +286,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_negative_infinity_and_other_value_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_negative_infinity_and_other_value_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -295,7 +295,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_negative_infinity_and_other_value_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_negative_infinity_and_other_value_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -304,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_nan_and_other_value_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_nan_and_other_value_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -313,7 +313,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_nan_and_other_value_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_nan_and_other_value_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = PMCMean::new(error_bound_max);
@@ -323,7 +323,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_sequence_of_different_values_with_absolute_error_bound() {
+    fn test_cannot_fit_sequence_of_different_values_with_absolute_error_bound_zero() {
         let error_bound_zero = ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap();
         assert!(!fit_sequence_of_different_values_with_error_bound(
             error_bound_zero
@@ -331,7 +331,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_sequence_of_different_values_with_relative_error_bound() {
+    fn test_cannot_fit_sequence_of_different_values_with_relative_error_bound_zero() {
         let error_bound_zero = ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap();
         assert!(!fit_sequence_of_different_values_with_error_bound(
             error_bound_zero
@@ -339,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_different_values_with_absolute_error_bound() {
+    fn test_can_fit_sequence_of_different_values_with_absolute_error_bound_five() {
         let error_bound_five = ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap();
         assert!(fit_sequence_of_different_values_with_error_bound(
             error_bound_five
@@ -347,7 +347,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_different_values_with_relative_error_bound() {
+    fn test_can_fit_sequence_of_different_values_with_relative_error_bound_five() {
         let error_bound_five = ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap();
         assert!(fit_sequence_of_different_values_with_error_bound(
             error_bound_five

--- a/crates/modelardb_compression/src/models/pmc_mean.rs
+++ b/crates/modelardb_compression/src/models/pmc_mean.rs
@@ -123,10 +123,9 @@ mod tests {
     use proptest::num::f32 as ProptestValue;
     use proptest::{prop_assert, prop_assume, proptest};
 
-    const ERROR_BOUND_ZERO: f32 = 0.0;
-    const ERROR_BOUND_FIVE: f32 = 5.0;
-    const ERROR_BOUND_ABSOLUTE_MAX: f32 = f32::MAX;
-    const ERROR_BOUND_RELATIVE_MAX: f32 = 100.0;
+    use crate::tests::{
+        ERROR_BOUND_ABSOLUTE_MAX, ERROR_BOUND_FIVE, ERROR_BOUND_RELATIVE_MAX, ERROR_BOUND_ZERO,
+    };
 
     // Tests for PMCMean.
     proptest! {

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -472,7 +472,7 @@ mod tests {
     }
 
     #[test]
-        fn test_cannot_fit_other_value_and_positive_infinity_with_absolute_error_bound_max(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_positive_infinity_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -193,11 +193,11 @@ impl Swing {
     /// only require `size_of::<Value>` while the slope and intercept generally
     /// must be [`f64`] to be precise enough.
     pub fn model(self) -> (Value, Value) {
-        // TODO: Use the method in the Slide and Swing paper to select the
-        // linear function within the lower and upper that minimizes error
-        let first_value =
-            self.upper_bound_slope * self.start_time as f64 + self.upper_bound_intercept;
-        let last_value = self.upper_bound_slope * self.end_time as f64 + self.upper_bound_intercept;
+        // TODO: use the function with the minimum error as specified in the Swing and Slide paper.
+        let average_slope = (self.lower_bound_slope + self.upper_bound_slope) / 2.0;
+        let average_intercept = (self.lower_bound_intercept + self.upper_bound_intercept) / 2.0;
+        let first_value = average_slope * self.start_time as f64 + average_intercept;
+        let last_value = average_slope * self.end_time as f64 + average_intercept;
         (first_value as Value, last_value as Value)
     }
 }

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -331,15 +331,15 @@ mod tests {
     use super::*;
 
     use arrow::array::{BinaryArray, Float32Array, UInt64Array, UInt8Array};
+    use modelardb_common::test::{
+        ERROR_BOUND_ABSOLUTE_MAX, ERROR_BOUND_FIVE, ERROR_BOUND_RELATIVE_MAX, ERROR_BOUND_ZERO,
+    };
     use modelardb_common::types::{TimestampArray, TimestampBuilder, ValueArray, ValueBuilder};
     use proptest::num::f32 as ProptestValue;
     use proptest::strategy::Strategy;
     use proptest::{num, prop_assert, prop_assert_eq, prop_assume, proptest};
 
     use crate::models::SWING_ID;
-    use crate::tests::{
-        ERROR_BOUND_ABSOLUTE_MAX, ERROR_BOUND_FIVE, ERROR_BOUND_RELATIVE_MAX, ERROR_BOUND_ZERO,
-    };
 
     // Tests constants chosen to be realistic while minimizing the testing time.
     const SAMPLING_INTERVAL: Timestamp = 1000;
@@ -350,14 +350,14 @@ mod tests {
     // Tests for Swing.
     proptest! {
     #[test]
-    fn test_can_fit_sequence_of_finite_value_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_can_fit_sequence_of_finite_value_with_absolute_error_bound_zero(value in ProptestValue::ANY) {
         can_fit_sequence_of_value_with_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             value)
     }
 
     #[test]
-    fn test_can_fit_sequence_of_finite_value_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_can_fit_sequence_of_finite_value_with_relative_error_bound_zero(value in ProptestValue::ANY) {
         can_fit_sequence_of_value_with_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             value)
@@ -365,7 +365,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_positive_infinity_with_absolute_error_bound() {
+    fn test_can_fit_sequence_of_positive_infinity_with_absolute_error_bound_zero() {
         can_fit_sequence_of_value_with_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             Value::INFINITY,
@@ -373,7 +373,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_positive_infinity_with_relative_error_bound() {
+    fn test_can_fit_sequence_of_positive_infinity_with_relative_error_bound_zero() {
         can_fit_sequence_of_value_with_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             Value::INFINITY,
@@ -381,7 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_negative_infinity_with_absolute_error_bound() {
+    fn test_can_fit_sequence_of_negative_infinity_with_absolute_error_bound_zero() {
         can_fit_sequence_of_value_with_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             Value::NEG_INFINITY,
@@ -389,7 +389,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_negative_infinity_with_relative_error_bound() {
+    fn test_can_fit_sequence_of_negative_infinity_with_relative_error_bound_zero() {
         can_fit_sequence_of_value_with_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             Value::NEG_INFINITY,
@@ -397,7 +397,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_nans_with_absolute_error_bound() {
+    fn test_can_fit_sequence_of_nans_with_absolute_error_bound_zero() {
         can_fit_sequence_of_value_with_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             Value::NAN,
@@ -405,7 +405,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_nans_with_relative_error_bound() {
+    fn test_can_fit_sequence_of_nans_with_relative_error_bound_zero() {
         can_fit_sequence_of_value_with_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             Value::NAN,
@@ -438,19 +438,19 @@ mod tests {
 
     proptest! {
     #[test]
-    fn test_can_fit_one_value_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_can_fit_one_value_with_absolute_error_bound_zero(value in ProptestValue::ANY) {
         let error_bound_zero = ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap();
         prop_assert!(Swing::new(error_bound_zero).fit_data_point(START_TIME, value));
     }
 
     #[test]
-    fn test_can_fit_one_value_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_can_fit_one_value_with_relative_error_bound_zero(value in ProptestValue::ANY) {
         let error_bound_zero = ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap();
         prop_assert!(Swing::new(error_bound_zero).fit_data_point(START_TIME, value));
     }
 
     #[test]
-    fn test_can_fit_two_finite_value_with_absolute_error_bound(
+    fn test_can_fit_two_finite_value_with_absolute_error_bound_zero(
         first_value in ProptestValue::NORMAL,
         second_value in ProptestValue::NORMAL
     ) {
@@ -461,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_two_finite_value_with_relative_error_bound(
+    fn test_can_fit_two_finite_value_with_relative_error_bound_zero(
         first_value in ProptestValue::NORMAL,
         second_value in ProptestValue::NORMAL
     ) {
@@ -472,7 +472,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_positive_infinity_with_absolute_error_bound(value in ProptestValue::ANY) {
+        fn test_cannot_fit_other_value_and_positive_infinity_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -481,7 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_positive_infinity_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_positive_infinity_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -490,7 +490,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_negative_infinity_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_negative_infinity_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -499,7 +499,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_negative_infinity_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_negative_infinity_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -508,7 +508,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_nan_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_nan_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -517,7 +517,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_nan_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_nan_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -526,7 +526,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_positive_infinity_and_other_value_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_positive_infinity_and_other_value_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -535,7 +535,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_positive_infinity_and_other_value_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_positive_infinity_and_other_value_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -544,7 +544,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_negative_infinity_and_other_value_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_negative_infinity_and_other_value_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -553,7 +553,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_negative_infinity_and_other_value_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_negative_infinity_and_other_value_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -562,7 +562,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_nan_and_other_value_with_absolute_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_nan_and_other_value_with_absolute_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
         let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -571,7 +571,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_nan_and_other_value_with_relative_error_bound(value in ProptestValue::ANY) {
+    fn test_cannot_fit_nan_and_other_value_with_relative_error_bound_max(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
         let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
@@ -581,7 +581,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_linear_values_with_absolute_error_bound() {
+    fn test_can_fit_sequence_of_linear_values_with_absolute_error_bound_zero() {
         assert!(fit_sequence_of_values_with_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             &[42.0, 84.0, 126.0, 168.0, 210.0],
@@ -589,7 +589,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_linear_values_with_relative_error_bound() {
+    fn test_can_fit_sequence_of_linear_values_with_relative_error_bound_zero() {
         assert!(fit_sequence_of_values_with_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             &[42.0, 84.0, 126.0, 168.0, 210.0],
@@ -597,7 +597,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_sequence_of_different_values_with_absolute_error_bound() {
+    fn test_cannot_fit_sequence_of_different_values_with_absolute_error_bound_zero() {
         assert!(!fit_sequence_of_values_with_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             &[42.0, 42.0, 42.8, 42.0, 42.0],
@@ -605,7 +605,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_sequence_of_different_values_with_relative_error_bound() {
+    fn test_cannot_fit_sequence_of_different_values_with_relative_error_bound_zero() {
         assert!(!fit_sequence_of_values_with_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             &[42.0, 42.0, 42.8, 42.0, 42.0],
@@ -613,7 +613,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_different_values_with_absolute_error_bound() {
+    fn test_can_fit_sequence_of_different_values_with_absolute_error_bound_five() {
         assert!(fit_sequence_of_values_with_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
             &[42.0, 42.0, 42.8, 42.0, 42.0],
@@ -621,7 +621,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_different_values_with_relative_error_bound() {
+    fn test_can_fit_sequence_of_different_values_with_relative_error_bound_five() {
         assert!(fit_sequence_of_values_with_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             &[42.0, 42.0, 42.8, 42.0, 42.0],
@@ -700,44 +700,48 @@ mod tests {
     }
 
     #[test]
-    fn test_can_reconstruct_sequence_of_linear_increasing_values_within_absolute_error_bound() {
-        test_can_reconstruct_sequence_of_linear_values_within_error_bound(
+    fn test_can_reconstruct_sequence_of_linear_increasing_values_within_absolute_error_bound_zero()
+    {
+        assert_can_reconstruct_sequence_of_linear_values_within_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             (42..=4200).step_by(42).map(|value| value as f32).collect(),
         )
     }
 
     #[test]
-    fn test_can_reconstruct_sequence_of_linear_increasing_values_within_relative_error_bound() {
-        test_can_reconstruct_sequence_of_linear_values_within_error_bound(
+    fn test_can_reconstruct_sequence_of_linear_increasing_values_within_relative_error_bound_zero()
+    {
+        assert_can_reconstruct_sequence_of_linear_values_within_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             (42..=4200).step_by(42).map(|value| value as f32).collect(),
         )
     }
 
     #[test]
-    fn test_can_reconstruct_sequence_of_linear_decreasing_values_within_absolute_error_bound() {
+    fn test_can_reconstruct_sequence_of_linear_decreasing_values_within_absolute_error_bound_zero()
+    {
         let mut values: Vec<Value> = (42..=4200).step_by(42).map(|value| value as f32).collect();
         values.reverse();
 
-        test_can_reconstruct_sequence_of_linear_values_within_error_bound(
+        assert_can_reconstruct_sequence_of_linear_values_within_error_bound(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             values,
         );
     }
 
     #[test]
-    fn test_can_reconstruct_sequence_of_linear_decreasing_values_within_relative_error_bound() {
+    fn test_can_reconstruct_sequence_of_linear_decreasing_values_within_relative_error_bound_zero()
+    {
         let mut values: Vec<Value> = (42..=4200).step_by(42).map(|value| value as f32).collect();
         values.reverse();
 
-        test_can_reconstruct_sequence_of_linear_values_within_error_bound(
+        assert_can_reconstruct_sequence_of_linear_values_within_error_bound(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             values,
         );
     }
 
-    fn test_can_reconstruct_sequence_of_linear_values_within_error_bound(
+    fn assert_can_reconstruct_sequence_of_linear_values_within_error_bound(
         error_bound: ErrorBound,
         values: Vec<Value>,
     ) {

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -368,7 +368,7 @@ mod tests {
     }
 
     fn can_fit_sequence_of_value_with_error_bound_zero(value: Value) {
-        let error_bound_zero = ErrorBound::try_new(0.0).unwrap();
+        let error_bound_zero = ErrorBound::try_new_relative(0.0).unwrap();
         let mut model_type = Swing::new(error_bound_zero);
         let end_time = START_TIME + SEGMENT_LENGTH * SAMPLING_INTERVAL;
         for timestamp in (START_TIME..end_time).step_by(SAMPLING_INTERVAL as usize) {
@@ -395,7 +395,7 @@ mod tests {
     proptest! {
     #[test]
     fn test_can_fit_one_value(value in ProptestValue::ANY) {
-        let error_bound_zero = ErrorBound::try_new(0.0).unwrap();
+        let error_bound_zero = ErrorBound::try_new_relative(0.0).unwrap();
         prop_assert!(Swing::new(error_bound_zero).fit_data_point(START_TIME, value));
     }
 
@@ -404,7 +404,7 @@ mod tests {
         first_value in ProptestValue::NORMAL,
         second_value in ProptestValue::NORMAL
     ) {
-        let error_bound_zero = ErrorBound::try_new(0.0).unwrap();
+        let error_bound_zero = ErrorBound::try_new_relative(0.0).unwrap();
         let mut model_type = Swing::new(error_bound_zero);
         prop_assert!(model_type.fit_data_point(START_TIME, first_value));
         prop_assert!(model_type.fit_data_point(END_TIME, second_value));
@@ -413,7 +413,7 @@ mod tests {
     #[test]
     fn test_cannot_fit_other_value_and_positive_infinity(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, value));
         prop_assert!(!model_type.fit_data_point(END_TIME, Value::INFINITY));
@@ -422,7 +422,7 @@ mod tests {
     #[test]
     fn test_cannot_fit_other_value_and_negative_infinity(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, value));
         prop_assert!(!model_type.fit_data_point(END_TIME, Value::NEG_INFINITY));
@@ -431,7 +431,7 @@ mod tests {
     #[test]
     fn test_cannot_fit_other_value_and_nan(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, value));
         prop_assert!(!model_type.fit_data_point(END_TIME, Value::NAN));
@@ -440,7 +440,7 @@ mod tests {
     #[test]
     fn test_cannot_fit_positive_infinity_and_other_value(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, Value::INFINITY));
         prop_assert!(!model_type.fit_data_point(END_TIME, value));
@@ -449,7 +449,7 @@ mod tests {
     #[test]
     fn test_cannot_fit_negative_infinity_and_other_value(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, Value::NEG_INFINITY));
         prop_assert!(!model_type.fit_data_point(END_TIME, value));
@@ -458,7 +458,7 @@ mod tests {
     #[test]
     fn test_cannot_fit_nan_and_other_value(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
-        let error_bound_max = ErrorBound::try_new(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, Value::NAN));
         prop_assert!(!model_type.fit_data_point(END_TIME, value));
@@ -490,7 +490,7 @@ mod tests {
     }
 
     fn fit_sequence_of_values_with_error_bound(values: &[Value], error_bound: Value) -> bool {
-        let error_bound = ErrorBound::try_new(error_bound).unwrap();
+        let error_bound = ErrorBound::try_new_relative(error_bound).unwrap();
         let mut model_type = Swing::new(error_bound);
         let mut fit_all_values = true;
         let mut timestamp = START_TIME;
@@ -578,7 +578,7 @@ mod tests {
 
     fn test_can_reconstruct_sequence_of_linear_values_within_error_bound_zero(values: Vec<Value>) {
         // Fit model of type Swing to perfectly linear sequence.
-        let error_bound = ErrorBound::try_new(0.0).unwrap();
+        let error_bound = ErrorBound::try_new_relative(0.0).unwrap();
         let end_time = START_TIME + values.len() as i64 * SAMPLING_INTERVAL;
         let timestamps = TimestampArray::from_iter_values(
             (START_TIME..end_time).step_by(SAMPLING_INTERVAL as usize),

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -344,32 +344,78 @@ mod tests {
     const END_TIME: Timestamp = START_TIME + SAMPLING_INTERVAL;
     const SEGMENT_LENGTH: Timestamp = 5; // Timestamp is used to remove casts.
 
+    const ERROR_BOUND_ZERO: f32 = 0.0;
+    const ERROR_BOUND_FIVE: f32 = 5.0;
+    const ERROR_BOUND_ABSOLUTE_MAX: f32 = f32::MAX;
+    const ERROR_BOUND_RELATIVE_MAX: f32 = 100.0;
+
     // Tests for Swing.
     proptest! {
     #[test]
-    fn test_can_fit_sequence_of_finite_value_with_error_bound_zero(value in ProptestValue::ANY) {
-        can_fit_sequence_of_value_with_error_bound_zero(value)
+    fn test_can_fit_sequence_of_finite_value_with_absolute_error_bound(value in ProptestValue::ANY) {
+        can_fit_sequence_of_value_with_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            value)
+    }
+
+    #[test]
+    fn test_can_fit_sequence_of_finite_value_with_relative_error_bound(value in ProptestValue::ANY) {
+        can_fit_sequence_of_value_with_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            value)
     }
     }
 
     #[test]
-    fn test_can_fit_sequence_of_positive_infinity_with_error_bound_zero() {
-        can_fit_sequence_of_value_with_error_bound_zero(Value::INFINITY)
+    fn test_can_fit_sequence_of_positive_infinity_with_absolute_error_bound() {
+        can_fit_sequence_of_value_with_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            Value::INFINITY,
+        )
     }
 
     #[test]
-    fn test_can_fit_sequence_of_negative_infinity_with_error_bound_zero() {
-        can_fit_sequence_of_value_with_error_bound_zero(Value::NEG_INFINITY)
+    fn test_can_fit_sequence_of_positive_infinity_with_relative_error_bound() {
+        can_fit_sequence_of_value_with_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            Value::INFINITY,
+        )
     }
 
     #[test]
-    fn test_can_fit_sequence_of_nans_with_error_bound_zero() {
-        can_fit_sequence_of_value_with_error_bound_zero(Value::NAN)
+    fn test_can_fit_sequence_of_negative_infinity_with_absolute_error_bound() {
+        can_fit_sequence_of_value_with_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            Value::NEG_INFINITY,
+        )
     }
 
-    fn can_fit_sequence_of_value_with_error_bound_zero(value: Value) {
-        let error_bound_zero = ErrorBound::try_new_relative(0.0).unwrap();
-        let mut model_type = Swing::new(error_bound_zero);
+    #[test]
+    fn test_can_fit_sequence_of_negative_infinity_with_relative_error_bound() {
+        can_fit_sequence_of_value_with_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            Value::NEG_INFINITY,
+        )
+    }
+
+    #[test]
+    fn test_can_fit_sequence_of_nans_with_absolute_error_bound() {
+        can_fit_sequence_of_value_with_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            Value::NAN,
+        )
+    }
+
+    #[test]
+    fn test_can_fit_sequence_of_nans_with_relative_error_bound() {
+        can_fit_sequence_of_value_with_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            Value::NAN,
+        )
+    }
+
+    fn can_fit_sequence_of_value_with_error_bound(error_bound: ErrorBound, value: Value) {
+        let mut model_type = Swing::new(error_bound);
         let end_time = START_TIME + SEGMENT_LENGTH * SAMPLING_INTERVAL;
         for timestamp in (START_TIME..end_time).step_by(SAMPLING_INTERVAL as usize) {
             assert!(model_type.fit_data_point(timestamp, value));
@@ -394,71 +440,142 @@ mod tests {
 
     proptest! {
     #[test]
-    fn test_can_fit_one_value(value in ProptestValue::ANY) {
-        let error_bound_zero = ErrorBound::try_new_relative(0.0).unwrap();
+    fn test_can_fit_one_value_with_absolute_error_bound(value in ProptestValue::ANY) {
+        let error_bound_zero = ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap();
         prop_assert!(Swing::new(error_bound_zero).fit_data_point(START_TIME, value));
     }
 
     #[test]
-    fn test_can_fit_two_finite_value(
+    fn test_can_fit_one_value_with_relative_error_bound(value in ProptestValue::ANY) {
+        let error_bound_zero = ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap();
+        prop_assert!(Swing::new(error_bound_zero).fit_data_point(START_TIME, value));
+    }
+
+    #[test]
+    fn test_can_fit_two_finite_value_with_absolute_error_bound(
         first_value in ProptestValue::NORMAL,
         second_value in ProptestValue::NORMAL
     ) {
-        let error_bound_zero = ErrorBound::try_new_relative(0.0).unwrap();
+        let error_bound_zero = ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap();
         let mut model_type = Swing::new(error_bound_zero);
         prop_assert!(model_type.fit_data_point(START_TIME, first_value));
         prop_assert!(model_type.fit_data_point(END_TIME, second_value));
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_positive_infinity(value in ProptestValue::ANY) {
+    fn test_can_fit_two_finite_value_with_relative_error_bound(
+        first_value in ProptestValue::NORMAL,
+        second_value in ProptestValue::NORMAL
+    ) {
+        let error_bound_zero = ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap();
+        let mut model_type = Swing::new(error_bound_zero);
+        prop_assert!(model_type.fit_data_point(START_TIME, first_value));
+        prop_assert!(model_type.fit_data_point(END_TIME, second_value));
+    }
+
+    #[test]
+    fn test_cannot_fit_other_value_and_positive_infinity_with_absolute_error_bound(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
-        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, value));
         prop_assert!(!model_type.fit_data_point(END_TIME, Value::INFINITY));
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_negative_infinity(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_positive_infinity_with_relative_error_bound(value in ProptestValue::ANY) {
+        prop_assume!(value != Value::INFINITY);
+        let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
+        let mut model_type = Swing::new(error_bound_max);
+        prop_assert!(model_type.fit_data_point(START_TIME, value));
+        prop_assert!(!model_type.fit_data_point(END_TIME, Value::INFINITY));
+    }
+
+    #[test]
+    fn test_cannot_fit_other_value_and_negative_infinity_with_absolute_error_bound(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
-        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, value));
         prop_assert!(!model_type.fit_data_point(END_TIME, Value::NEG_INFINITY));
     }
 
     #[test]
-    fn test_cannot_fit_other_value_and_nan(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_negative_infinity_with_relative_error_bound(value in ProptestValue::ANY) {
+        prop_assume!(value != Value::NEG_INFINITY);
+        let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
+        let mut model_type = Swing::new(error_bound_max);
+        prop_assert!(model_type.fit_data_point(START_TIME, value));
+        prop_assert!(!model_type.fit_data_point(END_TIME, Value::NEG_INFINITY));
+    }
+
+    #[test]
+    fn test_cannot_fit_other_value_and_nan_with_absolute_error_bound(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
-        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, value));
         prop_assert!(!model_type.fit_data_point(END_TIME, Value::NAN));
     }
 
     #[test]
-    fn test_cannot_fit_positive_infinity_and_other_value(value in ProptestValue::ANY) {
+    fn test_cannot_fit_other_value_and_nan_with_relative_error_bound(value in ProptestValue::ANY) {
+        prop_assume!(!value.is_nan());
+        let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
+        let mut model_type = Swing::new(error_bound_max);
+        prop_assert!(model_type.fit_data_point(START_TIME, value));
+        prop_assert!(!model_type.fit_data_point(END_TIME, Value::NAN));
+    }
+
+    #[test]
+    fn test_cannot_fit_positive_infinity_and_other_value_with_absolute_error_bound(value in ProptestValue::ANY) {
         prop_assume!(value != Value::INFINITY);
-        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, Value::INFINITY));
         prop_assert!(!model_type.fit_data_point(END_TIME, value));
     }
 
     #[test]
-    fn test_cannot_fit_negative_infinity_and_other_value(value in ProptestValue::ANY) {
+    fn test_cannot_fit_positive_infinity_and_other_value_with_relative_error_bound(value in ProptestValue::ANY) {
+        prop_assume!(value != Value::INFINITY);
+        let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
+        let mut model_type = Swing::new(error_bound_max);
+        prop_assert!(model_type.fit_data_point(START_TIME, Value::INFINITY));
+        prop_assert!(!model_type.fit_data_point(END_TIME, value));
+    }
+
+    #[test]
+    fn test_cannot_fit_negative_infinity_and_other_value_with_absolute_error_bound(value in ProptestValue::ANY) {
         prop_assume!(value != Value::NEG_INFINITY);
-        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, Value::NEG_INFINITY));
         prop_assert!(!model_type.fit_data_point(END_TIME, value));
     }
 
     #[test]
-    fn test_cannot_fit_nan_and_other_value(value in ProptestValue::ANY) {
+    fn test_cannot_fit_negative_infinity_and_other_value_with_relative_error_bound(value in ProptestValue::ANY) {
+        prop_assume!(value != Value::NEG_INFINITY);
+        let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
+        let mut model_type = Swing::new(error_bound_max);
+        prop_assert!(model_type.fit_data_point(START_TIME, Value::NEG_INFINITY));
+        prop_assert!(!model_type.fit_data_point(END_TIME, value));
+    }
+
+    #[test]
+    fn test_cannot_fit_nan_and_other_value_with_absolute_error_bound(value in ProptestValue::ANY) {
         prop_assume!(!value.is_nan());
-        let error_bound_max = ErrorBound::try_new_relative(100.0).unwrap();
+        let error_bound_max = ErrorBound::try_new_absolute(ERROR_BOUND_ABSOLUTE_MAX).unwrap();
+        let mut model_type = Swing::new(error_bound_max);
+        prop_assert!(model_type.fit_data_point(START_TIME, Value::NAN));
+        prop_assert!(!model_type.fit_data_point(END_TIME, value));
+    }
+
+    #[test]
+    fn test_cannot_fit_nan_and_other_value_with_relative_error_bound(value in ProptestValue::ANY) {
+        prop_assume!(!value.is_nan());
+        let error_bound_max = ErrorBound::try_new_relative(ERROR_BOUND_RELATIVE_MAX).unwrap();
         let mut model_type = Swing::new(error_bound_max);
         prop_assert!(model_type.fit_data_point(START_TIME, Value::NAN));
         prop_assert!(!model_type.fit_data_point(END_TIME, value));
@@ -466,31 +583,54 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_linear_values_with_error_bound_zero() {
+    fn test_can_fit_sequence_of_linear_values_with_absolute_error_bound() {
         assert!(fit_sequence_of_values_with_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             &[42.0, 84.0, 126.0, 168.0, 210.0],
-            0.0,
         ))
     }
 
     #[test]
-    fn test_cannot_fit_sequence_of_different_values_with_error_bound_zero() {
-        assert!(!fit_sequence_of_values_with_error_bound(
-            &[42.0, 42.0, 42.8, 42.0, 42.0],
-            0.0,
-        ))
-    }
-
-    #[test]
-    fn test_can_fit_sequence_of_different_values_with_error_bound_five() {
+    fn test_can_fit_sequence_of_linear_values_with_relative_error_bound() {
         assert!(fit_sequence_of_values_with_error_bound(
-            &[42.0, 42.0, 42.8, 42.0, 42.0],
-            5.0,
+            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            &[42.0, 84.0, 126.0, 168.0, 210.0],
         ))
     }
 
-    fn fit_sequence_of_values_with_error_bound(values: &[Value], error_bound: Value) -> bool {
-        let error_bound = ErrorBound::try_new_relative(error_bound).unwrap();
+    #[test]
+    fn test_cannot_fit_sequence_of_different_values_with_absolute_error_bound() {
+        assert!(!fit_sequence_of_values_with_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            &[42.0, 42.0, 42.8, 42.0, 42.0],
+        ))
+    }
+
+    #[test]
+    fn test_cannot_fit_sequence_of_different_values_with_relative_error_bound() {
+        assert!(!fit_sequence_of_values_with_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            &[42.0, 42.0, 42.8, 42.0, 42.0],
+        ))
+    }
+
+    #[test]
+    fn test_can_fit_sequence_of_different_values_with_absolute_error_bound() {
+        assert!(fit_sequence_of_values_with_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
+            &[42.0, 42.0, 42.8, 42.0, 42.0],
+        ))
+    }
+
+    #[test]
+    fn test_can_fit_sequence_of_different_values_with_relative_error_bound() {
+        assert!(fit_sequence_of_values_with_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
+            &[42.0, 42.0, 42.8, 42.0, 42.0],
+        ))
+    }
+
+    fn fit_sequence_of_values_with_error_bound(error_bound: ErrorBound, values: &[Value]) -> bool {
         let mut model_type = Swing::new(error_bound);
         let mut fit_all_values = true;
         let mut timestamp = START_TIME;
@@ -562,23 +702,48 @@ mod tests {
     }
 
     #[test]
-    fn test_can_reconstruct_sequence_of_linear_increasing_values_within_error_bound_zero() {
-        test_can_reconstruct_sequence_of_linear_values_within_error_bound_zero(
+    fn test_can_reconstruct_sequence_of_linear_increasing_values_within_absolute_error_bound() {
+        test_can_reconstruct_sequence_of_linear_values_within_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             (42..=4200).step_by(42).map(|value| value as f32).collect(),
         )
     }
 
     #[test]
-    fn test_can_reconstruct_sequence_of_linear_decreasing_values_within_error_bound_zero() {
+    fn test_can_reconstruct_sequence_of_linear_increasing_values_within_relative_error_bound() {
+        test_can_reconstruct_sequence_of_linear_values_within_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            (42..=4200).step_by(42).map(|value| value as f32).collect(),
+        )
+    }
+
+    #[test]
+    fn test_can_reconstruct_sequence_of_linear_decreasing_values_within_absolute_error_bound() {
         let mut values: Vec<Value> = (42..=4200).step_by(42).map(|value| value as f32).collect();
         values.reverse();
 
-        test_can_reconstruct_sequence_of_linear_values_within_error_bound_zero(values);
+        test_can_reconstruct_sequence_of_linear_values_within_error_bound(
+            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            values,
+        );
     }
 
-    fn test_can_reconstruct_sequence_of_linear_values_within_error_bound_zero(values: Vec<Value>) {
+    #[test]
+    fn test_can_reconstruct_sequence_of_linear_decreasing_values_within_relative_error_bound() {
+        let mut values: Vec<Value> = (42..=4200).step_by(42).map(|value| value as f32).collect();
+        values.reverse();
+
+        test_can_reconstruct_sequence_of_linear_values_within_error_bound(
+            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            values,
+        );
+    }
+
+    fn test_can_reconstruct_sequence_of_linear_values_within_error_bound(
+        error_bound: ErrorBound,
+        values: Vec<Value>,
+    ) {
         // Fit model of type Swing to perfectly linear sequence.
-        let error_bound = ErrorBound::try_new_relative(0.0).unwrap();
         let end_time = START_TIME + values.len() as i64 * SAMPLING_INTERVAL;
         let timestamps = TimestampArray::from_iter_values(
             (START_TIME..end_time).step_by(SAMPLING_INTERVAL as usize),

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -337,17 +337,15 @@ mod tests {
     use proptest::{num, prop_assert, prop_assert_eq, prop_assume, proptest};
 
     use crate::models::SWING_ID;
+    use crate::tests::{
+        ERROR_BOUND_ABSOLUTE_MAX, ERROR_BOUND_FIVE, ERROR_BOUND_RELATIVE_MAX, ERROR_BOUND_ZERO,
+    };
 
     // Tests constants chosen to be realistic while minimizing the testing time.
     const SAMPLING_INTERVAL: Timestamp = 1000;
     const START_TIME: Timestamp = 1658671178037;
     const END_TIME: Timestamp = START_TIME + SAMPLING_INTERVAL;
     const SEGMENT_LENGTH: Timestamp = 5; // Timestamp is used to remove casts.
-
-    const ERROR_BOUND_ZERO: f32 = 0.0;
-    const ERROR_BOUND_FIVE: f32 = 5.0;
-    const ERROR_BOUND_ABSOLUTE_MAX: f32 = f32::MAX;
-    const ERROR_BOUND_RELATIVE_MAX: f32 = 100.0;
 
     // Tests for Swing.
     proptest! {

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -94,13 +94,7 @@ impl Swing {
     pub fn fit_data_point(&mut self, timestamp: Timestamp, value: Value) -> bool {
         // Simplify the calculations by removing a significant number of casts.
         let value = value as f64;
-        let error_bound = self.error_bound.0 as f64;
-
-        // Compute the maximum allowed deviation within the error bound. The
-        // error bound in percentage is divided by 100.1 instead of 100.0 to
-        // ensure that the approximate value is below the error bound despite
-        // calculations with floating-point values not being fully accurate.
-        let maximum_deviation = f64::abs(value * (error_bound / 100.1));
+        let maximum_deviation = models::maximum_allowed_deviation(self.error_bound, value);
 
         if self.length == 0 {
             // Line 1 - 2 of Algorithm 1 in the Swing and Slide paper.

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -496,10 +496,10 @@ mod tests {
 
     use arrow::array::BinaryArray;
     use modelardb_common::test::data_generation::{self, ValuesStructure};
+    use modelardb_common::test::{ERROR_BOUND_TEN, ERROR_BOUND_ZERO};
     use modelardb_common::types::{TimestampArray, ValueArray};
 
     use crate::compression;
-    use crate::tests::ERROR_BOUND_ZERO;
 
     const UNCOMPRESSED_TIMESTAMPS: &[Timestamp] = &[100, 200, 300, 400, 500];
 
@@ -846,7 +846,7 @@ mod tests {
 
         let model = compression::fit_next_model(
             0,
-            ErrorBound::try_new_relative(10.0).unwrap(),
+            ErrorBound::try_new_relative(ERROR_BOUND_TEN).unwrap(),
             &uncompressed_timestamps,
             &uncompressed_values.finish(),
         );

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -499,8 +499,8 @@ mod tests {
     use modelardb_common::types::{TimestampArray, ValueArray};
 
     use crate::compression;
+    use crate::tests::ERROR_BOUND_ZERO;
 
-    const ERROR_BOUND_ZERO: f32 = 0.0;
     const UNCOMPRESSED_TIMESTAMPS: &[Timestamp] = &[100, 200, 300, 400, 500];
 
     // Tests for CompressedSegmentBuilder.

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -775,7 +775,7 @@ mod tests {
 
         let model = compression::fit_next_model(
             0,
-            ErrorBound::try_new(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             &uncompressed_timestamps,
             uncompressed_values,
         );
@@ -797,7 +797,7 @@ mod tests {
 
         model.finish(
             0,
-            ErrorBound::try_new(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             residuals_end_index,
             &uncompressed_timestamps,
             uncompressed_values,
@@ -846,7 +846,7 @@ mod tests {
 
         let model = compression::fit_next_model(
             0,
-            ErrorBound::try_new(10.0).unwrap(),
+            ErrorBound::try_new_relative(10.0).unwrap(),
             &uncompressed_timestamps,
             &uncompressed_values.finish(),
         );

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -933,8 +933,8 @@ mod tests {
                 test::MODEL_TABLE_NAME.to_owned(),
                 query_schema,
                 vec![
-                    ErrorBound::try_new(0.0).unwrap(),
-                    ErrorBound::try_new(0.0).unwrap(),
+                    ErrorBound::try_new_relative(0.0).unwrap(),
+                    ErrorBound::try_new_relative(0.0).unwrap(),
                 ],
                 vec![None, None],
             )

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -549,6 +549,7 @@ mod tests {
     use tempfile::{self, TempDir};
 
     const COLUMN_INDEX: u16 = 5;
+    const ERROR_BOUND_ZERO: f32 = 0.0;
 
     // Tests for insert_record_batch().
     #[tokio::test]
@@ -933,8 +934,8 @@ mod tests {
                 test::MODEL_TABLE_NAME.to_owned(),
                 query_schema,
                 vec![
-                    ErrorBound::try_new_relative(0.0).unwrap(),
-                    ErrorBound::try_new_relative(0.0).unwrap(),
+                    ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+                    ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
                 ],
                 vec![None, None],
             )

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -1010,7 +1010,7 @@ fn assert_ne_query_plans_and_eq_result(segment_query: String, error_bound: f32) 
         let segment_query_result = array!(segment_query_result_set, 0, Float64Array);
 
         let within_error_bound = modelardb_compression::is_value_within_error_bound(
-            ErrorBound::try_new(error_bound).unwrap(),
+            ErrorBound::try_new_relative(error_bound).unwrap(),
             data_point_query_result.value(0) as f32,
             segment_query_result.value(0) as f32,
         );

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -148,24 +148,26 @@ MODELARDBD_PORT=8889
 ```
 
 ### Ingest Data
-Before time series can be ingested into `modelardbd`, a model table must be created. From a user's perspective a model
-table functions like any other table and can be queried using SQL. However, the implementation of model table is highly
+Before time series can be ingested into `modelardbd`, a model table must be created. From a user's perspective, a model
+table functions like any other table and can be queried using SQL. However, the implementation of a model table is highly
 optimized for time series and a model table must contain a single column with timestamps, one or more columns with
 fields (measurements as floating-point values), and zero or more columns with tags (metadata as strings). Model tables
 can be created using `CREATE MODEL TABLE` statements with the column types `TIMESTAMP`, `FIELD`, and `TAG`. For `FIELD`
-an error bound can optionally be specified in parentheses to enable lossy compression with a relative per value error
-bound, e.g., `FIELD(1.0)` creates a column with a one percent error bound. `FIELD` columns default to an error bound of
-zero when none is specified. If the values in a `FIELD` column can be computed from other columns they need not be stored.
-Instead, if a `FIELD` column is defined using the syntax `FIELD AS expression`, e.g., `FIELD AS column_one + column_two`,
-the values of the `FIELD` column will be the result of the expression. As these generated `FIELD` columns do not store any
-data, an error bound cannot be defined. `modelardb` also supports normal tables created through `CREATE TABLE` statements.
+an error bound can optionally be specified in parentheses to enable lossy compression with a per-value error bound.
+The error bound can be absolute or relative, e.g., `FIELD(1.0)` creates a column with an absolute per-value error bound that
+allows each value to deviate by at most 1.0 while `FIELD(1.0%)` creates a column with a relative per-value error bound that
+allows each value to deviate by at most 1.0%. `FIELD` columns default to an error bound of zero when none is specified.
+If the values in a `FIELD` column can be computed from other columns they need not be stored. Instead, if a `FIELD` column
+is defined using the syntax `FIELD AS expression`, e.g., `FIELD AS column_one + column_two`, the values of the `FIELD` column
+will be the result of the expression. As these generated `FIELD` columns do not store any data, an error bound cannot be
+defined. `modelardb` also supports normal tables created through `CREATE TABLE` statements.
 
 As both `CREATE MODEL TABLE` and `CREATE TABLE` are just SQL statements, both types of tables can be created using
 `modelardb` or programmatically using Apache Arrow Flight. For example, a model table storing a simple multivariate
 time series with weather data collected at different wind turbines can be created as follows:
 
 ```shell
-CREATE MODEL TABLE wind_turbine(timestamp TIMESTAMP, wind_turbine TAG, wind_direction FIELD, wind_speed FIELD(1.0))
+CREATE MODEL TABLE wind_turbine(timestamp TIMESTAMP, wind_turbine TAG, wind_direction FIELD, wind_speed FIELD(1.0%))
 ```
 
 The following example shows how to create the same model table in Python using Apache Arrow Flight:


### PR DESCRIPTION
This PR add support for an absolute error bound in addition to the existing relative error bound. This is done by changing `ErrorBound` from a `struct` to an `enum` with two implementations and moving the code in `swing.rs` that computed the maximum allowed difference to `models/mod.rs`. Thus, all of the code that works directly with the error bounds is now in `models/mod.rs` and by using an `enum` instead of a `struct` with a flag, `rustc` refuses to compile code that does handle both of the error bounds. While the PR is very large, the majority of it is tests.