### PR TITLE
Add support for Swing's recording mechanism for minimum MSE

### DIFF
--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -90,7 +90,7 @@ impl Swing {
     /// - (2) When the second data point is received, two linear functions that
     /// intersect with the first data point are computed to designate the upper
     /// and lower bounds for the linear functions Swing can fit to the segment.
-    /// From the second data point, the nominator and denominator of
+    /// From the second data point, the numerator and denominator of
     /// the slope with minimum MSE is updated.    
     /// - (3) Then for each subsequent data point, Swing determines if the data
     /// point can be represented by a linear function in the space delimited by

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -56,10 +56,10 @@ pub struct Swing {
     /// Intercept for the linear function specifying the lower bound for the
     /// current model.
     lower_bound_intercept: f64,
-    /// Computation of the slope to minimize MSE for the current model.
-    /// Specifically, it is the numerator and denominator of Equation 6
-    /// described in Section 3.2 of Swing and Slide paper.
-    slope_with_minimum_mse: (f64, f64),
+    /// Numerator of the slope equation for minimum MSE.
+    slope_with_minimum_mse_numerator: f64,
+    /// Denominator of the slope equation for minimum MSE.
+    slope_with_minimum_mse_denominator: f64,
     /// The number of data points the current model has been fitted to.
     length: usize,
 }
@@ -75,7 +75,8 @@ impl Swing {
             upper_bound_intercept: f64::NAN,
             lower_bound_slope: f64::NAN,
             lower_bound_intercept: f64::NAN,
-            slope_with_minimum_mse: (0.0, 0.0),
+            slope_with_minimum_mse_numerator: 0.0,
+            slope_with_minimum_mse_denominator: 0.0,
             length: 0,
         }
     }
@@ -94,7 +95,7 @@ impl Swing {
     /// - (3) Then for each subsequent data point, Swing determines if the data
     /// point can be represented by a linear function in the space delimited by
     /// the upper and lower bounds and updates these bounds if necessary.
-    /// If not, the recording mechanism is used to find the best slope.
+    /// If not, the slope with minimum MSE is identified.
     ///
     /// For more detail see Algorithm 1 in the [Swing and Slide paper].
     ///
@@ -178,17 +179,19 @@ impl Swing {
                         );
                 }
 
-                // Incremental computation of Equation 6 in Section 3.2 in the Swing and Slide paper.
-                let local_optimal_slope = compute_local_optimal_slope(
+                // Equation 6 in the Swing and Slide paper.
+                let (
+                    slope_minimum_mse_numerator_current_value,
+                    slope_minimum_mse_denominator_current_value,
+                ) = compute_slope_with_minimum_mse(
                     self.start_time,
                     self.first_value,
                     timestamp,
                     value,
                 );
-                self.slope_with_minimum_mse = (
-                    self.slope_with_minimum_mse.0 + local_optimal_slope.0,
-                    self.slope_with_minimum_mse.1 + local_optimal_slope.1,
-                );
+                self.slope_with_minimum_mse_numerator += slope_minimum_mse_numerator_current_value;
+                self.slope_with_minimum_mse_denominator +=
+                    slope_minimum_mse_denominator_current_value;
                 self.length += 1;
                 true
             }
