### PR TITLE
Updated Docker files to no longer use PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__
 proptest-regressions
 .idea
 *.log
+/data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY . .
 
 RUN cargo build --profile $BUILD_PROFILE
 
-CMD ["target/release/modelardbd", "edge", "data"]
+CMD ["target/debug/modelardbd", "edge", "data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,12 @@
 
 FROM rust:latest
 
+ARG BUILD_PROFILE=dev
+
 WORKDIR /usr/src/app
 
 COPY . .
 
-RUN cargo build --release
+RUN cargo build --profile $BUILD_PROFILE
 
 CMD ["target/release/modelardbd", "edge", "data"]

--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -39,17 +39,6 @@ services:
       exit 0;
       "
 
-  # Metadata database service.
-  postgres:
-    image: postgres:latest
-    container_name: postgres
-    ports:
-      - "5432:5432"
-    environment:
-      POSTGRES_PASSWORD: modelardb_password
-      POSTGRES_USER: modelardb_user
-      POSTGRES_DB: metadata
-
   # ModelarDB services.
   modelardb-manager:
     image: modelardb

--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -44,13 +44,10 @@ services:
     image: modelardb
     build: .
     container_name: modelardb-manager
-    command: ["target/release/modelardbm", "metadata", "s3://modelardb"]
+    command: ["target/release/modelardbm", "s3://modelardb"]
     ports:
       - "9998:9998"
     environment:
-      METADATA_DB_HOST: postgres
-      METADATA_DB_PASSWORD: modelardb_password
-      METADATA_DB_USER: modelardb_user
       AWS_ACCESS_KEY_ID: minioadmin
       AWS_SECRET_ACCESS_KEY: minioadmin
       AWS_DEFAULT_REGION: eu-central-1
@@ -59,7 +56,6 @@ services:
     depends_on:
       - minio-server
       - create-bucket
-      - postgres
 
   modelardb-edge:
     image: modelardb

--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -44,7 +44,7 @@ services:
     image: modelardb
     build: .
     container_name: modelardb-manager
-    command: ["target/release/modelardbm", "s3://modelardb"]
+    command: ["target/debug/modelardbm", "s3://modelardb"]
     ports:
       - "9998:9998"
     environment:
@@ -60,7 +60,7 @@ services:
   modelardb-edge:
     image: modelardb
     container_name: modelardb-edge
-    command: ["target/release/modelardbd", "edge", "data/edge", "grpc://modelardb-manager:9998"]
+    command: ["target/debug/modelardbd", "edge", "data/edge", "grpc://modelardb-manager:9998"]
     ports:
       - "9999:9999"
     environment:
@@ -77,7 +77,7 @@ services:
   modelardb-cloud:
     image: modelardb
     container_name: modelardb-cloud
-    command: [ "target/release/modelardbd", "cloud", "data/cloud", "grpc://modelardb-manager:9998"]
+    command: [ "target/debug/modelardbd", "cloud", "data/cloud", "grpc://modelardb-manager:9998"]
     ports:
       - "9997:9997"
     environment:

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -408,9 +408,7 @@ docker-compose -p modelardb-cluster stop
 
 The cluster deployment sets up a [MinIO](https://min.io/) object store and a [MinIO](https://min.io/) client is used to
 initialize the bucket `modelardb` in the object store. [MinIO](https://min.io/) can be administered through its
-[web interface](http://127.0.0.1:9001). The default username and password, `minioadmin`, can be used to log in. The
-deployment also sets up a PostgreSQL database named `metadata` that is used as the metadata database for the cluster.
-The username `modelardb_user` and the password `modelardb_password` can be used to access the database.
+[web interface](http://127.0.0.1:9001). The default username and password, `minioadmin`, can be used to log in.
 
 The cluster itself consists of a manager node, an edge node, and a cloud node. The manager node can be accessed using
 the URL `grpc://127.0.0.1:9998`, the edge node using the URL `grpc://127.0.0.1:9999`, and the cloud node using the URL


### PR DESCRIPTION
This PR fixes https://github.com/ModelarData/ModelarDB-RS/issues/235 by updating the Docker files to no longer create a service for PostgreSQL and to use the new structure for the command line arguments. Also, since the Docker is currently intended to be used for testing during development, the default built profile has been changed to `dev`.