### PR TITLE
Fix #188 by replacing macos-13 with -latest

### DIFF
--- a/.github/workflows/cargo-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/cargo-build-lint-and-test-on-pr-and-push.yml
@@ -30,13 +30,10 @@ jobs:
   cargo_build_lint_and_test:
     name: Cargo Build, Lint, and Test
 
-    # macos-13 is used instead of macos-latest due to "stepWithCompactEncoding
-    # - invalid compact unwind encoding" occurring in libunwind when using
-    # macos-latest, this is maybe related to rust-lang/rust/issues/113783.
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, macos-13, windows-latest]
+        operating-system: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - name: Checkout

--- a/crates/modelardb_query/Cargo.toml
+++ b/crates/modelardb_query/Cargo.toml
@@ -26,7 +26,6 @@ deltalake-core = { workspace = true, features = ["datafusion"] }
 futures.workspace = true
 modelardb_common = { path = "../modelardb_common" }
 modelardb_compression = { path = "../modelardb_compression" }
-parquet = { workspace = true, features = ["object_store"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
 tonic.workspace = true
 

--- a/crates/modelardb_server/Cargo.toml
+++ b/crates/modelardb_server/Cargo.toml
@@ -37,7 +37,6 @@ modelardb_common = { path = "../modelardb_common" }
 modelardb_compression = { path = "../modelardb_compression" }
 modelardb_query = { path = "../modelardb_query" }
 object_store = { workspace = true, features = ["aws", "azure"] }
-parquet = { workspace = true, features = ["object_store"] }
 ringbuf.workspace = true
 snmalloc-rs = { workspace = true, features = ["build_cc"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }


### PR DESCRIPTION
This PR fixes #188 by replacing `macos-13` with `macos-latest` as the problem with unwinding failing in macOS is now fixed in [XCode](https://github.com/rust-lang/rust/issues/113783#issuecomment-1758036690) and rust-lang/rust/issues/113783 is closed as a result.