@@ -213,16 +216,46 @@ impl Swing {
     /// only require `size_of::<Value>` while the slope and intercept generally
     /// must be [`f64`] to be precise enough.
     pub fn model(self) -> (Value, Value) {
-        // Implementation of the function with the minimized MSE as specified in the Swing and Slide paper.
-        // Equation 5 and 6 in the Swing and Slide paper.
-        let projected_slope = self.slope_with_minimum_mse.0 / self.slope_with_minimum_mse.1;
-        let optimal_slope = self
+        // Implementation of the Equations for minimizing MSE as specified in the Swing and Slide paper.
+        // Equations 5 and 6 in the Swing and Slide paper.
+        let projected_slope =
+            self.slope_with_minimum_mse_numerator / self.slope_with_minimum_mse_denominator;
+        let slope_with_minimum_mse = self
             .lower_bound_slope
             .max(projected_slope.min(self.upper_bound_slope));
         // Equation 2 in the Swing and Slide paper.
         let last_value =
-            optimal_slope * (self.end_time - self.start_time) as f64 + self.first_value;
+            slope_with_minimum_mse * (self.end_time - self.start_time) as f64 + self.first_value;
         (self.first_value as Value, last_value as Value)
+    }
+}
+
+/// Compute the slope that minimizes the MSE for the current line segment based on
+/// the first value (`start_time`, `first_value`) and (`end_time`, `last_value`).
+/// Return numerator and denominator of the best slope.
+///
+/// After the second data point, Swing starts computing the best slope for
+/// each current line segment. Once the data point that exceeds the error bound arrives,
+/// Swing compares the summation of the slopes with minimum MSE to the upper and lower
+/// bounds to find the best slope.
+///
+/// For more detail see Equations 1-6 in the [Swing and Slide paper].
+///
+/// [Swing and Slide paper]: https://dl.acm.org/doi/10.14778/1687627.1687645
+fn compute_slope_with_minimum_mse(
+    start_time: Timestamp,
+    first_value: f64,
+    end_time: Timestamp,
+    last_value: f64,
+) -> (f64, f64) {
+    if models::equal_or_nan(first_value, last_value) {
+        (0.0, 0.0)
+    } else {
+        debug_assert!(first_value.is_finite(), "First value is not finite.");
+        debug_assert!(last_value.is_finite(), "Last value is not finite.");
+        let numerator = (last_value - first_value) * (end_time - start_time) as f64;
+        let denominator = ((end_time - start_time) as f64).powi(2);
+        (numerator, denominator)
     }
 }
 
@@ -347,26 +380,6 @@ fn compute_slope_and_intercept(
         let slope = (last_value - first_value) / (end_time - start_time) as f64;
         let intercept = first_value - slope * start_time as f64;
         (slope, intercept)
-    }
-}
-
-/// Computes numerator and denominator for Equation 6 
-/// in Section 3.2 of [Swing and Slide paper](https://dl.acm.org/doi/10.14778/1687627.1687645).
-/// It is a part of recording mechanism for finding the optimal slope with minimum MSE.
-fn compute_local_optimal_slope(
-    start_time: Timestamp,
-    first_value: f64,
-    end_time: Timestamp,
-    last_value: f64,
-) -> (f64, f64) {
-    if first_value == last_value || (first_value.is_nan() || last_value.is_nan()) {
-        (0.0, 0.0)
-    } else {
-        debug_assert!(first_value.is_finite(), "First value is not finite.");
-        debug_assert!(last_value.is_finite(), "Last value is not finite.");
-        let numerator = (last_value - first_value) * (end_time - start_time) as f64;
-        let denominator = ((end_time - start_time) as f64).powi(2);
-        (numerator, denominator)
     }
 }
 
@@ -671,6 +684,21 @@ mod tests {
             &[42.0, 42.0, 42.8, 42.0, 42.0],
         ))
     }
