### PR TITLE
Fixed flaky test_append_to_metric test

### DIFF
--- a/crates/modelardb_server/src/storage/types.rs
+++ b/crates/modelardb_server/src/storage/types.rs
@@ -606,13 +606,13 @@ mod tests {
 
         metric.append(30, false);
 
-        // timestamp is measured just before metric.append() to minimize the chance that enough time
-        // has passed that the timestamp written to metric is different from what the test expects.
         let since_the_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
         let timestamp = since_the_epoch.as_micros() as Timestamp;
         metric.append(30, false);
 
-        assert_eq!(metric.timestamps.pop_iter().last(), Some(timestamp));
+        // Check that the timestamp is no more than 10 microseconds after the expected timestamp to
+        // account for the time it takes to execute the append function.
+        assert!((metric.timestamps.pop_iter().last().unwrap() - timestamp) <= 10);
         assert_eq!(metric.values.pop_iter().last(), Some(30));
     }
 


### PR DESCRIPTION
This PR fixes the flaky `storage::types::tests::test_append_to_metric` test. Now we are checking if the timestamp is within 10 microseconds instead of exact to account for the time it takes it execute the `append()` function. 