### PR TITLE
Added NodeType action

### DIFF
--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -445,6 +445,8 @@ impl FlightService for FlightServiceHandler {
     /// * `RemoveNode`: Remove a node from the cluster of nodes controlled by the manager and
     /// kill the process running on the node. The specific node to remove is given through the
     /// uniquely identifying URL of the node.
+    /// * `NodeType`: Get the type of the node. The type is always `manager`. The type of the node
+    /// is returned as a string.
     async fn do_action(
         &self,
         request: Request<Action>,
@@ -631,6 +633,14 @@ impl FlightService for FlightServiceHandler {
 
             // Confirm the node was removed.
             Ok(Response::new(Box::pin(stream::empty())))
+        } else if action.r#type == "NodeType" {
+            let flight_result = FlightResult {
+                body: "manager".bytes().collect(),
+            };
+
+            Ok(Response::new(Box::pin(stream::once(async {
+                Ok(flight_result)
+            }))))
         } else {
             Err(Status::unimplemented("Action not implemented."))
         }
@@ -675,6 +685,11 @@ impl FlightService for FlightServiceHandler {
                 .to_owned(),
         };
 
+        let node_type_action = ActionType {
+            r#type: "NodeType".to_owned(),
+            description: "Get the type of the node.".to_owned(),
+        };
+
         let output = stream::iter(vec![
             Ok(initialize_database_action),
             Ok(create_table_action),
@@ -682,6 +697,7 @@ impl FlightService for FlightServiceHandler {
             Ok(truncate_table_action),
             Ok(register_node_action),
             Ok(remove_node_action),
+            Ok(node_type_action),
         ]);
 
         Ok(Response::new(Box::pin(output)))

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -456,6 +456,8 @@ impl FlightService for FlightServiceHandler {
     /// body should start with the size of the argument, immediately followed by the argument value.
     /// The first argument should be the setting to update. The second argument should be the new
     /// value of the setting as an unsigned integer.
+    /// * `NodeType`: Get the type of the node. The type is always `server`. The type of the node
+    /// is returned as a string.
     async fn do_action(
         &self,
         request: Request<Action>,
@@ -695,6 +697,14 @@ impl FlightService for FlightServiceHandler {
 
             // Confirm the configuration was updated.
             Ok(Response::new(Box::pin(stream::empty())))
+        } else if action.r#type == "NodeType" {
+            let flight_result = FlightResult {
+                body: "server".bytes().collect(),
+            };
+
+            Ok(Response::new(Box::pin(stream::once(async {
+                Ok(flight_result)
+            }))))
         } else {
             Err(Status::unimplemented("Action not implemented."))
         }
@@ -761,6 +771,11 @@ impl FlightService for FlightServiceHandler {
             description: "Update a specific setting in the server configuration.".to_owned(),
         };
 
+        let node_type_action = ActionType {
+            r#type: "NodeType".to_owned(),
+            description: "Get the type of the node.".to_owned(),
+        };
+
         let output = stream::iter(vec![
             Ok(create_table_action),
             Ok(drop_table_action),
@@ -771,6 +786,7 @@ impl FlightService for FlightServiceHandler {
             Ok(collect_metrics_action),
             Ok(get_configuration_action),
             Ok(update_configuration_action),
+            Ok(node_type_action),
         ]);
 
         Ok(Response::new(Box::pin(output)))

--- a/crates/modelardb_storage/src/delta_lake.rs
+++ b/crates/modelardb_storage/src/delta_lake.rs
@@ -172,7 +172,7 @@ impl DeltaLake {
     }
 
     /// Create a new [`DeltaLake`] that manages the Delta tables in an object store with an
-    /// Azure-compatible API. Returns a [`ModelarDbStorageError`] if a connection to the object 
+    /// Azure-compatible API. Returns a [`ModelarDbStorageError`] if a connection to the object
     /// store could not be made.
     pub fn try_from_azure_configuration(
         account_name: String,

--- a/crates/modelardb_types/src/macros.rs
+++ b/crates/modelardb_types/src/macros.rs
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-
 /// Extract an [`array`](arrow::array::Array) from a slice of
 /// `ArrayRef` and cast it to the specified type or panic with `msg`:
 ///
@@ -37,10 +36,7 @@
 #[macro_export]
 macro_rules! value {
     ($values:ident, $index:expr, $type:ident) => {
-        $values[$index]
-            .as_any()
-            .downcast_ref::<$type>()
-            .unwrap()
+        $values[$index].as_any().downcast_ref::<$type>().unwrap()
     };
 }
 


### PR DESCRIPTION
This PR adds a very simple action to the Apache Arrow Flight server for both the server and manager that can be used to "ping" the nodes and get the type of the node back. The action will always return `server` on the server and `manager` on the manager. The PR also includes an integration test for this new action on the server.