### PR TITLE
Fixed bug causing cloud nodes to return error when querying

### DIFF
--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -146,7 +146,7 @@ impl Context {
             .create_model_table(&model_table_metadata.name)
             .await?;
 
-        let query_table_metadata_manager = self
+        let query_folder_table_metadata_manager = self
             .data_folders
             .query_data_folder
             .table_metadata_manager
@@ -155,7 +155,7 @@ impl Context {
         // Register the model table with Apache DataFusion.
         self.register_model_table(
             model_table_metadata.clone(),
-            query_table_metadata_manager.clone(),
+            query_folder_table_metadata_manager.clone(),
         )
         .await?;
 
@@ -169,7 +169,7 @@ impl Context {
         // Register the metadata table needed for querying the model table if it is not already
         // registered. The tags table is already registered if the query data folder and local data
         // folder is the same.
-        query_table_metadata_manager
+        query_folder_table_metadata_manager
             .register_tags_table(&model_table_metadata.name)
             .await?;
 

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -146,21 +146,31 @@ impl Context {
             .create_model_table(&model_table_metadata.name)
             .await?;
 
-        let table_metadata_manager = self
+        let query_table_metadata_manager = self
             .data_folders
             .query_data_folder
             .table_metadata_manager
             .clone();
 
         // Register the model table with Apache DataFusion.
-        self.register_model_table(model_table_metadata.clone(), table_metadata_manager)
-            .await?;
+        self.register_model_table(
+            model_table_metadata.clone(),
+            query_table_metadata_manager.clone(),
+        )
+        .await?;
 
-        // Persist the new model table to the Delta Lake.
+        // Persist the new model table to the metadata Delta Lake.
         self.data_folders
             .local_data_folder
             .table_metadata_manager
             .save_model_table_metadata(&model_table_metadata, sql)
+            .await?;
+
+        // Register the metadata table needed for querying the model table if it is not already
+        // registered. The tags table is already registered if the query data folder and local data
+        // folder is the same.
+        query_table_metadata_manager
+            .register_tags_table(&model_table_metadata.name)
             .await?;
 
         info!("Created model table '{}'.", model_table_metadata.name);


### PR DESCRIPTION
This PR fixes https://github.com/ModelarData/ModelarDB-RS/issues/270 which caused cloud nodes to return an error when trying to query a table that was created while the cloud node was running.

The PR adds a new method to the table metadata manager that can be used to register the `model_table_name_tags` table which is the only metadata table required during querying. This new method is used to register the metadata table in the query data folder table metadata manager when a table is created.

The PR also adds unit tests for this new method since it is public.