### PR TITLE
Update dev and user READMEs

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -60,18 +60,18 @@ processing.
   from compressed segments instead of from reconstructed data points.
   - **Query** - Types that implement traits provided by Apache DataFusion so SQL queries can be executed for ModelarDB
   tables.
-- [modelardb_server](/crates/modelardb_server) - ModelarDB's server in the form of the binary `modelardbd`.
+- [modelardb_server](/crates/modelardb_server) - ModelarDB's DBMS server in the form of the binary `modelardbd`.
   - **Storage** - Manages uncompressed data, compresses uncompressed data, manages compressed data, and writes
   compressed data to Delta Lake.
-  - **Configuration** - Manages the configuration of the ModelarDB server and provides functionality for updating the
-  configuration.
-  - **Context** - A type that contains all of the components in ModelarDB server and makes it easy to share and access
-  them.
-  - **Data Folders** - A type for managing data and metadata in a local data folder, an S3 bucket, or an Azure Blob
-  Store container.
+  - **Configuration** - Manages the configuration of the ModelarDB DBMS server and provides functionality for updating
+  the configuration.
+  - **Context** - A type that contains all of the components in ModelarDB DBMS server and makes it easy to share and
+  access them.
+  - **Data Folders** - A type for managing data and metadata in a local data folder, an Amazon S3 bucket, or an
+  Microsoft Azure Blob Storage container.
   - **Manager** - Manages metadata related to ModelarDB manager and provides functionality for interacting with
   ModelarDB manager.