+    #[test]
+    fn test_can_minimize_mse_with_relative_error_bound_five() {
+        assert!(can_minimize_mse(
+            ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
+            &[42.0, 42.0, 42.8, 42.0, 41.0, 40.0, 42.0, 42.0, 42.0, 42.1]
+        ))
+    }
+
+    #[test]
+    fn test_slope_is_between_higher_and_lower_hyperplane() {
+        assert!(slope_is_between_higher_lower_hyperplanes(
+            ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
+            &[42.0, 42.0, 42.8, 42.0, 41.0, 40.0, 42.0, 42.0, 42.0, 42.1]
+        ))
+    }
 
     fn fit_sequence_of_values_with_error_bound(error_bound: ErrorBound, values: &[Value]) -> bool {
         let mut model_type = Swing::new(error_bound);
@@ -681,6 +709,74 @@ mod tests {
             timestamp += SAMPLING_INTERVAL;
         }
         fit_all_values
+    }
+
+    fn can_minimize_mse(error_bound: ErrorBound, values: &[Value]) -> bool {
+        let mut model_type = Swing::new(error_bound);
+        let mut timestamp = START_TIME;
+        // Fit model of type Swing to perfectly linear sequence.
+        let end_time = START_TIME + values.len() as i64 * SAMPLING_INTERVAL;
+        for value in values {
+            assert!(model_type.fit_data_point(timestamp, *value));
+            timestamp += SAMPLING_INTERVAL;
+        }
+        // Compute the slope and intercept according to a default case in the Swing and Slide paper
+        let (default_slope, default_intercept) = compute_slope_and_intercept(
+            model_type.start_time,
+            model_type.first_value,
+            end_time,
+            *values.get(values.len() - 1).unwrap() as f64,
+        );
+        // Compute slope and intercept with minimum MSE
+        let (first_value, last_value) = model_type.model();
+        let (slope_with_minimum_mse, intercept_with_minimum_mse) = compute_slope_and_intercept(
+            START_TIME,
+            first_value as f64,
+            end_time,
+            last_value as f64,
+        );
+        // Compute MSE for each approximated value using: (1) default slope and intercept;
+        // (2) slope and intercept with minimum MSE
+        let mut mse = 0.0;
+        let mut optimized_mse = 0.0;
+
+        for (i, timestamp) in (START_TIME..end_time)
+            .step_by(SAMPLING_INTERVAL as usize)
+            .enumerate()
+        {
+            let approximate_value = default_slope * timestamp as f64 + default_intercept;
+            mse += (values[i] as f64 - approximate_value).powi(2);
+            let approximate_value_with_minimized_mse =
+                slope_with_minimum_mse * timestamp as f64 + intercept_with_minimum_mse;
+            optimized_mse += (values[i] as f64 - approximate_value_with_minimized_mse).powi(2);
+        }
+        let mse = mse / values.len() as f64;
+        let optimized_mse = optimized_mse / values.len() as f64;
+        mse > optimized_mse
+    }
+
+    fn slope_is_between_higher_lower_hyperplanes(
+        error_bound: ErrorBound,
+        values: &[Value],
+    ) -> bool {
+        let mut model_type = Swing::new(error_bound);
+        let mut timestamp = START_TIME;
+        let end_time = START_TIME + values.len() as i64 * SAMPLING_INTERVAL;
+        for value in values {
+            assert!(model_type.fit_data_point(timestamp, *value));
+            timestamp += SAMPLING_INTERVAL;
+        }
+        let lower_hyper_plane_slope = model_type.lower_bound_slope;
+        let upper_hyper_plane_slope = model_type.upper_bound_slope;
+        let (first_value, last_value) = model_type.model();
+        let (slope_with_minimum_mse, _) = compute_slope_and_intercept(
+            START_TIME,
+            first_value as f64,
+            end_time,
+            last_value as f64,
+        );
+        (slope_with_minimum_mse <= upper_hyper_plane_slope)
+            & (slope_with_minimum_mse >= lower_hyper_plane_slope)
     }
 
     // Tests for sum().

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -350,7 +350,8 @@ fn compute_slope_and_intercept(
     }
 }
 
