### PR TITLE
Fix #187 by storing univariate_id as int64

### DIFF
--- a/crates/modelardb_common/src/schemas.rs
+++ b/crates/modelardb_common/src/schemas.rs
@@ -45,8 +45,16 @@ pub static COMPRESSED_SCHEMA: LazyLock<CompressedSchema> = LazyLock::new(|| {
     CompressedSchema(Arc::new(Schema::new(query_compressed_schema_fields)))
 });
 
+/// [`RecordBatch`](arrow::record_batch::RecordBatch) [`Schema`] used when writing compressed
+/// segments to disk as the Delta Lake Protocol does not support unsigned integers.
+pub static DISK_COMPRESSED_SCHEMA: LazyLock<CompressedSchema> = LazyLock::new(|| {
+    let mut compressed_schema_fields = COMPRESSED_SCHEMA.0.fields().to_vec();
+    compressed_schema_fields[0] = Arc::new(Field::new("univariate_id", DataType::Int64, false));
+    CompressedSchema(Arc::new(Schema::new(compressed_schema_fields)))
+});
+
 /// [`RecordBatch`](arrow::record_batch::RecordBatch) [`Schema`] used for compressed segments when
-/// executing queries as [`FIELD_COLUMN`] is stored in the Apache Parquet files.
+/// executing queries as [`FIELD_COLUMN`] is not stored in the Apache Parquet files.
 pub static QUERY_COMPRESSED_SCHEMA: LazyLock<QueryCompressedSchema> = LazyLock::new(|| {
     QueryCompressedSchema(Arc::new(Schema::new(vec![
         Field::new("univariate_id", DataType::UInt64, false),
@@ -60,6 +68,15 @@ pub static QUERY_COMPRESSED_SCHEMA: LazyLock<QueryCompressedSchema> = LazyLock::
         Field::new("residuals", DataType::Binary, false),
         Field::new("error", DataType::Float32, false),
     ])))
+});
+
+/// [`RecordBatch`](arrow::record_batch::RecordBatch) [`Schema`] used when reading compressed
+/// segments from disk as the Delta Lake Protocol does not support unsigned integers.
+pub static DISK_QUERY_COMPRESSED_SCHEMA: LazyLock<CompressedSchema> = LazyLock::new(|| {
+    let mut query_compressed_schema_fields = QUERY_COMPRESSED_SCHEMA.0.fields().to_vec();
+    query_compressed_schema_fields[0] =
+        Arc::new(Field::new("univariate_id", DataType::Int64, false));
+    CompressedSchema(Arc::new(Schema::new(query_compressed_schema_fields)))
 });
 
 /// Minimum size of the metadata required for a compressed segment. Meaning that the sizes of