-  - **Remote** - A public interface to interact with the ModelarDB server using Apache Arrow Flight.
+  - **Remote** - A public interface to interact with the ModelarDB DBMS server using Apache Arrow Flight.
 
 ## Development
 All code must be formatted according to the [Rust Style

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -39,11 +39,11 @@ other crates.
 - [modelardb_compression](/crates/modelardb_compression) - Library providing lossless and lossy model-based compression
 of time series.
   - **Models** - Multiple types of models used for compressing time series within different kinds of error bounds
-  (possible 0% error).
-  - **Compression** - Compresses univariate time series within user-defined error bounds (possible 0% error) and outputs
+  (possibly 0% error).
+  - **Compression** - Compresses univariate time series within user-defined error bounds (possibly 0% error) and outputs
   compressed segments.
   - **Merge** - Merges compressed segments if possible within the error bound to further decrease the amount of storage
-  bandwidth required.
+  and bandwidth required.
   For example, if a time series has the same structure at the end of a batch of data points and the start of the
   following batch of data points.
   - **Types** - Types used throughout modelardb_compression, e.g., for creating compressed segments and accumulating
@@ -81,7 +81,7 @@ this repository, are covered here.
 
 ### Documentation
 All modules must have an accompanying doc comment that describes the general functionality of the module and its
-content. Thus, a brief description of the central structs, functions, etc should be included if important to understand
+content. Thus, a brief description of the central structs, functions, etc. should be included if important to understand
 the module.
 
 Functions and methods should be ordered by visibility and the order in which they are expected to be used. For example,
@@ -89,9 +89,9 @@ for a struct its public constructors should be placed first, then the most commo
 most commonly used public methods, and so on. Private functions and methods should be placed right after the last public
 function or method that calls them.
 
-All public and private structs, traits, functions, and methods must have an accompanying doc comment that describes
-their purpose. Generally, these doc comments should include a description of the main parameters, the return value, and,
-if beneficial, examples.
+All public and private structs, traits, functions, and methods must have accompanying doc comments that describes their
+purpose. Generally, these doc comments should include a description of the main parameters, the return value, and, if
+beneficial, examples.
 
 ### Terminology
 The following terminology must be used throughout the ModelarDB project.
@@ -100,9 +100,9 @@ The following terminology must be used throughout the ModelarDB project.
 - **try** - Used as a prefix for functions and methods that return `Result` or `Option` to indicate it may return a
 value.
 - **normal table** A relational table that stores data directly in Apache Parquet files managed by Delta Lake and thus
-use the same schema at the logical and physical layer.
+uses the same schema at the logical and physical layer.
 - **model table** A relational table that stores time series data as compressed segments containing metadata and models
-in Apache Parquet files managed by Delta Lake and thus use different schemas at the logical and physical layer.
+in Apache Parquet files managed by Delta Lake and thus uses different schemas at the logical and physical layer.
 - **table** A normal table or a model table, e.g., used when a function or method accepts both types of tables.
 
 ### Testing and Linting

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,9 +1,8 @@
 # ModelarDB Development
 This document describes the structure of the code and general considerations to consider when doing further development.
-As such, this document should be used as a guideline when contributing to the repository.
-
-Contributions to all aspects of ModelarDB are highly appreciated and do not need to be in the form of new features or even code.
-For example, contributions can be:
+As such, this document should be used as a guideline when contributing to the repository. Contributions to all aspects
+of ModelarDB are highly appreciated and do not need to be in the form of new features or even code. For example,
+contributions can be:
 
 - Helping other users.
 - Writing documentation.
@@ -13,67 +12,93 @@ For example, contributions can be:
 - Refactoring existing functionality.
 - Implementing new functionality.
 
-Any questions or discussions regarding a possible contribution should be posted in the appropriate GitHub issue if
-one exists, e.g., the bug report if it is a bugfix, and as a new GitHub issue otherwise.
+Any questions or discussions regarding a possible contribution should be posted in the appropriate GitHub issue if one
+exists, e.g., the bug report if it is a bugfix, and as a new GitHub issue otherwise.
 
 ## Structure
 The ModelarDB project consists of the following crates and major components:
 
 - [modelardb_client](/crates/modelardb_client) - ModelarDB's command-line client in the form of the binary `modelardb`.
   - **Helper** - Enhances the command-line client with autocompletion of keywords and names.
-- [modelardb_common](/crates/modelardb_common) - Library providing shared functions, macros, and types for use by the other crates.
-  - **Metadata** - Manages metadata stored in Delta Lake, e.g., information about the tables' schema and compressed data.
-  - **Arguments** - Parses command-line arguments and serializes and deserializes arguments for use with Apache Arrow Flight.
-  - **Errors** - Error type used throughout the ModelarDB project, a single error type is used throughout the ModelarDB project for simplicity.
-  - **Macros** - Macros for extracting an array from a `RecordBatch` and extracting all arrays from a `RecordBatch` with compressed segments.
-  - **Parser** - Extension to Apache DataFusion's SQL parser so it can create model tables with a timestamp, one or more fields, and zero or more tags.
-  - **Schemas** - Schemas used throughout the ModelarDB project, e.g., for buffers and for Apache Parquet files with compressed segments.
-  - **Types** - Types used throughout the ModelarDB project, e.g., for representing timestamps and different kinds of error bounds.
-- [modelardb_compression](/crates/modelardb_compression) - Library providing lossless and lossy model-based compression of time series.
-  - **Models** - Multiple types of models used for compressing time series within different kinds of error bounds (possible 0% error).
-  - **Compression** - Compresses univariate time series within a user-defined error bounds (possible 0% error) and outputs compressed segments.
-  - **Merge** - Merges compressed segments if possible within the error bound to further decrease the amount of storage bandwidth required.
-  For example, if a time series has the same structure at the end of a batch of data points and the start of the following batch of data points.
-  - **Types** - Types used throughout modelardb_compression, e.g., for creating compressed segments and accumulating batches of them.
+- [modelardb_common](/crates/modelardb_common) - Library providing shared functions, macros, and types for use by the
+other crates.
+  - **Metadata** - Manages metadata stored in Delta Lake, e.g., information about the tables' schema and compressed
+  data.
+  - **Arguments** - Parses command-line arguments and serializes and deserializes arguments for use with Apache Arrow
+  Flight.
+  - **Errors** - Error type used throughout the ModelarDB project, a single error type is used throughout the ModelarDB
+  project for simplicity.
+  - **Macros** - Macros for extracting an array from a `RecordBatch` and extracting all arrays from a `RecordBatch` with
+  compressed segments.
+  - **Parser** - Extension to Apache DataFusion's SQL parser so it can create model tables with a timestamp, one or more
+  fields, and zero or more tags.
+  - **Schemas** - Schemas used throughout the ModelarDB project, e.g., for buffers and for Apache Parquet files with
+  compressed segments.
+  - **Types** - Types used throughout the ModelarDB project, e.g., for representing timestamps and different kinds of
+  error bounds.
+- [modelardb_compression](/crates/modelardb_compression) - Library providing lossless and lossy model-based compression
+of time series.
+  - **Models** - Multiple types of models used for compressing time series within different kinds of error bounds
+  (possible 0% error).
+  - **Compression** - Compresses univariate time series within a user-defined error bounds (possible 0% error) and
+  outputs compressed segments.
+  - **Merge** - Merges compressed segments if possible within the error bound to further decrease the amount of storage
+  bandwidth required.
+  For example, if a time series has the same structure at the end of a batch of data points and the start of the
+  following batch of data points.
+  - **Types** - Types used throughout modelardb_compression, e.g., for creating compressed segments and accumulating
+  batches of them.
 - [modelardb_manager](/crates/modelardb_manager) - ModelarDB's manager in the form of the binary `modelardbm`.
-  - **Cluster** - Manages edge and cloud nodes currently controlled by the ModelarDB manager and provides functionality for balancing
-  query workloads across multiple cloud nodes.
-  - **Metadata** - Manages metadata stored in Delta Lake, e.g., information about the manager itself, the nodes controlled by the manager,
-  and the database schema and compressed data in the cluster.
+  - **Cluster** - Manages edge and cloud nodes currently controlled by the ModelarDB manager and provides functionality
+  for balancing query workloads across multiple cloud nodes.
+  - **Metadata** - Manages metadata stored in Delta Lake, e.g., information about the manager itself, the nodes
+  controlled by the manager, and the database schema and compressed data in the cluster.
   - **Remote** - A public interface for interacting with the ModelarDB manager using Apache Arrow Flight.
-- [modelardb_query](/crates/modelardb_query) - Library providing integration with Apache DataFusion for query processing.
-  - **Optimizer** - Rules for rewriting Apache DataFusion's physical plans for model tables so aggregates are computed from compressed segments
-  instead of from reconstructed data points.
-  - **Query** - Types that implement traits provided by Apache DataFusion so SQL queries can be executed for ModelarDB tables.
+- [modelardb_query](/crates/modelardb_query) - Library providing integration with Apache DataFusion for query
+processing.
+  - **Optimizer** - Rules for rewriting Apache DataFusion's physical plans for model tables so aggregates are computed
+  from compressed segments instead of from reconstructed data points.
+  - **Query** - Types that implement traits provided by Apache DataFusion so SQL queries can be executed for ModelarDB
+  tables.
 - [modelardb_server](/crates/modelardb_server) - ModelarDB's server in the form of the binary `modelardbd`.
-  - **Storage** - Manages uncompressed data, compresses uncompressed data, manages compressed data, and writes compressed data to Delta Lake.
-  - **Configuration** - Manages the configuration of the ModelarDB server and provides functionality for updating the configuration.
-  - **Context** - A type that contains all of the components in ModelarDB server and makes it easy to share and access them.
-  - **Data Folders** - A type for managing data and metadata in a local data folder, an S3 bucket, or an Azure Blob Store container.
-  - **Manager** - Manages metadata related to ModelarDB manager and provides functionality for interacting with ModelarDB manager.
+  - **Storage** - Manages uncompressed data, compresses uncompressed data, manages compressed data, and writes
+  compressed data to Delta Lake.
+  - **Configuration** - Manages the configuration of the ModelarDB server and provides functionality for updating the
+  configuration.
+  - **Context** - A type that contains all of the components in ModelarDB server and makes it easy to share and access
+  them.
+  - **Data Folders** - A type for managing data and metadata in a local data folder, an S3 bucket, or an Azure Blob
+  Store container.
+  - **Manager** - Manages metadata related to ModelarDB manager and provides functionality for interacting with
+  ModelarDB manager.
   - **Remote** - A public interface to interact with the ModelarDB server using Apache Arrow Flight.
 
 ## Development
-All code must be formatted according to the [Rust Style Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md)
-using [rustfmt](https://github.com/rust-lang/rustfmt). Subjects not covered in the style guide, or requirements specific
-to this repository, are covered here.
+All code must be formatted according to the [Rust Style
+Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md) using
+[rustfmt](https://github.com/rust-lang/rustfmt). Subjects not covered in the style guide, or requirements specific to
+this repository, are covered here.
 
 ### Documentation
-All modules must have an accompanying doc comment that describes the general functionality of the module and its content.
-Thus, a brief description of the central structs, functions, etc should be included if important to understand the module.
+All modules must have an accompanying doc comment that describes the general functionality of the module and its
+content. Thus, a brief description of the central structs, functions, etc should be included if important to understand
+the module.
 
-Function and methods should be ordered by visibility and the order in which they are expected to be used. For example, for a struct
-its public constructors should be placed first, then the most commonly used public methods, then the 2nd most commonly used public
-methods, and so on. Private functions and methods should be placed right after the last public function or method that calls them.
+Function and methods should be ordered by visibility and the order in which they are expected to be used. For example,
+for a struct its public constructors should be placed first, then the most commonly used public methods, then the 2nd
+most commonly used public methods, and so on. Private functions and methods should be placed right after the last public
+function or method that calls them.
 
-All public and private structs, traits, functions, and methods must have an accompanying doc comment that describes their purpose.
-Generally, these doc comments should include a description of the main parameters, the return value, and, if beneficial, examples.
+All public and private structs, traits, functions, and methods must have an accompanying doc comment that describes
+their purpose. Generally, these doc comments should include a description of the main parameters, the return value, and,
+if beneficial, examples.
 
 ### Terminology
 The following terminology must be used throughout the ModelarDB project.
 
 - **maybe** - Used as a prefix for variables of type `Result` or `Option` to indicate it may contain a value.
-- **try** - Used as a prefix for functions and methods that return `Result` or `Option` to indicate it may return a value.
+- **try** - Used as a prefix for functions and methods that return `Result` or `Option` to indicate it may return a
+value.
 - **normal table** A relational table that stores data directly in Apache Parquet files managed by Delta Lake and thus
 use the same schema at the logical and physical layer.
 - **model table** A relational table that stores time series data as compressed segments containing metadata and models

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -89,7 +89,7 @@ for a struct its public constructors should be placed first, then the most commo
 most commonly used public methods, and so on. Private functions and methods should be placed right after the last public
 function or method that calls them.
 
-All public and private structs, traits, functions, and methods must have accompanying doc comments that describes their
+All public and private structs, traits, functions, and methods must have accompanying doc comments that describe their
 purpose. Generally, these doc comments should include a description of the main parameters, the return value, and, if
 beneficial, examples.
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -40,8 +40,8 @@ other crates.
 of time series.
   - **Models** - Multiple types of models used for compressing time series within different kinds of error bounds
   (possible 0% error).
-  - **Compression** - Compresses univariate time series within a user-defined error bounds (possible 0% error) and
-  outputs compressed segments.
+  - **Compression** - Compresses univariate time series within user-defined error bounds (possible 0% error) and outputs
+  compressed segments.
   - **Merge** - Merges compressed segments if possible within the error bound to further decrease the amount of storage
   bandwidth required.
   For example, if a time series has the same structure at the end of a batch of data points and the start of the
@@ -65,11 +65,11 @@ processing.
   compressed data to Delta Lake.
   - **Configuration** - Manages the configuration of the ModelarDB DBMS server and provides functionality for updating
   the configuration.
-  - **Context** - A type that contains all of the components in ModelarDB DBMS server and makes it easy to share and
+  - **Context** - A type that contains all of the components in the ModelarDB DBMS server and makes it easy to share and
   access them.
   - **Data Folders** - A type for managing data and metadata in a local data folder, an Amazon S3 bucket, or an
   Microsoft Azure Blob Storage container.
-  - **Manager** - Manages metadata related to ModelarDB manager and provides functionality for interacting with
+  - **Manager** - Manages metadata related to the ModelarDB manager and provides functionality for interacting with the
   ModelarDB manager.
   - **Remote** - A public interface to interact with the ModelarDB DBMS server using Apache Arrow Flight.
 
@@ -84,7 +84,7 @@ All modules must have an accompanying doc comment that describes the general fun
 content. Thus, a brief description of the central structs, functions, etc should be included if important to understand
 the module.
 
-Function and methods should be ordered by visibility and the order in which they are expected to be used. For example,
+Functions and methods should be ordered by visibility and the order in which they are expected to be used. For example,
 for a struct its public constructors should be placed first, then the most commonly used public methods, then the 2nd
 most commonly used public methods, and so on. Private functions and methods should be placed right after the last public
 function or method that calls them.
@@ -102,8 +102,8 @@ value.
 - **normal table** A relational table that stores data directly in Apache Parquet files managed by Delta Lake and thus
 use the same schema at the logical and physical layer.
 - **model table** A relational table that stores time series data as compressed segments containing metadata and models
-in Apache Parquet files managed by Delta Lake and thus use the different schemas at the logical and physical layer.
-- **table** A normal table and a model table, e.g., used when a function or method accepts both types of tables.
+in Apache Parquet files managed by Delta Lake and thus use different schemas at the logical and physical layer.
+- **table** A normal table or a model table, e.g., used when a function or method accepts both types of tables.
 
 ### Testing and Linting
 All public and private functions must be appropriately covered by unit tests. Full coverage is intended, which means all

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -22,13 +22,14 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
 
 ### All
 2. Install the latest stable [Rust Toolchain](https://rustup.rs/).
-3. Build, test, and run the system using Cargo:
+3. Clone the repository: `git clone https://github.com/ModelarData/ModelarDB-RS`
+4. Build, test, and run the system using Cargo:
    - Debug Build: `cargo build`
    - Release Build: `cargo build --release`
    - Run Tests: `cargo test`
    - Run DBMS Server: `cargo run --bin modelardbd path_to_local_data_folder`
    - Run Client: `cargo run --bin modelardb [server_address] [query_file]`
-4. Move `modelardbd`, `modelardbm`, and `modelardb` from the `target` directory to any directory.
+5. Move `modelardbd`, `modelardbm`, and `modelardb` from the `target` directory to any directory.
 
 ## Usage
 ModelarDB consists of three binaries: `modelardbd` is a DBMS server that manages data and executes SQL queries,
@@ -49,7 +50,7 @@ of the instances in the cloud is to execute queries on the data in the object st
 Thus, when `modelardbd` is deployed in edge mode, it executes queries against local storage for low latency queries on
 the latest data and when it is deployed in cloud mode, it executes queries against the object store for efficient
 analytics on all the data transferred to the cloud. `modelardbm` implements the [Apache Arrow Flight
-protocol](https://arrow.apache.org/docs/format/Flight.html#downloading-data) for retrieving the `modelardbd` instance in
+protocol](https://arrow.apache.org/docs/format/Flight.html#downloading-data) for looking up the `modelardbd` instance in
 the cloud to use for executing each query, thus providing a single, workload-balanced, interface for querying the data
 in the object store using the `modelardbd` instances in the cloud.
 
@@ -60,9 +61,9 @@ has different requirements and supports different features.
 1. Start `modelardbd` in edge mode using only local storage - This is a simple and easy-to-use single-node deployment
 for use cases where a redundant object store is not required, e.g., when testing or experimenting. In edge mode without
 an object store, data is ingested to and queried from local storage. Thus, `modelardbd` instances in this configuration
-does not support transferring ingested data to an object store and does not support querying data from the object store.
-To run `modelardbd` in edge mode using only local storage, simply pass the path to the local folder `modelardbd` should
-use as its data folder:
+do not support transferring ingested data to an object store and do not support querying data from the object store. To
+run `modelardbd` in edge mode using only local storage, simply pass the path to the local folder `modelardbd` should use
+as its data folder:
 
 ```shell
 modelardbd path_to_local_data_folder
@@ -80,7 +81,7 @@ configuration supports ingesting data to a local folder in the cloud, transferri
 object store, and querying the data in the object store in the cloud.
 
 The following environment variables must be set to appropriate values if an Amazon S3-compatible object store is used so
-`modelardbm` and `modelardbd` knows how to connect to it:
+`modelardbm` and `modelardbd` know how to connect to it:
 
 ```shell
 AWS_ENDPOINT
@@ -89,7 +90,7 @@ AWS_SECRET_ACCESS_KEY
 ```
 
 For example, to use a local instance of [MinIO](https://min.io/), assuming the access key id `KURo1eQeMhDeVsrz` and the
-secret access key `sp7TDyD2ZruJ0VdFHmkacT1Y90PVPF7p` has been created through MinIO's command line tool or web
+secret access key `sp7TDyD2ZruJ0VdFHmkacT1Y90PVPF7p` have been created through MinIO's command line tool or web
 interface, set the environment variables as follows:
 
 ```shell
@@ -140,26 +141,26 @@ connected to it. Note that the manager uses `9998` as the default port and that 
 default port. The ports can be changed by specifying different ports with the following environment variables:
 
 ```shell
-MODELARDBM_PORT=8888
-MODELARDBD_PORT=8889
+MODELARDBM_PORT=8888  # By default modelardbm uses port 9998.
+MODELARDBD_PORT=8889  # By default modelardbd uses port 9999.
 ```
 
 ### Ingest Data
 Before data can be ingested into `modelardbd`, tables must be created. `modelardbd` supports two types of tables,
-standard relational tables created through `CREATE TABLE` statements and model tables created through `CREATE MODEL
-TABLE` statements. From a user's perspective, a model table functions like a standard relational table and can be
-queried using SQL. However, the implementation of a model table is highly optimized for time series and a model table
-must contain a single column with timestamps, one or more columns with fields (measurements as floating-point values),
-and zero or more columns with tags (metadata as strings). As stated, model tables can be created using `CREATE MODEL
-TABLE` statements with the column types `TIMESTAMP`, `FIELD`, and `TAG`. For `FIELD`, an error bound can optionally be
-specified in parentheses to enable lossy compression with a per-value error bound. The error bound can be absolute or
-relative, e.g., `FIELD(1.0)` creates a column with an absolute per-value error bound that allows each value to deviate
-by at most 1.0 while `FIELD(1.0%)` creates a column with a relative per-value error bound that allows each value to
-deviate by at most 1.0%. `FIELD` columns default to an error bound of zero when none is specified. Thus, by default
-lossless compression is used and lossy compression is only used if explicitly requested. If the values in a `FIELD`
-column can be computed from other columns they need not be stored. Instead, if a `FIELD` column is defined using the
-syntax `FIELD AS (expression)`, e.g., `FIELD AS (column_one + column_two)`, the values of the `FIELD` column will be the
-result of the expression. As these generated `FIELD` columns do not store any data, an error bound cannot be defined.
+standard relational tables created with `CREATE TABLE` statements and model tables created with `CREATE MODEL TABLE`
+statements. From a user's perspective, a model table functions like a standard relational table and can be queried using
+SQL. However, the implementation of a model table is highly optimized for time series and a model table must contain a
+single column with timestamps, one or more columns with fields (measurements as floating-point values), and zero or more
+columns with tags (metadata as strings). As stated, model tables can be created using `CREATE MODEL TABLE` statements
+with the column types `TIMESTAMP`, `FIELD`, and `TAG`. For `FIELD`, an error bound can optionally be specified in
+parentheses to enable lossy compression with a per-value error bound. The error bound can be absolute or relative, e.g.,
+`FIELD(1.0)` creates a column with an absolute per-value error bound that allows each value to deviate by at most 1.0
+while `FIELD(1.0%)` creates a column with a relative per-value error bound that allows each value to deviate by at most
+1.0%. `FIELD` columns default to an error bound of zero when none is specified. Thus, by default lossless compression is
+used and lossy compression is only used if explicitly requested. If the values in a `FIELD` column can be computed from
+other columns they need not be stored. Instead, if a `FIELD` column is defined using the syntax `FIELD AS (expression)`,
+e.g., `FIELD AS (column_one + column_two)`, the values of the `FIELD` column will be the result of the expression. As
+these generated `FIELD` columns do not store any data, an error bound cannot be defined.
 
 As both `CREATE MODEL TABLE` and `CREATE TABLE` are just SQL statements, both types of tables can be created using
 `modelardb` or programmatically using Apache Arrow Flight. For example, a model table storing a simple multivariate

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,7 +1,7 @@
 # ModelarDB Installation and Usage
-This document describes how to set up and use ModelarDB. Installation instructions are provided for
-Linux, macOS, FreeBSD, and Windows. To support running ModelarDB in a containerized environment, instructions for
-setting up a Docker environment are also provided. Once installed, using ModelarDB is consistent across all platforms.
+This document describes how to set up and use ModelarDB. Installation instructions are provided for Linux, macOS,
+FreeBSD, and Windows. To support running ModelarDB in a containerized environment, instructions for setting up a Docker
+environment are also provided. Once installed, using ModelarDB is consistent across all platforms.
 
 ## Installation
 ### Linux
@@ -17,7 +17,8 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
 
 ### Windows
 1. Install the latest versions of the Microsoft Visual C++ Prerequisites for Rust:
-   - Microsoft Visual C++ Prerequisites for Rust: see [The rustup book](https://rust-lang.github.io/rustup/installation/windows-msvc.html).
+   - Microsoft Visual C++ Prerequisites for Rust: see [The rustup
+   book](https://rust-lang.github.io/rustup/installation/windows-msvc.html).
 
 ### All
 2. Install the latest stable [Rust Toolchain](https://rustup.rs/).
@@ -25,105 +26,98 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
    - Debug Build: `cargo build`
    - Release Build: `cargo build --release`
    - Run Tests: `cargo test`
-   - Run Server: `cargo run --bin modelardbd path_to_local_data_folder`
+   - Run DBMS Server: `cargo run --bin modelardbd path_to_local_data_folder`
    - Run Client: `cargo run --bin modelardb [server_address] [query_file]`
 4. Move `modelardbd`, `modelardbm`, and `modelardb` from the `target` directory to any directory.
 
 ## Usage
-ModelarDB includes two binaries that can be deployed individually or together to support different use cases.
-`modelardbd` is a server that can be deployed in either *edge* or *cloud* mode and supports ingesting, compressing,
-and querying time series. `modelardbm` is a manager that can be deployed to manage a cluster of `modelardbd` edge and
-cloud instances. Specifically, `modelardbm` is responsible for keeping the database schema and access to external
-components consistent across all `modelardbd` instances in the cluster. Furthermore, `modelardbm` implements the
-[Arrow Flight RPC protocol](https://arrow.apache.org/docs/format/Flight.html#downloading-data) for querying data from
-the cluster, thus providing a single, workload-balanced, interface for querying data from all `modelardbd` instances in
-the cluster.
-
-For storage, `modelardbd` uses local storage and an Amazon S3-compatible or Azure Blob Storage object store. The
-execution mode dictates where queries are executed. When `modelardbd` is deployed in edge mode, it executes queries
-against local storage and when it is deployed in cloud mode, it executes queries against the object store.
+ModelarDB consists of three binaries: `modelardbd` is a DBMS server that manages data and executes SQL queries,
+`modelardbm` is a manager for one or more DBMS servers deployed on the *edge* or in the *cloud*, and `modelardb` is a
+command-line client for connecting to a DBMS server and executing commands and SQL queries.  `modelardbd` uses local
+storage on the edge and an Amazon S3-compatible or Azure Blob Storage object store in the cloud. `modelardbd` can be
+deployed alone or together with `modelardbm` depending on the use cases. `modelardbd` can be deployed on a single node
+and manage data in a local folder. In this configuration `modelardbm` is not needed. `modelardbd` can also be deployed
+in a distributed configuration across edge and cloud. In this configuration, `modelardbm` must first be deployed in the
+cloud to manager the `modelardbd` instances on the edge and in the cloud. Specifically, `modelardbm` is responsible for
+keeping the database schema consistent across all `modelardbd` instances in the cluster. After deploying `modelardbd`,
+instances of `modelardbd` can deployed on the edge and in cloud. While the `modelardbd` instances on the edge and in
+cloud provides the same functionality, the primary purpose of instances on the edge is to collect data and transfer it
+to an object store in the cloud while the primary purpose of the instances in the cloud is to execute queries on the
+data in the object store. Thus, when `modelardbd` is deployed in edge mode, it executes queries against local storage
+for low latency queries on the latest data and when it is deployed in cloud mode, it executes queries against the object
+store for efficient analytics on all the data transferred to the cloud. `modelardbm` implements the [Apache Arrow Flight
+protocol](https://arrow.apache.org/docs/format/Flight.html#downloading-data) for retrieving the cloud node to use, thus
+providing a single, workload-balanced, interface for querying data from all `modelardbd` instances in the cloud.
 
 ### Start Server
 There are three options available when starting `modelardbd` depending on the desired deployment use case. Each option
 has different requirements and supports different features.
 
-1. Start `modelardbd` in edge mode using only local storage - This is a simple and easy-to-use deployment that is ideal
-for testing and experimentation. It does not support transferring ingested time series to an object store and does not
-support querying data from the object store. However, it does support ingesting data to and querying data from local
-storage.
-2. Start `modelardbd` in edge mode with a manager - An already running instance of `modelardbm`, an object store, and a
-PostgreSQL database are required to start `modelardbd` in edge mode with a manager. This deployment supports transferring
-ingested time series to an object store but still queries data from local storage.
-3. Start `modelardbd` in cloud mode with a manager - As above, an already running instance of `modelardbm`, an object
-store, and a PostgreSQL database are required to start `modelardbd` in cloud mode with a manager. This deployment
-supports transferring ingested time series to an object store and queries data from the same object store.
-
-To run `modelardbd` in edge mode using only local storage, i.e., without transferring the ingested time series to an
-object store, simply pass the path to the local folder `modelardbd` should use as its data folder:
+1. Start `modelardbd` in edge mode using only local storage - This is a simple and easy-to-use single-node deployment
+for use cases where a redundant object store is not required, e.g., when testing or experimenting. In edge mode without
+an object store, data is ingested to and queried from local storage. Thus, `modelardbd` instances in this configuration
+does not support transferring ingested data to an object store and does not support querying data from the object store.
+To run `modelardbd` in edge mode using only local storage, simply pass the path to the local folder `modelardbd` should
+use as its data folder:
 
 ```shell
+modelardbd path_to_local_data_folder
+# or
 modelardbd edge path_to_local_data_folder
 ```
 
-To automatically transfer ingested time series to an object store, a manager must first be started. The manager requires
-a PostgreSQL database to store metadata and an Amazon S3-compatible or Azure Blob Storage object store to store the
-transferred time series. The following environment variables must first be set to appropriate values so `modelardbm`
-knows how to connect to the PostgreSQL database:
+2. Start `modelardbd` in edge mode with a manager - A running instance of `modelardbm` and an Amazon S3-compatible or
+Azure Blob Storage object store are required to start `modelardbd` in edge mode with a manager. This configuration
+supports ingesting data to a local folder on the edge, querying the data in the local folder on the edge, and
+transferring data in the local data folder to the object store.
+3. Start `modelardbd` in cloud mode with a manager - As above, a running instance of `modelardbm` and an Amazon
+S3-compatible or Azure Blob Storage object store are required to start `modelardbd` in cloud mode with a manager. This
+configuration supports ingesting data to a local folder in the cloud, transferring data in the local data folder to the
+object store, and querying the data in the object store in the cloud
+
+The following environment variables must be set to appropriate values if an Amazon S3-compatible object store is used so
+`modelardbm` and `modelardbd` knows how to connect to it:
 
 ```shell
-METADATA_DB_HOST
-METADATA_DB_PASSWORD
-METADATA_DB_USER
-```
-
-Furthermore, the following environment variables must be set to appropriate values so `modelardbm` knows which object
-store to connect to, how to authenticate, and if an HTTP connection is allowed or if HTTPS is required:
-
-```shell
+AWS_ENDPOINT
 AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
-AWS_DEFAULT_REGION
-AWS_ENDPOINT
-AWS_ALLOW_HTTP
 ```
 
 For example, to use a local instance of [MinIO](https://min.io/), assuming the access key id `KURo1eQeMhDeVsrz` and the
-secret access key `sp7TDyD2ZruJ0VdFHmkacT1Y90PVPF7p` has been created through
-MinIO's command line tool or web interface, set the environment variables as follows:
+secret access key `sp7TDyD2ZruJ0VdFHmkacT1Y90PVPF7p` has been created through MinIO's command line tool or web
+interface, set the environment variables as follows:
 
 ```shell
+AWS_ENDPOINT="http://127.0.0.1:9000"
 AWS_ACCESS_KEY_ID="KURo1eQeMhDeVsrz"
 AWS_SECRET_ACCESS_KEY="sp7TDyD2ZruJ0VdFHmkacT1Y90PVPF7p"
-AWS_DEFAULT_REGION=""
-AWS_ENDPOINT="http://127.0.0.1:9000"
-AWS_ALLOW_HTTP="true"
 ```
 
-Then, assuming a bucket named `wind-turbine` has been created through MinIO's command line tool or web interface and
-a PostgreSQL database named `metadata` has been created, `modelardbm` can be started with the following command:
+Then, assuming a bucket named `wind-turbine` has been created through MinIO's command line tool or web interface,
+`modelardbm` can be started with the following command:
 
 ```shell
 modelardbm metadata s3://wind-turbine
 ```
 
 `modelardbm` also supports using [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/)
-for the remote object store. To use [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/),
-set the following environment variables instead:
+for the remote object store. To use Azure Blob Storage, set the following environment variables:
 
 ```shell
 AZURE_STORAGE_ACCOUNT_NAME
 AZURE_STORAGE_ACCESS_KEY
 ```
 
-Assuming a container named `wind-turbine` already exists, `modelardbm` can then be started with transfer of the ingested
-time series to the [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/) container `wind-turbine`:
+Then, assuming a container named `wind-turbine` has been created, `modelardbm` can be started with the following
+command:
 
 ```shell
 modelardbm metadata azureblobstorage://wind-turbine
 ```
 
-When a manager is running, `modelardbd` can be started in edge mode with transfer of the ingested time series to the
-object store given to `modelardbm` using the following command:
+When a manager is running, `modelardbd` can be started in edge mode with transfer of the ingested data to the object
+store given to `modelardbm` using the following command:
 
 ```shell
 modelardbd edge path_to_local_data_folder manager_url
@@ -137,10 +131,9 @@ storage.
 modelardbd cloud path_to_local_data_folder manager_url
 ```
 
-In both cases, access to the PostgreSQL metadata database and the object store is automatically provided by the manager
-when the `modelardbd` instances are connected to it. Note that the manager uses `9998` as the default port and
-that the server uses `9999` as the default port. The ports can be changed by specifying different ports with the
-following environment variables:
+In both cases, access to the object store is automatically provided by the manager when `modelardbd` instances are
+connected to it. Note that the manager uses `9998` as the default port and that the DBMS server uses `9999` as the
+default port. The ports can be changed by specifying different ports with the following environment variables:
 
 ```shell
 MODELARDBM_PORT=8888
@@ -148,19 +141,21 @@ MODELARDBD_PORT=8889
 ```
 
 ### Ingest Data
-Before time series can be ingested into `modelardbd`, a model table must be created. From a user's perspective, a model
-table functions like any other table and can be queried using SQL. However, the implementation of a model table is highly
-optimized for time series and a model table must contain a single column with timestamps, one or more columns with
-fields (measurements as floating-point values), and zero or more columns with tags (metadata as strings). Model tables
-can be created using `CREATE MODEL TABLE` statements with the column types `TIMESTAMP`, `FIELD`, and `TAG`. For `FIELD`
-an error bound can optionally be specified in parentheses to enable lossy compression with a per-value error bound.
-The error bound can be absolute or relative, e.g., `FIELD(1.0)` creates a column with an absolute per-value error bound that
-allows each value to deviate by at most 1.0 while `FIELD(1.0%)` creates a column with a relative per-value error bound that
-allows each value to deviate by at most 1.0%. `FIELD` columns default to an error bound of zero when none is specified.
-If the values in a `FIELD` column can be computed from other columns they need not be stored. Instead, if a `FIELD` column
-is defined using the syntax `FIELD AS expression`, e.g., `FIELD AS column_one + column_two`, the values of the `FIELD` column
-will be the result of the expression. As these generated `FIELD` columns do not store any data, an error bound cannot be
-defined. `modelardb` also supports normal tables created through `CREATE TABLE` statements.
+Before data can be ingested into `modelardbd`, tables must be created. `modelardbd` supports two types of tables,
+standard relational tables created through `CREATE TABLE` statements and model tables created through `CREATE MODEL
+TABLE` statements. From a user's perspective, a model table functions like a standard relational table and can be
+queried using SQL. However, the implementation of a model table is highly optimized for time series and a model table
+must contain a single column with timestamps, one or more columns with fields (measurements as floating-point values),
+and zero or more columns with tags (metadata as strings). As stated, model tables can be created using `CREATE MODEL
+TABLE` statements with the column types `TIMESTAMP`, `FIELD`, and `TAG`. For `FIELD` an error bound can optionally be
+specified in parentheses to enable lossy compression with a per-value error bound. The error bound can be absolute or
+relative, e.g., `FIELD(1.0)` creates a column with an absolute per-value error bound that allows each value to deviate
+by at most 1.0 while `FIELD(1.0%)` creates a column with a relative per-value error bound that allows each value to
+deviate by at most 1.0%. `FIELD` columns default to an error bound of zero when none is specified. Thus, by default
+lossless compression is used and lossy compression is only used if explicitly requested. If the values in a `FIELD`
+column can be computed from other columns they need not be stored. Instead, if a `FIELD` column is defined using the
+syntax `FIELD AS (expression)`, e.g., `FIELD AS (column_one + column_two)`, the values of the `FIELD` column will be the
+result of the expression. As these generated `FIELD` columns do not store any data, an error bound cannot be defined.
 
 As both `CREATE MODEL TABLE` and `CREATE TABLE` are just SQL statements, both types of tables can be created using
 `modelardb` or programmatically using Apache Arrow Flight. For example, a model table storing a simple multivariate
@@ -184,12 +179,12 @@ result = flight_client.do_action(action)
 print(list(result))
 ```
 
-When running a larger cluster of `modelardbd` instances, it is required to use `modelardbm` to create tables and model
-tables. This is a necessity as `modelardbm` is responsible for keeping the database schema consistent across all
-`modelardbd` instances in the cluster. The process for creating a table on the manager is the same as when creating the
-table directly on a `modelardbd` instance, as shown above. The only difference is that the gRPC URL should be changed to
-connect to the manager instead. When the table is created through `modelardbm`, the table is created in all `modelardbd`
-instances managed by `modelardbm` automatically.
+When running a cluster of `modelardbd` instances, it is required to use `modelardbm` to create tables and model tables.
+This is a necessity as `modelardbm` is responsible for keeping the database schema consistent across all `modelardbd`
+instances in the cluster. The process for creating a table on the manager is the same as when creating the table
+directly on a `modelardbd` instance, as shown above. The only difference is that the gRPC URL should be changed to
+connect to the manager instead of the DBMS server. When the table is created through `modelardbm`, the table is
+automatically created in all `modelardbd` instances managed by `modelardbm`.
 
 After creating a table or a model table, data can be ingested into `modelardbd` with `INSERT` in `modelardb`. Be aware that
 `INSERT` statements currently must contain values for all columns but that the values for generated columns will be dropped
@@ -217,16 +212,18 @@ writer.close()
 ```
 
 While this example simply ingests three data points from memory, it is simple to extend such that it reads from other
-data sources. For example, [this Python script](https://github.com/ModelarData/Utilities/blob/main/Apache-Parquet-Loader/main.py)
-makes it simple to bulk load time series from Apache Parquet files with the same schema by reading the Apache Parquet
-files, creating a model table that matches their schema if it does not exist, and transferring the data in the Apache
-Parquet files to `modelardbd` using Apache Arrow Flight.
+data sources. For example, [this Python
+script](https://github.com/ModelarData/Utilities/blob/main/Apache-Parquet-Loader/main.py) makes it simple to bulk load
+time series from Apache Parquet files with the same schema by reading the Apache Parquet files, creating a model table
+that matches their schema if it does not exist, and transferring the data in the Apache Parquet files to `modelardbd`
+using Apache Arrow Flight.
 
-Time series can also be ingested into `modelardbd` using [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/)
-with the [Apache Arrow Flight output plugin](https://github.com/ModelarData/Telegraf-Output-Apache-Arrow-Flight).
-By using Telegraf, data points can be efficiently streamed into `modelardbd` from a large
-[collection of data sources](https://www.influxdata.com/time-series-platform/telegraf/telegraf-input-plugin/)
-such as [MQTT](https://mqtt.org/) and [OPC-UA](https://opcfoundation.org/about/opc-technologies/opc-ua/).
+Time series can also be ingested into `modelardbd` using
+[Telegraf](https://www.influxdata.com/time-series-platform/telegraf/) with the [Apache Arrow Flight output
+plugin](https://github.com/ModelarData/Telegraf-Output-Apache-Arrow-Flight). By using Telegraf, data points can be
+efficiently streamed into `modelardbd` from a large [collection of data
+sources](https://www.influxdata.com/time-series-platform/telegraf/telegraf-input-plugin/) such as
+[MQTT](https://mqtt.org/) and [OPC-UA](https://opcfoundation.org/about/opc-technologies/opc-ua/).
 
 It should be noted that the ingested data is only transferred to the remote object store when `modelardbd` is deployed
 in edge mode with a manager or in cloud mode with a manager. When `modelardbd` is deployed in edge mode without a
@@ -274,8 +271,8 @@ necessary to specify a port:
 modelardb 10.0.0.37
 ```
 
-However, if `modelardbd` has been configured to use another port using the environment variable `MODELARDBD_PORT`,
-the same port must also be passed to the client:
+Also, if `modelardbd` has been configured to use another port using the environment variable `MODELARDBD_PORT`, the same
+port must also be passed to the client:
 
 ```shell
 modelardb 10.0.0.37:9998
@@ -287,11 +284,11 @@ modelardb 10.0.0.37:9998
 modelardb 10.0.0.37 path_to_file_with_sql_statements.sql
 ```
 
-`modelardbd` can also be queried programmatically [from many different programming languages](https://arrow.apache.org/docs/index.html)
-using Apache Arrow Flight. The following Python example shows how to execute a simple SQL query against `modelardbd`
-and process the resulting stream of data points using [`pyarrow`](https://pypi.org/project/pyarrow/) and
-[`pandas`](https://pypi.org/project/pandas/). A PEP 249 compatible connector is also available for Python in the
-form of [PyModelarDB](https://github.com/ModelarData/PyModelarDB).
+`modelardbd` can also be queried programmatically [from many different programming
+languages](https://arrow.apache.org/docs/index.html) using Apache Arrow Flight. The following Python example shows how
+to execute a simple SQL query against `modelardbd` and process the resulting stream of data points using
+[`pyarrow`](https://pypi.org/project/pyarrow/) and [`pandas`](https://pypi.org/project/pandas/). A PEP 249 compatible
+connector is also available for Python in the form of [PyModelarDB](https://github.com/ModelarData/PyModelarDB).
 
 ```python
 from pyarrow import flight
@@ -306,16 +303,16 @@ for flight_stream_chunk in flight_stream_reader:
     print(pandas_data_frame)
 ```
 
-When running a larger cluster of `modelardbd` instances, it is recommended to use `modelardbm` to query the data in the
-remote object store. As mentioned above, `modelardbm` implements the
-[Arrow Flight RPC protocol](https://arrow.apache.org/docs/format/Flight.html#downloading-data) for querying data. This
-means that a request is made to the manager first to determine which `modelardbd` cloud instance in the cluster should
-be queried. The workload of the queries sent to the manager is balanced across all `modelardbd` cloud instances and
-at least one `modelardbd` cloud instance must be running for the manager to accept queries. The following Python example
-shows how to execute a simple SQL query using a `modelardbm` instance and how to process the resulting stream of data
-points using [`pyarrow`](https://pypi.org/project/pyarrow/) and [`pandas`](https://pypi.org/project/pandas/). It should
-be noted that the manager is only responsible for workload balancing and that the query is sent directly to the `modelardbd`
-cloud instance chosen by the manager which then sends the result set directly back to the requesting client.
+When running a cluster of `modelardbd` instances, it is recommended to use `modelardbm` to query the data in the remote
+object store. As mentioned above, `modelardbm` implements the [Apache Arrow Flight
+protocol](https://arrow.apache.org/docs/format/Flight.html#downloading-data) for querying data. This means that a
+request is made to the manager first to determine which `modelardbd` cloud instance in the cluster should be queried.
+The workload of the queries sent to the manager is balanced across all `modelardbd` cloud instances and at least one
+`modelardbd` cloud instance must be running for the manager to accept queries. The following Python example shows how to
+execute a simple SQL query using a `modelardbm` instance and how to process the resulting stream of data points using
+[`pyarrow`](https://pypi.org/project/pyarrow/) and [`pandas`](https://pypi.org/project/pandas/). It should be noted that
+the manager is only responsible for workload balancing and that the query is sent directly to the `modelardbd` cloud
+instance chosen by the manager which then sends the result set directly back to the client.
 
 ```python
 from pyarrow import flight
@@ -355,12 +352,12 @@ variables is provided here. If an environment variable is not set, the specified
 ## Docker
 Two different [Docker](https://docs.docker.com/) environments are included to make it easy to experiment with the
 different use cases of ModelarDB. The first environment sets up a single instance of `modelardbd` that only uses local
-storage. Time series data can be ingested into this instance, compressed, and saved to local storage. The compressed
-data in local storage can then be queried. The second environment covers the more complex use case of ModelarDB where
-multiple instances of `modelardbd` are deployed in a cluster with a manager that is responsible for managing the
-cluster. A single edge node and a single cloud node is set up in the cluster. Data can be ingested into the edge or
-cloud node, compressed, and transferred to a remote object store. The compressed data in the remote object store can
-then be queried through the cloud node or by directing the query through the manager node.
+storage. Data can be ingested into this instance, compressed, and saved to local storage. The compressed data in local
+storage can then be queried. The second environment covers the more complex use case of ModelarDB where multiple
+instances of `modelardbd` are deployed in a cluster with a manager that is responsible for managing the cluster. A
+single edge node and a single cloud node is set up in the cluster. Data can be ingested into the edge or cloud node,
+compressed, and transferred to a remote object store. The compressed data in the remote object store can then be queried
+through the cloud node or by directing the query through the manager node.
 
 Note that since [Rust](https://www.rust-lang.org/) is a compiled language and a more dynamic ModelarDB configuration
 might be needed, it is not recommended to use the [Docker](https://docs.docker.com/) environments during active
@@ -370,49 +367,48 @@ make maintenance of the created containers easier.
 
 ### Single edge deployment
 Once [Docker](https://docs.docker.com/) is set up, the single edge deployment can be started by running the following
-command from the root of the ModelarDB-RS repository:
+command from the root of the ModelarDB repository:
+
 
 ```shell
 docker-compose -p modelardb-single -f docker-compose-single.yml up
 ```
 
-Note that `-p modelardb-single` is only used to name the project to make it easier to manage in
-[Docker Desktop](https://docs.docker.com/desktop/). Once created, the container can be started and stopped using
-[Docker Desktop](https://docs.docker.com/desktop/) or by using the corresponding commands:
+Note that `-p modelardb-single` is only used to name the project to make it easier to manage in [Docker
+Desktop](https://docs.docker.com/desktop/). Once created, the container can be started and stopped using Docker Desktop
+or by using the corresponding commands:
 
 ```console
 docker-compose -p modelardb-single start
 docker-compose -p modelardb-single stop
 ```
 
-The single edge is running locally on port `9999` and can be accessed using the `modelardb` client or through
-Apache Arrow Flight as described above. Tables can be created and data can be ingested, compressed, and saved to local
-disk. The compressed data on local disk can then be queried.
+The single edge is running locally on port `9999` and can be accessed using the `modelardb` client or through Apache
+Arrow Flight as described above. Tables can be created and data can be ingested, compressed, and saved to local disk.
+The compressed data on local disk can then be queried.
 
 ### Cluster deployment
-Once [Docker](https://docs.docker.com/) is set up, the cluster deployment can be started by running the following
-command from the root of the ModelarDB-RS repository:
+Once Docker is set up, the cluster deployment can be started by running the following command from the root of the
+ModelarDB repository:
 
 ```shell
 docker-compose -p modelardb-cluster -f docker-compose-cluster.yml up
 ```
 
-Note that `-p modelardb-cluster` is only used to name the project to make it easier to manage in
-[Docker Desktop](https://docs.docker.com/desktop/). Once created, the containers can be started and stopped using
-[Docker Desktop](https://docs.docker.com/desktop/) or by using the corresponding commands:
+Note that `-p modelardb-cluster` is only used to name the project to make it easier to manage in Docker Desktop. Once
+created, the containers can be started and stopped using Docker Desktop or by using the corresponding commands:
 
 ```console
 docker-compose -p modelardb-cluster start
 docker-compose -p modelardb-cluster stop
 ```
 
-The cluster deployment sets up a [MinIO](https://min.io/) object store and a [MinIO](https://min.io/) client is used to
-initialize the bucket `modelardb` in the object store. [MinIO](https://min.io/) can be administered through its
-[web interface](http://127.0.0.1:9001). The default username and password, `minioadmin`, can be used to log in.
+The cluster deployment sets up a MinIO object store and a MinIO client is used to initialize the bucket `modelardb` in
+the object store. MinIO can be administered through its [web interface](http://127.0.0.1:9001). The default username and
+password, `minioadmin`, can be used to log in.
 
 The cluster itself consists of a manager node, an edge node, and a cloud node. The manager node can be accessed using
 the URL `grpc://127.0.0.1:9998`, the edge node using the URL `grpc://127.0.0.1:9999`, and the cloud node using the URL
 `grpc://127.0.0.1:9997`. Tables can be created through the manager node and data can be ingested, compressed, and
-transferred to the object store through the edge node or the cloud node. The compressed data in the
-[MinIO](https://min.io/) object store can then be queried through the cloud node or by directing the query through
-the manager node.
+transferred to the object store through the edge node or the cloud node. The compressed data in the MinIO object store
+can then be queried through the cloud node or by directing the query through the manager node.


### PR DESCRIPTION
This PR fixes #225 by updating the dev and user READMEs to make them consistent with the current implementation of `modelardbd`, `modelardm`, and `modelardb`. In addition, all of the text have been reordered so all lines have a length of 120 as that line length was used in most parts of the user README. Thus, the formatting of the two READMEs should now be consistent. When reviewing the changes, please look at how GitHub renders the READMEs to ensure they are easy to read when rendered.