### PR TITLE
Add conservative rule that checks for extra space

### DIFF
--- a/crates/modelardb_compression/src/models/timestamps.rs
+++ b/crates/modelardb_compression/src/models/timestamps.rs
@@ -354,7 +354,7 @@ mod tests {
         compress_and_decompress_timestamps_for_a_time_series(
             &[
                 100, 37, // -63.
-                38, //  64.
+                38, // 64.
                 200,
             ],
             Some(3),
@@ -366,7 +366,7 @@ mod tests {
         compress_and_decompress_timestamps_for_a_time_series(
             &[
                 500, 245, // -255.
-                246, //  256.
+                246, // 256.
                 500,
             ],
             Some(4),
@@ -378,7 +378,7 @@ mod tests {
         compress_and_decompress_timestamps_for_a_time_series(
             &[
                 5000, 2953, // -2047.
-                2954, //  2048.
+                2954, // 2048.
                 5000,
             ],
             Some(5),
@@ -390,7 +390,7 @@ mod tests {
         compress_and_decompress_timestamps_for_a_time_series(
             &[
                 5000000000, 2852516353, // -2147483647.
-                2852516354, //  2147483648.
+                2852516354, // 2147483648.
                 5000000000,
             ],
             Some(10),

--- a/crates/modelardb_server/src/query/generated_as_exec.rs
+++ b/crates/modelardb_server/src/query/generated_as_exec.rs
@@ -39,7 +39,7 @@ use futures::stream::Stream;
 use futures::StreamExt;
 use modelardb_common::types::{TimestampArray, ValueArray};
 
-///  A column the [`GeneratedAsExec`] must add to each of the [`RecordBatches`](RecordBatch) using
+/// A column the [`GeneratedAsExec`] must add to each of the [`RecordBatches`](RecordBatch) using
 /// [`GeneratedAsStream`] with the location it must be at and the [`PhysicalExpr`] that compute it.
 #[derive(Debug, Clone)]
 pub struct ColumnToGenerate {

--- a/rules/extra_space_character.yml
+++ b/rules/extra_space_character.yml
@@ -1,0 +1,10 @@
+id: extra_space_character
+message: Comment or string contains an extra space.
+severity: error
+language: Rust
+# The rule only check for double space to not report errors when whitespace is used for formatting.
+rule:
+  any:
+    - kind: line_comment
+    - kind: string_literal
+  regex: "[^ ]  [^ ]"


### PR DESCRIPTION
This PR adds an Ast-Grep rule that checks if an extra space has been added to a comment or string. The rule does purposely not match an arbitrary number of space so false positives are not emitted when whitespace is used for formatting. The rule is also limited to comments and string as `rustfmt` removes extra whitespace in the code except for comments and strings. If there are other AST nodes where `rustfmt` does not remove extra whitespace they should be added to this rule.