-/// Computes numerator and denominator for Equation 6 in Section 3.2 of Swing and Slide paper.
+/// Computes numerator and denominator for Equation 6 
+/// in Section 3.2 of [Swing and Slide paper](https://dl.acm.org/doi/10.14778/1687627.1687645).
 /// It is a part of recording mechanism for finding the optimal slope with minimum MSE.
 fn compute_local_optimal_slope(
     start_time: Timestamp,

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -56,9 +56,9 @@ pub struct Swing {
     /// Intercept for the linear function specifying the lower bound for the
     /// current model.
     lower_bound_intercept: f64,
-    /// Computation of the slope to minimize MSE for the current model 
-    /// and holds the numenator and denominator of Equation 6 
-    /// described in Section 3.2 of [Swing and Slide paper].
+    /// Computation of the slope to minimize MSE for the current model.
+    /// Specifically, it is the numerator and denominator of Equation 6
+    /// described in Section 3.2 of Swing and Slide paper.
     slope_with_minimum_mse: (f64, f64),
     /// The number of data points the current model has been fitted to.
     length: usize,
@@ -88,12 +88,12 @@ impl Swing {
     /// - (1) When the first data point is received, it is stored in memory.
     /// - (2) When the second data point is received, two linear functions that
     /// intersect with the first data point are computed to designate the upper
-    /// and lower bounds for the linear functions Swing can fit to the segment. 
-    /// From the second data point, the recording mechanism that is used to 
+    /// and lower bounds for the linear functions Swing can fit to the segment.
+    /// From the second data point, the recording mechanism that is used to
     /// find the slope with minimum MSE is updated.    
     /// - (3) Then for each subsequent data point, Swing determines if the data
     /// point can be represented by a linear function in the space delimited by
-    /// the upper and lower bounds and updates these bounds if necessary. 
+    /// the upper and lower bounds and updates these bounds if necessary.
     /// If not, the recording mechanism is used to find the best slope.
     ///
     /// For more detail see Algorithm 1 in the [Swing and Slide paper].
@@ -177,17 +177,17 @@ impl Swing {
                             value - maximum_deviation,
                         );
                 }
-        
-                // Incremental computation of Equation 6 in Section 3.2 in the Swing and Slide paper
+
+                // Incremental computation of Equation 6 in Section 3.2 in the Swing and Slide paper.
                 let local_optimal_slope = compute_local_optimal_slope(
                     self.start_time,
                     self.first_value,
                     timestamp,
-                    value
+                    value,
                 );
                 self.slope_with_minimum_mse = (
                     self.slope_with_minimum_mse.0 + local_optimal_slope.0,
-                    self.slope_with_minimum_mse.1 + local_optimal_slope.1
+                    self.slope_with_minimum_mse.1 + local_optimal_slope.1,
                 );
                 self.length += 1;
                 true
@@ -214,11 +214,14 @@ impl Swing {
     /// must be [`f64`] to be precise enough.
     pub fn model(self) -> (Value, Value) {
         // Implementation of the function with the minimized MSE as specified in the Swing and Slide paper.
-        // Equation 5 and 6
+        // Equation 5 and 6 in the Swing and Slide paper.
         let projected_slope = self.slope_with_minimum_mse.0 / self.slope_with_minimum_mse.1;
-        let optimal_slope =  self.lower_bound_slope.max(projected_slope.min(self.upper_bound_slope));
-        // Equation 2
-        let last_value = optimal_slope * (self.end_time - self.start_time) as f64 + self.first_value;
+        let optimal_slope = self
+            .lower_bound_slope
+            .max(projected_slope.min(self.upper_bound_slope));
+        // Equation 2 in the Swing and Slide paper.
+        let last_value =
+            optimal_slope * (self.end_time - self.start_time) as f64 + self.first_value;
         (self.first_value as Value, last_value as Value)
     }
 }
@@ -347,7 +350,7 @@ fn compute_slope_and_intercept(
     }
 }
 
-/// Computes numenator and denominator for Equation 6 in Section 3.2 of Swing and Slide paper.
+/// Computes numerator and denominator for Equation 6 in Section 3.2 of Swing and Slide paper.
 /// It is a part of recording mechanism for finding the optimal slope with minimum MSE.
 fn compute_local_optimal_slope(
     start_time: Timestamp,
@@ -360,9 +363,9 @@ fn compute_local_optimal_slope(
     } else {
         debug_assert!(first_value.is_finite(), "First value is not finite.");
         debug_assert!(last_value.is_finite(), "Last value is not finite.");
-        let numenator =  (last_value - first_value) * (end_time - start_time) as f64;
+        let numerator = (last_value - first_value) * (end_time - start_time) as f64;
         let denominator = ((end_time - start_time) as f64).powi(2);
-        (numenator, denominator)
+        (numerator, denominator)
     }
 }
 

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -725,14 +725,14 @@ mod tests {
             timestamp += SAMPLING_INTERVAL;
         }
         // Compute the slope and intercept according to a default case in the Swing and Slide paper
-        // which is computing the slope from the first and the last value in a segment
+        // which is computing the slope from the first and the last value in a segment.
         let (default_slope, default_intercept) = compute_slope_and_intercept(
             model_type.start_time,
             model_type.first_value,
             end_time,
             *values.last().unwrap() as f64,
         );
-        // Compute slope and intercept with minimum MSE
+        // Compute slope and intercept with minimum MSE.
         let (first_value, last_value) = model_type.model();
         let (slope_with_minimum_mse, intercept_with_minimum_mse) = compute_slope_and_intercept(
             START_TIME,
@@ -741,7 +741,7 @@ mod tests {
             last_value as f64,
         );
         // Compute MSE for each approximated value using: (1) default slope and intercept;
-        // (2) slope and intercept with minimum MSE
+        // (2) slope and intercept with minimum MSE.
         let mut mse = 0.0;
         let mut optimized_mse = 0.0;
 

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -56,6 +56,10 @@ pub struct Swing {
     /// Intercept for the linear function specifying the lower bound for the
     /// current model.
     lower_bound_intercept: f64,
+    /// Computation of the slope to minimize MSE for the current model 
+    /// and holds the numenator and denominator of Equation 6 
+    /// described in Section 3.2 of [Swing and Slide paper].
+    slope_with_minimum_mse: (f64, f64),
     /// The number of data points the current model has been fitted to.
     length: usize,
 }
@@ -71,6 +75,7 @@ impl Swing {
             upper_bound_intercept: f64::NAN,
             lower_bound_slope: f64::NAN,
             lower_bound_intercept: f64::NAN,
+            slope_with_minimum_mse: (0.0, 0.0),
             length: 0,
         }
     }
@@ -83,10 +88,13 @@ impl Swing {
     /// - (1) When the first data point is received, it is stored in memory.
     /// - (2) When the second data point is received, two linear functions that
     /// intersect with the first data point are computed to designate the upper
-    /// and lower bounds for the linear functions Swing can fit to the segment.
+    /// and lower bounds for the linear functions Swing can fit to the segment. 
+    /// From the second data point, the recording mechanism that is used to 
+    /// find the slope with minimum MSE is updated.    
     /// - (3) Then for each subsequent data point, Swing determines if the data
     /// point can be represented by a linear function in the space delimited by
-    /// the upper and lower bounds and updates these bounds if necessary.
+    /// the upper and lower bounds and updates these bounds if necessary. 
+    /// If not, the recording mechanism is used to find the best slope.
     ///
     /// For more detail see Algorithm 1 in the [Swing and Slide paper].
     ///
@@ -169,6 +177,18 @@ impl Swing {
                             value - maximum_deviation,
                         );
                 }
+        
+                // Incremental computation of Equation 6 in Section 3.2 in the Swing and Slide paper
+                let local_optimal_slope = compute_local_optimal_slope(
+                    self.start_time,
+                    self.first_value,
+                    timestamp,
+                    value
+                );
+                self.slope_with_minimum_mse = (
+                    self.slope_with_minimum_mse.0 + local_optimal_slope.0,
+                    self.slope_with_minimum_mse.1 + local_optimal_slope.1
+                );
                 self.length += 1;
                 true
             }
