### PR TITLE
Update upload-artifact as v3 is deprecated

### DIFF
--- a/.github/workflows/cargo-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/cargo-build-lint-and-test-on-pr-and-push.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: grcov
       run: grcov . --source-dir . --binary-path ./target/debug/ --output-types html --branch --ignore-not-existing -o ./target/debug/coverage/
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Code Coverage ${{ matrix.operating-system }}
         path: ./target/debug/coverage/


### PR DESCRIPTION
This PR updates the GitHub Action [upload-artifact](https://github.com/actions/upload-artifact) from v3 to v4 as v3 is [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).