--- a/crates/modelardb_common/src/storage.rs
+++ b/crates/modelardb_common/src/storage.rs
@@ -18,7 +18,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use arrow::array::RecordBatch;
+use arrow::array::{Int64Array, RecordBatch, UInt64Array};
 use arrow::compute;
 use arrow::datatypes::{Field, Schema};
 use datafusion::parquet::arrow::async_reader::{
@@ -42,7 +42,9 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::arguments::decode_argument;
-use crate::schemas::{COMPRESSED_SCHEMA, FIELD_COLUMN};
+use crate::schemas::{
+    COMPRESSED_SCHEMA, DISK_COMPRESSED_SCHEMA, FIELD_COLUMN, QUERY_COMPRESSED_SCHEMA,
+};
 
 /// The folder storing compressed data in the data folders.
 const COMPRESSED_DATA_FOLDER: &str = "tables";
@@ -186,7 +188,7 @@ impl DeltaLake {
     ) -> Result<DeltaTable, DeltaTableError> {
         self.create_partitioned_delta_lake_table(
             table_name,
-            &COMPRESSED_SCHEMA.0,
+            &DISK_COMPRESSED_SCHEMA.0,
             &[FIELD_COLUMN.to_owned()],
         )
         .await
@@ -243,8 +245,11 @@ impl DeltaLake {
     pub async fn write_compressed_segments_to_model_table(
         &self,
         table_name: &str,
-        compressed_segments: Vec<RecordBatch>,
+        mut compressed_segments: Vec<RecordBatch>,
     ) -> Result<DeltaTable, DeltaTableError> {
+        // Reinterpret univariate_ids from uint64 to int64 to fix #187 as a stopgap until #197.
+        univariate_ids_uint64_to_int64(&mut compressed_segments);
+
         // Specify that the file must be sorted by univariate_id and then by start_time.
         let sorting_columns = Some(vec![
             SortingColumn::new(0, false, false),
@@ -328,6 +333,34 @@ pub async fn extract_azure_blob_storage_arguments(
     let (container_name, offset_data) = decode_argument(offset_data)?;
 
     Ok((account, access_key, container_name, offset_data))
+}
+
+/// Reinterpret the bits used for univariate ids in column zero in `compressed_segments` from
+/// [`uint64`] to [`int64`] as the Delta Lake Protocol does not support unsigned integers.
+fn univariate_ids_uint64_to_int64(compressed_segments: &mut Vec<RecordBatch>) {
+    for record_batch in compressed_segments {
+        let mut columns = record_batch.columns().to_vec();
+        let univariate_ids = crate::array!(record_batch, 0, UInt64Array);
+        let signed_univariate_ids: Int64Array =
+            univariate_ids.unary(|value| i64::from_ne_bytes(value.to_ne_bytes()));
+        columns[0] = Arc::new(signed_univariate_ids);
+
+        // unwrap() is safe as columns are constructs to match DISK_COMPRESSED_SCHEMA.
+        *record_batch = RecordBatch::try_new(DISK_COMPRESSED_SCHEMA.0.clone(), columns).unwrap();
+    }
+}
+
+/// Reinterpret the bits used for univariate ids in column zero in `compressed_segments` from
+/// [`int64`] to [`uint64`] as the Delta Lake Protocol does not support unsigned integers.
+pub fn univariate_ids_int64_to_uint64(compressed_segments: &RecordBatch) -> RecordBatch {
+    let mut columns = compressed_segments.columns().to_vec();
+    let signed_univariate_ids = crate::array!(compressed_segments, 0, Int64Array);
+    let univariate_ids: UInt64Array =
+        signed_univariate_ids.unary(|value| u64::from_ne_bytes(value.to_ne_bytes()));
+    columns[0] = Arc::new(univariate_ids);
+
+    // unwrap() is safe as columns are constructs to match DISK_COMPRESSED_SCHEMA.
+    RecordBatch::try_new(QUERY_COMPRESSED_SCHEMA.0.clone(), columns).unwrap()
 }
 
 /// Read all rows from the Apache Parquet file at the location given by `file_path` in

--- a/crates/modelardb_common/src/storage.rs
+++ b/crates/modelardb_common/src/storage.rs
@@ -335,8 +335,8 @@ pub async fn extract_azure_blob_storage_arguments(
     Ok((account, access_key, container_name, offset_data))
 }
 
-/// Reinterpret the bits used for univariate ids in column zero in `compressed_segments` from
-/// [`uint64`] to [`int64`] as the Delta Lake Protocol does not support unsigned integers.
+/// Reinterpret the bits used for univariate ids in `compressed_segments` to convert the column from
+/// [`UInt64Array`] to [`Int64Array`] as the Delta Lake Protocol does not support unsigned integers.
 fn univariate_ids_uint64_to_int64(compressed_segments: &mut Vec<RecordBatch>) {
     for record_batch in compressed_segments {
         let mut columns = record_batch.columns().to_vec();
@@ -350,8 +350,8 @@ fn univariate_ids_uint64_to_int64(compressed_segments: &mut Vec<RecordBatch>) {
     }
 }
 
-/// Reinterpret the bits used for univariate ids in column zero in `compressed_segments` from
-/// [`int64`] to [`uint64`] as the Delta Lake Protocol does not support unsigned integers.
+/// Reinterpret the bits used for univariate ids in `compressed_segments` to convert the column from
+/// [`Int64Array`] to [`UInt64Array`] as the Delta Lake Protocol does not support unsigned integers.
 pub fn univariate_ids_int64_to_uint64(compressed_segments: &RecordBatch) -> RecordBatch {
     let mut columns = compressed_segments.columns().to_vec();
     let signed_univariate_ids = crate::array!(compressed_segments, 0, Int64Array);

--- a/crates/modelardb_server/src/optimizer/model_simple_aggregates.rs
+++ b/crates/modelardb_server/src/optimizer/model_simple_aggregates.rs
@@ -48,6 +48,7 @@ use datafusion::physical_plan::{
 };
 use datafusion::scalar::ScalarValue;
 use modelardb_common::types::{ArrowValue, TimestampArray, Value, ValueArray};
+use modelardb_common::storage;
 
 use crate::query::sorted_join_exec::SortedJoinExec;
 
@@ -382,6 +383,9 @@ impl PhysicalExpr for ModelCountPhysicalExpr {
 
     /// Evaluate this [`PhysicalExpr`] against `record_batch`.
     fn evaluate(&self, record_batch: &RecordBatch) -> Result<ColumnarValue> {
+        // Reinterpret univariate_ids from int64 to uint64 to fix #187 as a stopgap until #197.
+        let record_batch = storage::univariate_ids_int64_to_uint64(record_batch);
+
         modelardb_common::arrays!(
             record_batch,
             _univariate_ids,
@@ -750,6 +754,9 @@ impl PhysicalExpr for ModelSumPhysicalExpr {
 
     /// Evaluate this [`PhysicalExpr`] against `record_batch`.
     fn evaluate(&self, record_batch: &RecordBatch) -> Result<ColumnarValue> {
+        // Reinterpret univariate_ids from int64 to uint64 to fix #187 as a stopgap until #197.
+        let record_batch = storage::univariate_ids_int64_to_uint64(record_batch);
+
         modelardb_common::arrays!(
             record_batch,
             _univariate_ids,
@@ -897,6 +904,9 @@ impl PhysicalExpr for ModelAvgPhysicalExpr {
 
     /// Evaluate this [`PhysicalExpr`] against `record_batch`.
     fn evaluate(&self, record_batch: &RecordBatch) -> Result<ColumnarValue> {
+        // Reinterpret univariate_ids from int64 to uint64 to fix #187 as a stopgap until #197.
+        let record_batch = storage::univariate_ids_int64_to_uint64(record_batch);
+
         modelardb_common::arrays!(
             record_batch,
             _univariate_ids,

--- a/crates/modelardb_server/src/query/grid_exec.rs
+++ b/crates/modelardb_server/src/query/grid_exec.rs
@@ -46,6 +46,7 @@ use datafusion::physical_plan::{
 };
 use futures::stream::{Stream, StreamExt};
 use modelardb_common::schemas::GRID_SCHEMA;
+use modelardb_common::storage;
 use modelardb_common::types::{TimestampArray, TimestampBuilder, ValueArray, ValueBuilder};
 use modelardb_compression::{self, MODEL_TYPE_COUNT, MODEL_TYPE_NAMES};
 
@@ -263,6 +264,9 @@ impl GridStream {
             .baseline_metrics
             .elapsed_compute()
             .timer();
+
+        // Reinterpret univariate_ids from int64 to uint64 to fix #187 as a stopgap until #197.
+        let batch = storage::univariate_ids_int64_to_uint64(batch);
 
         // Retrieve the arrays from batch and cast them to their concrete type.
         modelardb_common::arrays!(

--- a/crates/modelardb_server/src/query/model_table.rs
+++ b/crates/modelardb_server/src/query/model_table.rs
@@ -40,7 +40,7 @@ use datafusion::physical_plan::{ExecutionPlan, PhysicalExpr};
 use deltalake_core::kernel::LogicalFile;
 use deltalake_core::{DeltaTable, DeltaTableError, ObjectMeta, PartitionFilter, PartitionValue};
 use modelardb_common::metadata::model_table_metadata::ModelTableMetadata;
-use modelardb_common::schemas::{FIELD_COLUMN, GRID_SCHEMA, QUERY_COMPRESSED_SCHEMA};
+use modelardb_common::schemas::{DISK_QUERY_COMPRESSED_SCHEMA, FIELD_COLUMN, GRID_SCHEMA};
 use modelardb_common::types::{ArrowTimestamp, ArrowValue};
 
 use crate::context::Context;
@@ -297,9 +297,9 @@ fn new_apache_parquet_exec(
     let log_store = delta_table.log_store();
     let file_scan_config = FileScanConfig {
         object_store_url: log_store.object_store_url(),
-        file_schema: QUERY_COMPRESSED_SCHEMA.0.clone(),
+        file_schema: DISK_QUERY_COMPRESSED_SCHEMA.0.clone(),
         file_groups: vec![partitioned_files],
-        statistics: Statistics::new_unknown(&QUERY_COMPRESSED_SCHEMA.0),
+        statistics: Statistics::new_unknown(&DISK_QUERY_COMPRESSED_SCHEMA.0),
         projection: None,
         limit: maybe_limit,
         table_partition_cols: vec![],
@@ -469,7 +469,7 @@ impl TableProvider for ModelTable {
 
         let maybe_physical_parquet_filters = maybe_convert_logical_expr_to_physical_expr(
             maybe_rewritten_parquet_filters.as_ref(),
-            QUERY_COMPRESSED_SCHEMA.0.clone(),
+            DISK_QUERY_COMPRESSED_SCHEMA.0.clone(),
         )?;
 
         let maybe_physical_grid_filters = maybe_convert_logical_expr_to_physical_expr(

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -871,9 +871,9 @@ fn test_do_put_can_ingest_multiple_time_series_with_different_tags() {
     let mut test_context = TestContext::new();
 
     let time_series_with_tag_one: RecordBatch =
-        TestContext::generate_time_series_with_tag(false, None, Some("a"));
+        TestContext::generate_time_series_with_tag(false, None, Some("tag_one"));
     let time_series_with_tag_two: RecordBatch =
-        TestContext::generate_time_series_with_tag(false, None, Some("b"));
+        TestContext::generate_time_series_with_tag(false, None, Some("tag_two"));
     let time_series = &[time_series_with_tag_one, time_series_with_tag_two];
 
     ingest_time_series_and_flush_data(&mut test_context, time_series, TableType::ModelTable);


### PR DESCRIPTION
This PR fixes #187 by storing `univariate_id` as `Int64Array` instead of `UInt64Array` as the [Delta](https://github.com/delta-io/delta-rs/issues/2175) [Lake](https://github.com/delta-io/delta-rs/issues/1751) [Protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types) does not support unsigned integers and #197 probably will not be resolved for some time. When reviewing this PR, please double check the necessary casts are performed everywhere they are needed. Currently, `UInt64Array` is reinterpreted as `Int64Array` when writing compressed segments to disk and `Int64Array` is reinterpreted as `UInt64Array` when data points are reconstructed from segments and aggregates are computed directly from the segments.