@@ -193,12 +213,13 @@ impl Swing {
     /// only require `size_of::<Value>` while the slope and intercept generally
     /// must be [`f64`] to be precise enough.
     pub fn model(self) -> (Value, Value) {
-        // TODO: use the function with the minimum error as specified in the Swing and Slide paper.
-        let average_slope = (self.lower_bound_slope + self.upper_bound_slope) / 2.0;
-        let average_intercept = (self.lower_bound_intercept + self.upper_bound_intercept) / 2.0;
-        let first_value = average_slope * self.start_time as f64 + average_intercept;
-        let last_value = average_slope * self.end_time as f64 + average_intercept;
-        (first_value as Value, last_value as Value)
+        // Implementation of the function with the minimized MSE as specified in the Swing and Slide paper.
+        // Equation 5 and 6
+        let projected_slope = self.slope_with_minimum_mse.0 / self.slope_with_minimum_mse.1;
+        let optimal_slope =  self.lower_bound_slope.max(projected_slope.min(self.upper_bound_slope));
+        // Equation 2
+        let last_value = optimal_slope * (self.end_time - self.start_time) as f64 + self.first_value;
+        (self.first_value as Value, last_value as Value)
     }
 }
 
@@ -323,6 +344,25 @@ fn compute_slope_and_intercept(
         let slope = (last_value - first_value) / (end_time - start_time) as f64;
         let intercept = first_value - slope * start_time as f64;
         (slope, intercept)
+    }
+}
+
+/// Computes numenator and denominator for Equation 6 in Section 3.2 of Swing and Slide paper.
+/// It is a part of recording mechanism for finding the optimal slope with minimum MSE.
+fn compute_local_optimal_slope(
+    start_time: Timestamp,
+    first_value: f64,
+    end_time: Timestamp,
+    last_value: f64,
+) -> (f64, f64) {
+    if first_value == last_value || (first_value.is_nan() || last_value.is_nan()) {
+        (0.0, 0.0)
+    } else {
+        debug_assert!(first_value.is_finite(), "First value is not finite.");
+        debug_assert!(last_value.is_finite(), "Last value is not finite.");
+        let numenator =  (last_value - first_value) * (end_time - start_time) as f64;
+        let denominator = ((end_time - start_time) as f64).powi(2);
+        (numenator, denominator)
     }
 }
 

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -15,7 +15,7 @@
 
 //! Implementation of ModelarDB's main function.
 
