### PR TITLE
Disallow tables containing unsigned integers

### DIFF
--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -329,7 +329,8 @@ impl CompressedDataManager {
 mod tests {
     use super::*;
 
-    use datafusion::arrow::datatypes::{ArrowPrimitiveType, Field, Schema};
+    use datafusion::arrow::array::{Array, Int8Array};
+    use datafusion::arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
     use modelardb_common::metadata;
     use modelardb_common::metadata::model_table_metadata::ModelTableMetadata;
     use modelardb_common::test;
@@ -344,7 +345,13 @@ mod tests {
     // Tests for insert_record_batch().
     #[tokio::test]
     async fn test_insert_record_batch() {
-        let record_batch = test::compressed_segments_record_batch();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "the_column",
+            DataType::Int8,
+            false,
+        )]));
+        let columns: Vec<Arc<dyn Array>> = vec![Arc::new(Int8Array::from(vec![37, 73]))];
+        let record_batch = RecordBatch::try_new(schema, columns).unwrap();
         let (temp_dir, data_manager) = create_compressed_data_manager().await;
 
         let local_data_folder =


### PR DESCRIPTION
This PR prevents users from creating normal tables containing tables with columns for unsigned integers as Delta Lake does not support unsigned integers and [simply convert them to signed integers](https://docs.rs/delta_kernel/0.2.0/src/delta_kernel/engine/arrow_conversion.rs.html#163). So to remove this surprising behavior, is  support for unsigned integers removed for now. Due to the increasing amount of complexity caused by ModelarDB use of unsigned integers for some of the values in compressed segments and Delta Lake's lack of support for them, I have added a [comment](https://github.com/ModelarData/ModelarDB-RS/issues/197#issuecomment-2284776711) to #197 that we should look into using signed integers both in memory and on disk to remove the conversions and significantly reduce the number of schemas required. However, as this will require many small changes to many files, it should not be done until [dev/delta-metadata](https://github.com/ModelarData/ModelarDB-RS/tree/dev/delta-metadata) has been merged. If the results of #197 shows that it is beneficial to store tags in compressed segments instead of `univariate_id`, it may be sensible make this change and remove unsigned integers at the same time as both changes will require modification of and, hopefully, removal of the schemas. 