### PR TITLE
Rename folders to better match their content

### DIFF
--- a/crates/modelardb_common/src/storage.rs
+++ b/crates/modelardb_common/src/storage.rs
@@ -45,7 +45,7 @@ use crate::arguments::decode_argument;
 use crate::schemas::{COMPRESSED_SCHEMA, FIELD_COLUMN};
 
 /// The folder storing compressed data in the data folders.
-const COMPRESSED_DATA_FOLDER: &str = "compressed";
+const COMPRESSED_DATA_FOLDER: &str = "tables";
 
 /// The folder storing metadata in the data folders.
 const METADATA_FOLDER: &str = "metadata";
@@ -638,7 +638,7 @@ mod tests {
         let object_store = LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap();
 
         write_compressed_segments_to_apache_parquet_file(
-            "compressed",
+            COMPRESSED_DATA_FOLDER,
             test::MODEL_TABLE_NAME,
             0,
             compressed_segments,

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -414,7 +414,7 @@ mod tests {
         // A Delta Lake log should be created to save the schema.
         let folder_path = temp_dir
             .path()
-            .join("compressed")
+            .join("tables")
             .join("table_name")
             .join("_delta_log");
 

--- a/crates/modelardb_server/src/storage/mod.rs
+++ b/crates/modelardb_server/src/storage/mod.rs
@@ -57,7 +57,7 @@ use crate::storage::uncompressed_data_manager::UncompressedDataManager;
 use crate::ClusterMode;
 
 /// The folder storing spilled uncompressed data buffers in the local data folder.
-const UNCOMPRESSED_DATA_FOLDER: &str = "uncompressed";
+const UNCOMPRESSED_DATA_FOLDER: &str = "buffers";
 
 /// The capacity of each uncompressed data buffer as the number of elements in the buffer where each
 /// element is a [`Timestamp`](modelardb_common::types::Timestamp) and a


### PR DESCRIPTION
This PR renames the data folder "uncompressed" to "buffers" and "compressed" to "tables" so their names better represent the data they contain. Only the name of the folders have purposely been changed to keep the terminology in the code consistent without changing a significant number of variables, functions, types, and comments.