-#![allow(clippy::too_many_arguments)]
+#![allow(clippy::too_many_arguments, clippy::unconditional_recursion)]
 
 mod configuration;
 mod context;

--- a/crates/modelardb_server/src/main.rs
+++ b/crates/modelardb_server/src/main.rs
@@ -15,7 +15,7 @@
 
 //! Implementation of ModelarDB's main function.
 
-#![allow(clippy::too_many_arguments, clippy::unconditional_recursion)]
+#![allow(clippy::too_many_arguments)]
 
 mod configuration;
 mod context;

--- a/crates/modelardb_server/src/optimizer/model_simple_aggregates.rs
+++ b/crates/modelardb_server/src/optimizer/model_simple_aggregates.rs
@@ -17,6 +17,8 @@
 //! reconstructed values from a single column without filtering so they are computed directly from
 //! segments instead of the reconstructed values.
 
+#![allow(clippy::unconditional_recursion)]
+
 use std::any::Any;
 use std::cmp::PartialEq;
 use std::fmt::{Display, Formatter};


### PR DESCRIPTION
Implementation of recording mechanism for Swing (Section 3.2 in Swing and Slide paper) to minimize MSE. The mechanism generated slightly lower Mean Squared Error and Mean Absolute Percentage Error than the current approach when tested with real-life datasets. However, its improvement over the current approach is not absolute and it varies depending on data points' properties.   