### PR TITLE
Make deltalake-core explicitly use datafusion

### DIFF
--- a/crates/modelardb_common/Cargo.toml
+++ b/crates/modelardb_common/Cargo.toml
@@ -25,7 +25,7 @@ arrow-flight.workspace = true
 chrono.workspace = true
 dashmap.workspace = true
 datafusion.workspace = true
-deltalake-core.workspace = true
+deltalake-core = { workspace = true, features = ["datafusion"] }
 futures.workspace = true
 object_store = { workspace = true, features = ["aws", "azure"] }
 rand.workspace = true


### PR DESCRIPTION
This PR makes `deltalake-core` explicitly use the `datafusion` feature for `deltalake-core` in `modelardb_common` as it is not enabled by default and it is not required for multiple of the methods we use from [`DeltaOps`](https://github.com/delta-io/delta-rs/blob/rust-v0.18.2/crates/core/src/operations/mod.rs#L154). It is technically not necessary to enable the feature for `modelardb_common` as it is already done for `modelardb_server`, thus it becomes enabled for all crates in ModelarDB as [Cargo unions features](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification). However, without enabling the `datafusion` feature for `deltalake-core` in `modelardb_common`, `modelardb_common` cannot be compiled outside of the ModelarDB project as it will fail with the confusing error "_no method named `write` found for struct `DeltaOps` in the current scope_" despite [`DeltaOps.write()`](https://docs.rs/deltalake/latest/deltalake/struct.DeltaOps.html#method.write) clearly existing.