### PR TITLE
Added new CreateTables action to create tables using table metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,7 +2945,6 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "arrow-flight",
- "bytes",
  "deltalake",
  "futures",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,6 +2945,7 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "arrow-flight",
+ "bytes",
  "deltalake",
  "futures",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "deltalake"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9db0cbd4a5cb31cbcfc3fd887545c241ac162539529bc2e6b5b2418839ec3b5"
+checksum = "258ea17ff3de424995ed51ebfb7e74bae9f307b2b513fa1ab71a2c26c772cb01"
 dependencies = [
  "deltalake-aws",
  "deltalake-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2999,6 +2999,7 @@ dependencies = [
  "arrow",
  "arrow-flight",
  "async-trait",
+ "bytes",
  "dashmap",
  "datafusion",
  "deltalake",

--- a/crates/modelardb_common/src/remote.rs
+++ b/crates/modelardb_common/src/remote.rs
@@ -16,6 +16,7 @@
 //! Utility functions used in the Apache Arrow Flight API for both the server and manager.
 
 use std::collections::HashMap;
+use std::error::Error;
 
 use arrow::array::ArrayRef;
 use arrow::datatypes::SchemaRef;
@@ -45,4 +46,16 @@ pub fn flight_data_to_record_batch(
 
     utils::flight_data_to_arrow_batch(flight_data, schema.clone(), dictionaries_by_id)
         .map_err(|error| Status::invalid_argument(error.to_string()))
+}
+
+/// Convert an `error` to a [`Status`] with [`tonic::Code::InvalidArgument`] as the code and `error`
+/// converted to a [`String`] as the message.
+pub fn error_to_status_invalid_argument(error: impl Error) -> Status {
+    Status::invalid_argument(error.to_string())
+}
+
+/// Convert an `error` to a [`Status`] with [`tonic::Code::Internal`] as the code and `error`
+/// converted to a [`String`] as the message.
+pub fn error_to_status_internal(error: impl Error) -> Status {
+    Status::internal(error.to_string())
 }

--- a/crates/modelardb_manager/Cargo.toml
+++ b/crates/modelardb_manager/Cargo.toml
@@ -26,6 +26,7 @@ path = "src/main.rs"
 [dependencies]
 arrow-flight.workspace = true
 arrow.workspace = true
+bytes.workspace = true
 deltalake.workspace = true
 futures.workspace = true
 modelardb_common = { path = "../modelardb_common" }

--- a/crates/modelardb_manager/Cargo.toml
+++ b/crates/modelardb_manager/Cargo.toml
@@ -26,7 +26,6 @@ path = "src/main.rs"
 [dependencies]
 arrow-flight.workspace = true
 arrow.workspace = true
-bytes.workspace = true
 deltalake.workspace = true
 futures.workspace = true
 modelardb_common = { path = "../modelardb_common" }

--- a/crates/modelardb_manager/src/metadata.rs
+++ b/crates/modelardb_manager/src/metadata.rs
@@ -378,7 +378,7 @@ mod tests {
 
         metadata_manager
             .table_metadata_manager
-            .save_normal_table_metadata(test::NORMAL_TABLE_NAME, test::NORMAL_TABLE_SQL)
+            .save_normal_table_metadata(test::NORMAL_TABLE_NAME)
             .await
             .unwrap();
 
@@ -396,7 +396,7 @@ mod tests {
         let model_table_metadata = test::model_table_metadata();
         metadata_manager
             .table_metadata_manager
-            .save_model_table_metadata(&model_table_metadata, test::MODEL_TABLE_SQL)
+            .save_model_table_metadata(&model_table_metadata)
             .await
             .unwrap();
 
@@ -422,14 +422,14 @@ mod tests {
 
         metadata_manager
             .table_metadata_manager
-            .save_normal_table_metadata(test::NORMAL_TABLE_NAME, test::NORMAL_TABLE_SQL)
+            .save_normal_table_metadata(test::NORMAL_TABLE_NAME)
             .await
             .unwrap();
 
         let model_table_metadata = test::model_table_metadata();
         metadata_manager
             .table_metadata_manager
-            .save_model_table_metadata(&model_table_metadata, test::MODEL_TABLE_SQL)
+            .save_model_table_metadata(&model_table_metadata)
             .await
             .unwrap();
 

--- a/crates/modelardb_manager/src/metadata.rs
+++ b/crates/modelardb_manager/src/metadata.rs
@@ -31,7 +31,7 @@ use modelardb_types::types::ServerMode;
 use uuid::Uuid;
 
 use crate::cluster::Node;
-use crate::error::{ModelarDbManagerError, Result};
+use crate::error::Result;
 
 /// Stores the metadata required for reading from and writing to the normal tables and model tables
 /// and persisting edges. The data that needs to be persisted is stored in the metadata Delta Lake.
@@ -48,7 +48,8 @@ pub struct MetadataManager {
 impl MetadataManager {
     /// Create a new [`MetadataManager`] that saves the metadata to a remote object store given by
     /// `connection_info` and initialize the metadata tables. If `connection_info` could not be
-    /// parsed or the metadata tables could not be created, return [`ModelarDbManagerError`].
+    /// parsed or the metadata tables could not be created, return
+    /// [`ModelarDbManagerError`](crate::error::ModelarDbManagerError).
     pub async fn try_from_connection_info(connection_info: &[u8]) -> Result<MetadataManager> {
         let session_context = Arc::new(SessionContext::new());
 
@@ -77,7 +78,7 @@ impl MetadataManager {
     /// * The `nodes` table contains metadata for each node that is controlled by the manager.
     ///
     /// If the tables exist or were created, return [`Ok`], otherwise return
-    /// [`ModelarDbManagerError`].
+    /// [`ModelarDbManagerError`](crate::error::ModelarDbManagerError).
     async fn create_and_register_manager_metadata_delta_lake_tables(&self) -> Result<()> {
         // Create and register the manager_metadata table if it does not exist.
         let delta_table = self
@@ -109,7 +110,7 @@ impl MetadataManager {
 
     /// Retrieve the key for the manager from the `manager_metadata` table. If a key does not
     /// already exist, create one and save it to the Delta Lake. If a key could not be retrieved
-    /// or created, return [`ModelarDbManagerError`].
+    /// or created, return [`ModelarDbManagerError`](crate::error::ModelarDbManagerError).
     pub async fn manager_key(&self) -> Result<Uuid> {
         let sql = "SELECT key FROM manager_metadata";
         let batch = sql_and_concat(&self.session_context, sql).await?;
@@ -137,7 +138,7 @@ impl MetadataManager {
     }
 
     /// Save the node to the metadata Delta Lake and return [`Ok`]. If the node could not be saved,
-    /// return [`ModelarDbManagerError`].
+    /// return [`ModelarDbManagerError`](crate::error::ModelarDbManagerError).
     pub async fn save_node(&self, node: Node) -> Result<()> {
         self.delta_lake
             .write_columns_to_metadata_table(
@@ -153,7 +154,8 @@ impl MetadataManager {
     }
 
     /// Remove the row in the `nodes` table that corresponds to the node with `url` and return
-    /// [`Ok`]. If the row could not be removed, return [`ModelarDbManagerError`].
+    /// [`Ok`]. If the row could not be removed, return
+    /// [`ModelarDbManagerError`](crate::error::ModelarDbManagerError).
     pub async fn remove_node(&self, url: &str) -> Result<()> {
         let delta_ops = self.delta_lake.metadata_delta_ops("nodes").await?;
 
@@ -166,8 +168,8 @@ impl MetadataManager {
     }
 
     /// Return the nodes currently controlled by the manager that have been persisted to the
-    /// metadata Delta Lake. If the nodes could not be retrieved, [`ModelarDbManagerError`] is
-    /// returned.
+    /// metadata Delta Lake. If the nodes could not be retrieved,
+    /// [`ModelarDbManagerError`](crate::error::ModelarDbManagerError) is returned.
     pub async fn nodes(&self) -> Result<Vec<Node>> {
         let mut nodes: Vec<Node> = vec![];
 
@@ -190,35 +192,10 @@ impl MetadataManager {
         Ok(nodes)
     }
 
-    /// Return the SQL query used to create the table with the name `table_name`. If a table with
-    /// that name does not exist, return [`ModelarDbManagerError`].
-    pub async fn table_sql(&self, table_name: &str) -> Result<String> {
-        let sql =
-            format!("SELECT sql FROM normal_table_metadata WHERE table_name = '{table_name}'");
-        let batch = sql_and_concat(&self.session_context, &sql).await?;
-
-        let table_sql = modelardb_types::array!(batch, 0, StringArray);
-        if table_sql.is_empty() {
-            let sql =
-                format!("SELECT sql FROM model_table_metadata WHERE table_name = '{table_name}'");
-            let batch = sql_and_concat(&self.session_context, &sql).await?;
-
-            let model_table_sql = modelardb_types::array!(batch, 0, StringArray);
-            if model_table_sql.is_empty() {
-                Err(ModelarDbManagerError::InvalidArgument(format!(
-                    "No normal table or model table with the name '{table_name}' exists."
-                )))
-            } else {
-                Ok(model_table_sql.value(0).to_owned())
-            }
-        } else {
-            Ok(table_sql.value(0).to_owned())
-        }
-    }
-
     /// Retrieve all rows of `column` from both the normal_table_metadata and model_table_metadata
     /// tables. If the column could not be retrieved, either because it does not exist or because
-    /// it could not be converted to a string, return [`ModelarDbManagerError`].
+    /// it could not be converted to a string, return
+    /// [`ModelarDbManagerError`](crate::error::ModelarDbManagerError).
     pub async fn table_metadata_column(&self, column: &str) -> Result<Vec<String>> {
         // Retrieve the column from both tables containing table metadata.
         let sql = format!("SELECT {column} FROM normal_table_metadata");
@@ -373,50 +350,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_table_sql_for_normal_table() {
-        let (_temp_dir, metadata_manager) = create_metadata_manager().await;
-
-        metadata_manager
-            .table_metadata_manager
-            .save_normal_table_metadata(test::NORMAL_TABLE_NAME)
-            .await
-            .unwrap();
-
-        let sql = metadata_manager
-            .table_sql(test::NORMAL_TABLE_NAME)
-            .await
-            .unwrap();
-        assert_eq!(sql, test::NORMAL_TABLE_SQL);
-    }
-
-    #[tokio::test]
-    async fn test_table_sql_for_model_table() {
-        let (_temp_dir, metadata_manager) = create_metadata_manager().await;
-
-        let model_table_metadata = test::model_table_metadata();
-        metadata_manager
-            .table_metadata_manager
-            .save_model_table_metadata(&model_table_metadata)
-            .await
-            .unwrap();
-
-        let sql = metadata_manager
-            .table_sql(&model_table_metadata.name)
-            .await
-            .unwrap();
-
-        assert_eq!(sql, test::MODEL_TABLE_SQL);
-    }
-
-    #[tokio::test]
-    async fn test_table_sql_for_missing_table() {
-        let (_temp_dir, metadata_manager) = create_metadata_manager().await;
-
-        let result = metadata_manager.table_sql("missing_table").await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
     async fn test_table_metadata_column() {
         let (_temp_dir, metadata_manager) = create_metadata_manager().await;
 
@@ -438,15 +371,9 @@ mod tests {
             .await
             .unwrap();
 
-        let table_sql = metadata_manager.table_metadata_column("sql").await.unwrap();
-
         assert_eq!(
             table_names,
             vec![test::NORMAL_TABLE_NAME, &model_table_metadata.name]
-        );
-        assert_eq!(
-            table_sql,
-            vec![test::NORMAL_TABLE_SQL, test::MODEL_TABLE_SQL]
         );
     }
 

--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -103,7 +103,7 @@ impl FlightServiceHandler {
             .table_metadata_manager;
 
         let schema = if table_metadata_manager
-            .is_normal_table(&table_name)
+            .is_normal_table(table_name)
             .await
             .map_err(error_to_status_internal)?
         {
@@ -111,7 +111,7 @@ impl FlightServiceHandler {
                 .context
                 .remote_data_folder
                 .delta_lake
-                .delta_table(&table_name)
+                .delta_table(table_name)
                 .await
                 .map_err(error_to_status_internal)?;
 
@@ -123,12 +123,12 @@ impl FlightServiceHandler {
 
             Arc::new(schema)
         } else if table_metadata_manager
-            .is_model_table(&table_name)
+            .is_model_table(table_name)
             .await
             .map_err(error_to_status_internal)?
         {
             let model_table_metadata = table_metadata_manager
-                .model_table_metadata_for_model_table(&table_name)
+                .model_table_metadata_for_model_table(table_name)
                 .await
                 .map_err(error_to_status_internal)?;
 
@@ -424,7 +424,7 @@ impl FlightService for FlightServiceHandler {
         let flight_descriptor = request.into_inner();
         let table_name = remote::table_name_from_flight_descriptor(&flight_descriptor)?;
 
-        let schema = self.table_schema(&table_name).await?;
+        let schema = self.table_schema(table_name).await?;
 
         let options = IpcWriteOptions::default();
         let schema_as_ipc = SchemaAsIpc::new(&schema, &options);

--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -149,7 +149,8 @@ impl FlightServiceHandler {
             .context
             .remote_data_folder
             .metadata_manager
-            .table_metadata_column("table_name")
+            .table_metadata_manager
+            .table_names()
             .await
             .map_err(error_to_status_internal)?;
 
@@ -354,7 +355,8 @@ impl FlightService for FlightServiceHandler {
             .context
             .remote_data_folder
             .metadata_manager
-            .table_metadata_column("table_name")
+            .table_metadata_manager
+            .table_names()
             .await
             .map_err(error_to_status_internal)?;
 
@@ -573,7 +575,8 @@ impl FlightService for FlightServiceHandler {
                 .context
                 .remote_data_folder
                 .metadata_manager
-                .table_metadata_column("table_name")
+                .table_metadata_manager
+                .table_names()
                 .await
                 .map_err(error_to_status_internal)?;
 

--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -40,7 +40,7 @@ use modelardb_common::remote::{error_to_status_internal, error_to_status_invalid
 use modelardb_storage::metadata::model_table_metadata::ModelTableMetadata;
 use modelardb_storage::parser;
 use modelardb_storage::parser::ModelarDbStatement;
-use modelardb_types::schemas::CREATE_TABLE_SCHEMA;
+use modelardb_types::schemas::TABLE_METADATA_SCHEMA;
 use modelardb_types::types::ServerMode;
 use tokio::runtime::Runtime;
 use tonic::transport::Server;
@@ -540,7 +540,7 @@ impl FlightService for FlightServiceHandler {
             // Extract the record batch from the action body.
             let record_batch = modelardb_storage::try_convert_bytes_to_record_batch(
                 action.body.into(),
-                &CREATE_TABLE_SCHEMA.0.clone(),
+                &TABLE_METADATA_SCHEMA.0.clone(),
             )
             .map_err(error_to_status_invalid_argument)?;
 
@@ -623,7 +623,7 @@ impl FlightService for FlightServiceHandler {
                 }
 
                 let record_batch =
-                    compute::concat_batches(&CREATE_TABLE_SCHEMA.0.clone(), &record_batches)
+                    compute::concat_batches(&TABLE_METADATA_SCHEMA.0.clone(), &record_batches)
                         .map_err(error_to_status_internal)?;
 
                 let record_batch_bytes =
@@ -734,9 +734,10 @@ impl FlightService for FlightServiceHandler {
 
         let initialize_database_action = ActionType {
             r#type: "InitializeDatabase".to_owned(),
-            description: "Return the metadata required to create all normal tables and model tables \
-            currently in the manager's database schema."
-                .to_owned(),
+            description:
+                "Return the metadata required to create all normal tables and model tables \
+                 currently in the manager's database schema."
+                    .to_owned(),
         };
 
         let register_node_action = ActionType {

--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -171,7 +171,6 @@ impl FlightServiceHandler {
         &self,
         table_name: &str,
         schema: &Schema,
-        sql: &str,
     ) -> StdResult<(), Status> {
         // Create an empty Delta Lake table.
         self.context
@@ -186,7 +185,7 @@ impl FlightServiceHandler {
             .remote_data_folder
             .metadata_manager
             .table_metadata_manager
-            .save_normal_table_metadata(table_name, sql)
+            .save_normal_table_metadata(table_name)
             .await
             .map_err(error_to_status_internal)?;
 
@@ -214,7 +213,6 @@ impl FlightServiceHandler {
     async fn save_and_create_cluster_model_table(
         &self,
         model_table_metadata: Arc<ModelTableMetadata>,
-        sql: &str,
     ) -> StdResult<(), Status> {
         // Create an empty Delta Lake table.
         self.context
@@ -229,7 +227,7 @@ impl FlightServiceHandler {
             .remote_data_folder
             .metadata_manager
             .table_metadata_manager
-            .save_model_table_metadata(&model_table_metadata, sql)
+            .save_model_table_metadata(&model_table_metadata)
             .await
             .map_err(error_to_status_internal)?;
 
@@ -459,13 +457,13 @@ impl FlightService for FlightServiceHandler {
         match modelardb_statement {
             ModelarDbStatement::CreateNormalTable { name, schema } => {
                 self.check_if_table_exists(&name).await?;
-                self.save_and_create_cluster_normal_table(&name, &schema, &sql)
+                self.save_and_create_cluster_normal_table(&name, &schema)
                     .await?;
             }
             ModelarDbStatement::CreateModelTable(model_table_metadata) => {
                 self.check_if_table_exists(&model_table_metadata.name)
                     .await?;
-                self.save_and_create_cluster_model_table(model_table_metadata, &sql)
+                self.save_and_create_cluster_model_table(model_table_metadata)
                     .await?;
             }
             ModelarDbStatement::TruncateTable(table_names) => {
@@ -550,13 +548,13 @@ impl FlightService for FlightServiceHandler {
 
             for (table_name, schema) in normal_table_metadata {
                 self.check_if_table_exists(&table_name).await?;
-                self.save_and_create_cluster_normal_table(&table_name, &schema, "")
+                self.save_and_create_cluster_normal_table(&table_name, &schema)
                     .await?;
             }
 
             for metadata in model_table_metadata {
                 self.check_if_table_exists(&metadata.name).await?;
-                self.save_and_create_cluster_model_table(Arc::new(metadata), "")
+                self.save_and_create_cluster_model_table(Arc::new(metadata))
                     .await?;
             }
 

--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -191,11 +191,15 @@ impl FlightServiceHandler {
             .map_err(error_to_status_internal)?;
 
         // Register and save the table to each node in the cluster.
+        let record_batch =
+            modelardb_storage::normal_table_metadata_record_batch(table_name, schema)
+                .map_err(error_to_status_internal)?;
+
         self.context
             .cluster
             .read()
             .await
-            .cluster_do_get(sql, &self.context.key)
+            .create_tables(&record_batch, &self.context.key)
             .await
             .map_err(error_to_status_internal)?;
 
@@ -230,11 +234,15 @@ impl FlightServiceHandler {
             .map_err(error_to_status_internal)?;
 
         // Register and save the model table to each node in the cluster.
+        let record_batch =
+            modelardb_storage::model_table_metadata_record_batch(&model_table_metadata)
+                .map_err(error_to_status_internal)?;
+
         self.context
             .cluster
             .read()
             .await
-            .cluster_do_get(sql, &self.context.key)
+            .create_tables(&record_batch, &self.context.key)
             .await
             .map_err(error_to_status_internal)?;
 

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -445,12 +445,9 @@ impl Context {
 mod tests {
     use super::*;
 
-    use datafusion::arrow::compute::concat_batches;
+    use modelardb_storage::parser;
     use modelardb_storage::parser::ModelarDbStatement;
     use modelardb_storage::test;
-    use modelardb_storage::{
-        model_table_metadata_record_batch, normal_table_metadata_record_batch, parser,
-    };
     use tempfile::TempDir;
 
     use crate::data_folders::DataFolder;
@@ -460,21 +457,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        let normal_table_record_batch = normal_table_metadata_record_batch(
-            test::NORMAL_TABLE_NAME,
-            &test::normal_table_schema(),
-        )
-        .unwrap();
-
-        let metadata = test::model_table_metadata();
-        let model_table_record_batch = model_table_metadata_record_batch(&metadata).unwrap();
-
-        let table_record_batch = concat_batches(
-            &CREATE_TABLE_SCHEMA.0,
-            &vec![normal_table_record_batch, model_table_record_batch],
-        )
-        .unwrap();
-
+        let table_record_batch = test::table_metadata_record_batch();
         let table_record_batch_bytes =
             modelardb_storage::try_convert_record_batch_to_bytes(&table_record_batch).unwrap();
 

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -19,6 +19,7 @@
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::SchemaProvider;
 use datafusion::prelude::SessionContext;
 use modelardb_storage::metadata::model_table_metadata::ModelTableMetadata;
@@ -68,6 +69,19 @@ impl Context {
             session_context,
             storage_engine,
         })
+    }
+
+    /// Parse the [`RecordBatch`] in `record_batch` and create the tables based on the data in the
+    /// record batch. Returns [`ModelarDbServerError`] if the schema of the record batch is invalid
+    /// or if the tables could not be created. Note that if an error occurs while creating the
+    /// tables, the tables that were created before the error occurred are not dropped.
+    pub(crate) async fn create_tables_from_record_batch(
+        &self,
+        record_batch: RecordBatch,
+    ) -> Result<()> {
+        println!("Batch: {:?}", record_batch);
+
+        Ok(())
     }
 
     /// Create a normal table based on `name` and `schema` created from `sql`. Returns

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -76,7 +76,7 @@ impl Context {
     /// batch, the record batch could not be parsed, or the tables could not be created.
     pub(crate) async fn create_tables_from_bytes(&self, bytes: Vec<u8>) -> Result<()> {
         let record_batch = modelardb_storage::try_convert_bytes_to_record_batch(
-            bytes.into(),
+            bytes,
             &CREATE_TABLE_SCHEMA.0.clone(),
         )?;
 

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -503,7 +503,7 @@ fn array_to_error_bounds(error_bounds_array: ArrayRef) -> Result<Vec<ErrorBound>
         .downcast_ref::<Float32Array>()
         .unwrap();
 
-    let mut error_bounds = Vec::with_capacity(error_bounds_array.len());
+    let mut error_bounds = Vec::with_capacity(value_array.len());
     for value in value_array.iter().flatten() {
         if value < 0.0 {
             error_bounds.push(ErrorBound::try_new_relative(-value)?);
@@ -523,13 +523,13 @@ fn array_to_generated_columns(
     df_schema: &DFSchema,
 ) -> Result<Vec<Option<GeneratedColumn>>> {
     // unwrap() is safe since generated column expressions are always strings.
-    let generated_columns_array = generated_columns_array
+    let expr_array = generated_columns_array
         .as_any()
         .downcast_ref::<StringArray>()
         .unwrap();
 
-    let mut generated_columns = Vec::with_capacity(generated_columns_array.len());
-    for maybe_expr in generated_columns_array.iter() {
+    let mut generated_columns = Vec::with_capacity(expr_array.len());
+    for maybe_expr in expr_array.iter() {
         if let Some(expr) = maybe_expr {
             generated_columns.push(Some(GeneratedColumn::try_from_sql_expr(expr, df_schema)?));
         } else {

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -449,8 +449,6 @@ impl Context {
 mod tests {
     use super::*;
 
-    use modelardb_storage::parser;
-    use modelardb_storage::parser::ModelarDbStatement;
     use modelardb_storage::test;
     use tempfile::TempDir;
 
@@ -483,11 +481,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_parse_and_create_normal_table() {
+    async fn test_create_normal_table() {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::NORMAL_TABLE_SQL)
+        context
+            .create_normal_table(test::NORMAL_TABLE_NAME, &test::normal_table_schema())
             .await
             .unwrap();
 
@@ -517,25 +516,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_parse_and_create_existing_normal_table() {
+    async fn test_create_existing_normal_table() {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        assert!(parse_and_create_table(&context, test::NORMAL_TABLE_SQL)
+        assert!(context
+            .create_normal_table(test::NORMAL_TABLE_NAME, &test::normal_table_schema())
             .await
             .is_ok());
 
-        assert!(parse_and_create_table(&context, test::NORMAL_TABLE_SQL)
+        assert!(context
+            .create_normal_table(test::NORMAL_TABLE_NAME, &test::normal_table_schema())
             .await
-            .is_err())
+            .is_err());
     }
 
     #[tokio::test]
-    async fn test_parse_and_create_model_table() {
+    async fn test_create_model_table() {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::MODEL_TABLE_SQL)
+        context
+            .create_model_table(&test::model_table_metadata())
             .await
             .unwrap();
 
@@ -561,17 +563,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_parse_and_create_existing_model_table() {
+    async fn test_create_existing_model_table() {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        assert!(parse_and_create_table(&context, test::MODEL_TABLE_SQL)
+        assert!(context
+            .create_model_table(&test::model_table_metadata())
             .await
             .is_ok());
 
-        assert!(parse_and_create_table(&context, test::MODEL_TABLE_SQL)
+        assert!(context
+            .create_model_table(&test::model_table_metadata())
             .await
-            .is_err())
+            .is_err());
     }
 
     #[tokio::test]
@@ -582,7 +586,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::NORMAL_TABLE_SQL)
+        context
+            .create_normal_table(test::NORMAL_TABLE_NAME, &test::normal_table_schema())
             .await
             .unwrap();
 
@@ -601,7 +606,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::MODEL_TABLE_SQL)
+        context
+            .create_model_table(&test::model_table_metadata())
             .await
             .unwrap();
 
@@ -617,7 +623,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::NORMAL_TABLE_SQL)
+        context
+            .create_normal_table(test::NORMAL_TABLE_NAME, &test::normal_table_schema())
             .await
             .unwrap();
 
@@ -652,7 +659,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::MODEL_TABLE_SQL)
+        context
+            .create_model_table(&test::model_table_metadata())
             .await
             .unwrap();
 
@@ -695,7 +703,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::NORMAL_TABLE_SQL)
+        context
+            .create_normal_table(test::NORMAL_TABLE_NAME, &test::normal_table_schema())
             .await
             .unwrap();
 
@@ -741,7 +750,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::MODEL_TABLE_SQL)
+        context
+            .create_model_table(&test::model_table_metadata())
             .await
             .unwrap();
 
@@ -796,7 +806,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::MODEL_TABLE_SQL)
+        context
+            .create_model_table(&test::model_table_metadata())
             .await
             .unwrap();
 
@@ -814,7 +825,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::NORMAL_TABLE_SQL)
+        context
+            .create_normal_table(test::NORMAL_TABLE_NAME, &test::normal_table_schema())
             .await
             .unwrap();
 
@@ -841,7 +853,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::MODEL_TABLE_SQL)
+        context
+            .create_model_table(&test::model_table_metadata())
             .await
             .unwrap();
 
@@ -867,7 +880,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        parse_and_create_table(&context, test::MODEL_TABLE_SQL)
+        context
+            .create_model_table(&test::model_table_metadata())
             .await
             .unwrap();
 
@@ -877,18 +891,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(schema, test::model_table_metadata().schema)
-    }
-
-    async fn parse_and_create_table(context: &Context, sql: &str) -> Result<()> {
-        match parser::tokenize_and_parse_sql_statement(sql)? {
-            ModelarDbStatement::CreateNormalTable { name, schema } => {
-                context.create_normal_table(name, schema).await
-            }
-            ModelarDbStatement::CreateModelTable(model_table_metadata) => {
-                context.create_model_table(model_table_metadata).await
-            }
-            _ => unreachable!("Expected CreateNormalTable or CreateModelTable."),
-        }
     }
 
     #[tokio::test]

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -458,12 +458,55 @@ impl Context {
 mod tests {
     use super::*;
 
-    use modelardb_storage::parser;
+    use datafusion::arrow::compute::concat_batches;
     use modelardb_storage::parser::ModelarDbStatement;
     use modelardb_storage::test;
+    use modelardb_storage::{
+        model_table_metadata_record_batch, normal_table_metadata_record_batch, parser,
+    };
     use tempfile::TempDir;
 
     use crate::data_folders::DataFolder;
+
+    #[tokio::test]
+    async fn test_create_tables_from_bytes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let context = create_context(&temp_dir).await;
+
+        let normal_table_record_batch = normal_table_metadata_record_batch(
+            test::NORMAL_TABLE_NAME,
+            &test::normal_table_schema(),
+        )
+        .unwrap();
+
+        let metadata = test::model_table_metadata();
+        let model_table_record_batch = model_table_metadata_record_batch(&metadata).unwrap();
+
+        let table_record_batch = concat_batches(
+            &CREATE_TABLE_SCHEMA.0,
+            &vec![normal_table_record_batch, model_table_record_batch],
+        )
+        .unwrap();
+
+        let table_record_batch_bytes =
+            modelardb_storage::try_convert_record_batch_to_bytes(&table_record_batch).unwrap();
+
+        context
+            .create_tables_from_bytes(table_record_batch_bytes)
+            .await
+            .unwrap();
+
+        // Both a normal table and a model table should be created.
+        assert!(context
+            .check_if_table_exists(test::NORMAL_TABLE_NAME)
+            .await
+            .is_err());
+
+        assert!(context
+            .check_if_table_exists(test::MODEL_TABLE_NAME)
+            .await
+            .is_err());
+    }
 
     #[tokio::test]
     async fn test_parse_and_create_normal_table() {

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -23,7 +23,7 @@ use datafusion::catalog::SchemaProvider;
 use datafusion::prelude::SessionContext;
 use modelardb_storage::metadata::model_table_metadata::ModelTableMetadata;
 use modelardb_storage::metadata::table_metadata_manager::TableMetadataManager;
-use modelardb_types::schemas::CREATE_TABLE_SCHEMA;
+use modelardb_types::schemas::TABLE_METADATA_SCHEMA;
 use tokio::runtime::Runtime;
 use tokio::sync::RwLock;
 use tracing::info;
@@ -77,7 +77,7 @@ impl Context {
     pub(crate) async fn create_tables_from_bytes(&self, bytes: Vec<u8>) -> Result<()> {
         let record_batch = modelardb_storage::try_convert_bytes_to_record_batch(
             bytes,
-            &CREATE_TABLE_SCHEMA.0.clone(),
+            &TABLE_METADATA_SCHEMA.0.clone(),
         )?;
 
         let (normal_table_metadata, model_table_metadata) =
@@ -94,8 +94,8 @@ impl Context {
         Ok(())
     }
 
-    /// Create a normal table based on `name` and `schema` created from `sql`. Returns
-    /// [`ModelarDbServerError`] if the table could not be created.
+    /// Create a normal table with `name` and `schema`. Returns [`ModelarDbServerError`] if the
+    /// table could not be created.
     pub(crate) async fn create_normal_table(&self, name: String, schema: Schema) -> Result<()> {
         self.check_if_table_exists(&name).await?;
         self.register_and_save_normal_table(&name, schema).await?;
@@ -129,8 +129,8 @@ impl Context {
         Ok(())
     }
 
-    /// Create a model table based on `model_table_metadata` created from `sql`. Returns
-    /// [`ModelarDbServerError`] if the model table could not be created.
+    /// Create a model table with `model_table_metadata`. Returns [`ModelarDbServerError`] if the
+    /// model table could not be created.
     pub(crate) async fn create_model_table(
         &self,
         model_table_metadata: Arc<ModelTableMetadata>,

--- a/crates/modelardb_server/src/error.rs
+++ b/crates/modelardb_server/src/error.rs
@@ -27,7 +27,6 @@ use datafusion::error::DataFusionError;
 use deltalake::errors::DeltaTableError;
 use modelardb_common::error::ModelarDbCommonError;
 use modelardb_storage::error::ModelarDbStorageError;
-use modelardb_types::error::ModelarDbTypesError;
 use object_store::Error as ObjectStoreError;
 use tonic::transport::Error as TonicTransportError;
 use tonic::Status as TonicStatusError;
@@ -60,8 +59,6 @@ pub enum ModelarDbServerError {
     ModelarDbCommon(ModelarDbCommonError),
     /// Error returned by modelardb_storage.
     ModelarDbStorage(ModelarDbStorageError),
-    /// Error returned by modelardb_types.
-    ModelarDbTypes(ModelarDbTypesError),
     /// Status returned by Tonic.
     TonicStatus(TonicStatusError),
     /// Error returned by Tonic.
@@ -82,7 +79,6 @@ impl Display for ModelarDbServerError {
             Self::ObjectStore(reason) => write!(f, "Object Store Error: {reason}"),
             Self::ModelarDbCommon(reason) => write!(f, "ModelarDB Common Error: {reason}"),
             Self::ModelarDbStorage(reason) => write!(f, "ModelarDB Storage Error: {reason}"),
-            Self::ModelarDbTypes(reason) => write!(f, "ModelarDB Types Error: {reason}"),
             Self::TonicStatus(reason) => write!(f, "Tonic Status Error: {reason}"),
             Self::TonicTransport(reason) => write!(f, "Tonic Transport Error: {reason}"),
         }
@@ -104,7 +100,6 @@ impl Error for ModelarDbServerError {
             Self::ObjectStore(reason) => Some(reason),
             Self::ModelarDbCommon(reason) => Some(reason),
             Self::ModelarDbStorage(reason) => Some(reason),
-            Self::ModelarDbTypes(reason) => Some(reason),
             Self::TonicStatus(reason) => Some(reason),
             Self::TonicTransport(reason) => Some(reason),
         }
@@ -156,12 +151,6 @@ impl From<ModelarDbCommonError> for ModelarDbServerError {
 impl From<ModelarDbStorageError> for ModelarDbServerError {
     fn from(error: ModelarDbStorageError) -> Self {
         Self::ModelarDbStorage(error)
-    }
-}
-
-impl From<ModelarDbTypesError> for ModelarDbServerError {
-    fn from(error: ModelarDbTypesError) -> Self {
-        Self::ModelarDbTypes(error)
     }
 }
 

--- a/crates/modelardb_server/src/error.rs
+++ b/crates/modelardb_server/src/error.rs
@@ -27,6 +27,7 @@ use datafusion::error::DataFusionError;
 use deltalake::errors::DeltaTableError;
 use modelardb_common::error::ModelarDbCommonError;
 use modelardb_storage::error::ModelarDbStorageError;
+use modelardb_types::error::ModelarDbTypesError;
 use object_store::Error as ObjectStoreError;
 use tonic::transport::Error as TonicTransportError;
 use tonic::Status as TonicStatusError;
@@ -59,6 +60,8 @@ pub enum ModelarDbServerError {
     ModelarDbCommon(ModelarDbCommonError),
     /// Error returned by modelardb_storage.
     ModelarDbStorage(ModelarDbStorageError),
+    /// Error returned by modelardb_types.
+    ModelarDbTypes(ModelarDbTypesError),
     /// Status returned by Tonic.
     TonicStatus(TonicStatusError),
     /// Error returned by Tonic.
@@ -79,6 +82,7 @@ impl Display for ModelarDbServerError {
             Self::ObjectStore(reason) => write!(f, "Object Store Error: {reason}"),
             Self::ModelarDbCommon(reason) => write!(f, "ModelarDB Common Error: {reason}"),
             Self::ModelarDbStorage(reason) => write!(f, "ModelarDB Storage Error: {reason}"),
+            Self::ModelarDbTypes(reason) => write!(f, "ModelarDB Types Error: {reason}"),
             Self::TonicStatus(reason) => write!(f, "Tonic Status Error: {reason}"),
             Self::TonicTransport(reason) => write!(f, "Tonic Transport Error: {reason}"),
         }
@@ -100,6 +104,7 @@ impl Error for ModelarDbServerError {
             Self::ObjectStore(reason) => Some(reason),
             Self::ModelarDbCommon(reason) => Some(reason),
             Self::ModelarDbStorage(reason) => Some(reason),
+            Self::ModelarDbTypes(reason) => Some(reason),
             Self::TonicStatus(reason) => Some(reason),
             Self::TonicTransport(reason) => Some(reason),
         }
@@ -151,6 +156,12 @@ impl From<ModelarDbCommonError> for ModelarDbServerError {
 impl From<ModelarDbStorageError> for ModelarDbServerError {
     fn from(error: ModelarDbStorageError) -> Self {
         Self::ModelarDbStorage(error)
+    }
+}
+
+impl From<ModelarDbTypesError> for ModelarDbServerError {
+    fn from(error: ModelarDbTypesError) -> Self {
+        Self::ModelarDbTypes(error)
     }
 }
 

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -22,7 +22,6 @@ use std::{env, str};
 use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::{Action, Result as FlightResult};
 use modelardb_common::arguments;
-use modelardb_storage::parser::{self, ModelarDbStatement};
 use modelardb_types::types::ServerMode;
 use tokio::sync::RwLock;
 use tonic::metadata::MetadataMap;
@@ -97,36 +96,7 @@ impl Manager {
         };
 
         let message = do_action_and_extract_result(&self.flight_client, action).await?;
-
-        // Extract the SQL for the tables that need to be created from the response.
-        let create_table_sql_commands = str::from_utf8(&message.body)
-            .map_err(|error| ModelarDbServerError::InvalidArgument(error.to_string()))?
-            .split(';')
-            .filter(|sql| !sql.is_empty());
-
-        // For each table to create, register and save the table in the metadata Delta Lake.
-        for create_table_sql in create_table_sql_commands {
-            match parser::tokenize_and_parse_sql_statement(create_table_sql)? {
-                ModelarDbStatement::CreateNormalTable { name, schema } => {
-                    context
-                        .create_normal_table(name, schema, create_table_sql)
-                        .await?;
-                }
-                ModelarDbStatement::CreateModelTable(model_table_metadata) => {
-                    context
-                        .create_model_table(model_table_metadata, create_table_sql)
-                        .await?;
-                }
-                ModelarDbStatement::Statement(_)
-                | ModelarDbStatement::IncludeSelect(..)
-                | ModelarDbStatement::DropTable(_)
-                | ModelarDbStatement::TruncateTable(_) => {
-                    return Err(ModelarDbServerError::InvalidState(
-                        "Expected CreateNormalTable or CreateModelTable.".to_owned(),
-                    ))
-                }
-            }
-        }
+        context.create_tables_from_bytes(message.body.into()).await?;
 
         Ok(())
     }

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -96,7 +96,9 @@ impl Manager {
         };
 
         let message = do_action_and_extract_result(&self.flight_client, action).await?;
-        context.create_tables_from_bytes(message.body.into()).await?;
+        context
+            .create_tables_from_bytes(message.body.into())
+            .await?;
 
         Ok(())
     }

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -642,7 +642,10 @@ impl FlightService for FlightServiceHandler {
             while let Some(maybe_record_batch) = reader.next() {
                 let record_batch = maybe_record_batch.map_err(error_to_status_internal)?;
 
-                println!("Batch: {:?}", record_batch);
+                self.context
+                    .create_tables_from_record_batch(record_batch)
+                    .await
+                    .map_err(error_to_status_invalid_argument)?;
             }
 
             // Confirm the tables were created.

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -622,6 +622,8 @@ impl FlightService for FlightServiceHandler {
         info!("Received request to perform action '{}'.", action.r#type);
 
         if action.r#type == "CreateTables" {
+            self.validate_request(request.metadata()).await?;
+
             // Extract the record batches from the action body.
             let action_bytes = action.body.clone();
             let mut reader = StreamReader::try_new(action_bytes.reader(), None)

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -445,7 +445,7 @@ impl FlightService for FlightServiceHandler {
                 self.validate_request(request.metadata()).await?;
 
                 self.context
-                    .create_normal_table(name, schema)
+                    .create_normal_table(&name, &schema)
                     .await
                     .map_err(error_to_status_invalid_argument)?;
 
@@ -455,7 +455,7 @@ impl FlightService for FlightServiceHandler {
                 self.validate_request(request.metadata()).await?;
 
                 self.context
-                    .create_model_table(model_table_metadata)
+                    .create_model_table(&model_table_metadata)
                     .await
                     .map_err(error_to_status_invalid_argument)?;
 

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -445,7 +445,7 @@ impl FlightService for FlightServiceHandler {
                 self.validate_request(request.metadata()).await?;
 
                 self.context
-                    .create_normal_table(name, schema, &sql)
+                    .create_normal_table(name, schema)
                     .await
                     .map_err(error_to_status_invalid_argument)?;
 
@@ -455,7 +455,7 @@ impl FlightService for FlightServiceHandler {
                 self.validate_request(request.metadata()).await?;
 
                 self.context
-                    .create_model_table(model_table_metadata, &sql)
+                    .create_model_table(model_table_metadata)
                     .await
                     .map_err(error_to_status_invalid_argument)?;
 

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -18,7 +18,6 @@
 //! using [`FlightServiceHandler`] can be started with [`start_apache_arrow_flight_server()`].
 
 use std::collections::HashMap;
-use std::error::Error;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::result::Result as StdResult;
@@ -49,6 +48,7 @@ use datafusion::physical_plan::{EmptyRecordBatchStream, SendableRecordBatchStrea
 use deltalake::arrow::datatypes::Schema;
 use futures::stream::{self, BoxStream, SelectAll};
 use futures::StreamExt;
+use modelardb_common::remote::{error_to_status_internal, error_to_status_invalid_argument};
 use modelardb_common::{arguments, remote};
 use modelardb_storage::metadata::model_table_metadata::ModelTableMetadata;
 use modelardb_storage::parser::{self, ModelarDbStatement};
@@ -254,18 +254,6 @@ fn send_record_batch(
 /// command has been successfully executed but did not produce any rows to return.
 fn empty_record_batch_stream() -> SendableRecordBatchStream {
     Box::pin(EmptyRecordBatchStream::new(Arc::new(Schema::empty())))
-}
-
-/// Convert an `error` to a [`Status`] with [`tonic::Code::InvalidArgument`] as the code and `error`
-/// converted to a [`String`] as the message.
-fn error_to_status_invalid_argument(error: impl Error) -> Status {
-    Status::invalid_argument(error.to_string())
-}
-
-/// Convert an `error` to a [`Status`] with [`tonic::Code::Internal`] as the code and `error`
-/// converted to a [`String`] as the message.
-fn error_to_status_internal(error: impl Error) -> Status {
-    Status::internal(error.to_string())
 }
 
 /// Handler for processing Apache Arrow Flight requests.

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -632,6 +632,8 @@ impl FlightService for FlightServiceHandler {
         info!("Received request to perform action '{}'.", action.r#type);
 
         if action.r#type == "CreateTables" {
+            // Extract the record batch from the action body.
+
             // Confirm the tables were created.
             Ok(Response::new(Box::pin(stream::empty())))
         } else if action.r#type == "FlushMemory" {

--- a/crates/modelardb_server/src/storage/compressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/compressed_data_manager.rs
@@ -617,7 +617,7 @@ mod tests {
         let model_table_metadata = test::model_table_metadata();
         local_data_folder
             .table_metadata_manager
-            .save_model_table_metadata(&model_table_metadata, test::MODEL_TABLE_SQL)
+            .save_model_table_metadata(&model_table_metadata)
             .await
             .unwrap();
 

--- a/crates/modelardb_server/src/storage/data_transfer.rs
+++ b/crates/modelardb_server/src/storage/data_transfer.rs
@@ -515,7 +515,7 @@ mod tests {
 
         local_data_folder
             .table_metadata_manager
-            .save_normal_table_metadata(test::NORMAL_TABLE_NAME, test::NORMAL_TABLE_SQL)
+            .save_normal_table_metadata(test::NORMAL_TABLE_NAME)
             .await
             .unwrap();
 
@@ -529,7 +529,7 @@ mod tests {
 
         local_data_folder
             .table_metadata_manager
-            .save_model_table_metadata(&model_table_metadata, test::MODEL_TABLE_SQL)
+            .save_model_table_metadata(&model_table_metadata)
             .await
             .unwrap();
 

--- a/crates/modelardb_server/src/storage/uncompressed_data_buffer.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_buffer.rs
@@ -157,21 +157,18 @@ impl UncompressedInMemoryDataBuffer {
 
         // lexsort() is not used as it is unclear in what order it sorts multiple arrays, instead a
         // combination of sort_to_indices() and take(), like how lexsort() is implemented, is used.
-        // unwrap() is safe as timestamps has a supported type and sorted_indices are within bounds.
-        let sorted_indices = compute::sort_to_indices(&timestamps, None, None).unwrap();
+        let sorted_indices = compute::sort_to_indices(&timestamps, None, None)?;
 
         let mut columns = Vec::with_capacity(1 + self.values.len());
-        columns.push(compute::take(&timestamps, &sorted_indices, None).unwrap());
+        columns.push(compute::take(&timestamps, &sorted_indices, None)?);
         for value in &mut self.values {
-            columns.push(compute::take(&value.finish(), &sorted_indices, None).unwrap());
+            columns.push(compute::take(&value.finish(), &sorted_indices, None)?);
         }
 
-        // unwrap() is safe as uncompressed_schema only contains timestamps and values.
         Ok(RecordBatch::try_new(
             self.model_table_metadata.uncompressed_schema.clone(),
             columns,
-        )
-        .unwrap())
+        )?)
     }
 
     /// Return the tag hash that identifies the time series the buffer stores data points from.

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -807,9 +807,7 @@ mod tests {
         let _ = if let ModelarDbStatement::CreateModelTable(model_table_metadata) =
             modelardb_statement
         {
-            context
-                .create_model_table(model_table_metadata, test::MODEL_TABLE_SQL)
-                .await
+            context.create_model_table(model_table_metadata).await
         } else {
             panic!("Expected CreateModelTable.");
         };
@@ -1455,7 +1453,7 @@ mod tests {
 
         local_data_folder
             .table_metadata_manager
-            .save_model_table_metadata(&model_table_metadata, test::MODEL_TABLE_SQL)
+            .save_model_table_metadata(&model_table_metadata)
             .await
             .unwrap();
 

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -807,7 +807,7 @@ mod tests {
         let _ = if let ModelarDbStatement::CreateModelTable(model_table_metadata) =
             modelardb_statement
         {
-            context.create_model_table(model_table_metadata).await
+            context.create_model_table(&model_table_metadata).await
         } else {
             panic!("Expected CreateModelTable.");
         };

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -35,6 +35,7 @@ use datafusion::arrow::array::{
     Array, Float64Array, ListArray, StringArray, UInt32Array, UInt64Array,
 };
 use datafusion::arrow::compute;
+use datafusion::arrow::compute::concat_batches;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit::Microsecond};
 use datafusion::arrow::ipc::convert;
 use datafusion::arrow::ipc::reader::StreamReader;
@@ -43,6 +44,8 @@ use datafusion::arrow::record_batch::RecordBatch;
 use futures::{stream, StreamExt};
 use modelardb_common::test;
 use modelardb_common::test::data_generation;
+use modelardb_storage::{model_table_metadata_record_batch, normal_table_metadata_record_batch};
+use modelardb_types::schemas::CREATE_TABLE_SCHEMA;
 use modelardb_types::types::ErrorBound;
 use sysinfo::{Pid, ProcessesToUpdate, System};
 use tempfile::TempDir;
@@ -1311,4 +1314,46 @@ fn test_can_get_node_type() {
     let response_bytes = test_context.retrieve_action_bytes("NodeType");
 
     assert_eq!(str::from_utf8(&response_bytes).unwrap(), "server");
+}
+
+#[test]
+fn test_can_create_tables() {
+    let mut test_context = TestContext::new();
+
+    let normal_table_record_batch = normal_table_metadata_record_batch(
+        modelardb_storage::test::NORMAL_TABLE_NAME,
+        &modelardb_storage::test::normal_table_schema(),
+    )
+    .unwrap();
+
+    let metadata = modelardb_storage::test::model_table_metadata();
+    let model_table_record_batch = model_table_metadata_record_batch(&metadata).unwrap();
+
+    let table_record_batch = concat_batches(
+        &CREATE_TABLE_SCHEMA.0,
+        &vec![normal_table_record_batch, model_table_record_batch],
+    )
+    .unwrap();
+
+    let table_record_batch_bytes =
+        modelardb_storage::try_convert_record_batch_to_bytes(&table_record_batch).unwrap();
+
+    let action = Action {
+        r#type: "CreateTables".to_owned(),
+        body: table_record_batch_bytes.into(),
+    };
+
+    test_context
+        .runtime
+        .block_on(async { test_context.client.do_action(Request::new(action)).await })
+        .unwrap();
+
+    let retrieved_table_names = test_context.retrieve_all_table_names().unwrap();
+    assert_eq!(
+        retrieved_table_names,
+        vec![
+            modelardb_storage::test::NORMAL_TABLE_NAME.to_owned(),
+            modelardb_storage::test::MODEL_TABLE_NAME.to_owned(),
+        ]
+    );
 }

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -35,7 +35,6 @@ use datafusion::arrow::array::{
     Array, Float64Array, ListArray, StringArray, UInt32Array, UInt64Array,
 };
 use datafusion::arrow::compute;
-use datafusion::arrow::compute::concat_batches;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit::Microsecond};
 use datafusion::arrow::ipc::convert;
 use datafusion::arrow::ipc::reader::StreamReader;
@@ -44,8 +43,6 @@ use datafusion::arrow::record_batch::RecordBatch;
 use futures::{stream, StreamExt};
 use modelardb_common::test;
 use modelardb_common::test::data_generation;
-use modelardb_storage::{model_table_metadata_record_batch, normal_table_metadata_record_batch};
-use modelardb_types::schemas::CREATE_TABLE_SCHEMA;
 use modelardb_types::types::ErrorBound;
 use sysinfo::{Pid, ProcessesToUpdate, System};
 use tempfile::TempDir;
@@ -1320,21 +1317,7 @@ fn test_can_get_node_type() {
 fn test_can_create_tables() {
     let mut test_context = TestContext::new();
 
-    let normal_table_record_batch = normal_table_metadata_record_batch(
-        modelardb_storage::test::NORMAL_TABLE_NAME,
-        &modelardb_storage::test::normal_table_schema(),
-    )
-    .unwrap();
-
-    let metadata = modelardb_storage::test::model_table_metadata();
-    let model_table_record_batch = model_table_metadata_record_batch(&metadata).unwrap();
-
-    let table_record_batch = concat_batches(
-        &CREATE_TABLE_SCHEMA.0,
-        &vec![normal_table_record_batch, model_table_record_batch],
-    )
-    .unwrap();
-
+    let table_record_batch = modelardb_storage::test::table_metadata_record_batch();
     let table_record_batch_bytes =
         modelardb_storage::try_convert_record_batch_to_bytes(&table_record_batch).unwrap();
 

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -768,6 +768,7 @@ fn test_can_list_actions() {
         actions,
         vec![
             "CollectMetrics",
+            "CreateTables",
             "FlushMemory",
             "FlushNode",
             "GetConfiguration",

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -1347,7 +1347,6 @@ fn test_cannot_create_tables_with_invalid_record_batch() {
     let mut test_context = TestContext::new();
 
     let invalid_record_batch = modelardb_storage::test::normal_table_record_batch();
-
     let invalid_record_batch_bytes =
         modelardb_storage::try_convert_record_batch_to_bytes(&invalid_record_batch).unwrap();
 

--- a/crates/modelardb_storage/Cargo.toml
+++ b/crates/modelardb_storage/Cargo.toml
@@ -23,6 +23,7 @@ authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 arrow-flight.workspace = true
 arrow.workspace = true
 async-trait.workspace = true
+bytes.workspace = true
 dashmap.workspace = true
 datafusion.workspace = true
 deltalake = { workspace = true, features = ["datafusion", "s3"] }

--- a/crates/modelardb_storage/src/error.rs
+++ b/crates/modelardb_storage/src/error.rs
@@ -25,6 +25,7 @@ use datafusion::error::DataFusionError;
 use datafusion::parquet::errors::ParquetError;
 use deltalake::errors::DeltaTableError;
 use modelardb_common::error::ModelarDbCommonError;
+use modelardb_types::error::ModelarDbTypesError;
 use object_store::path::Error as ObjectStorePathError;
 use object_store::Error as ObjectStoreError;
 use sqlparser::parser::ParserError;
@@ -51,6 +52,8 @@ pub enum ModelarDbStorageError {
     ObjectStorePath(ObjectStorePathError),
     /// Error returned by modelardb_common.
     ModelarDbCommon(ModelarDbCommonError),
+    /// Error returned by modelardb_types.
+    ModelarDbTypes(ModelarDbTypesError),
     /// Error returned by Apache Parquet.
     Parquet(ParquetError),
     /// Error returned by sqlparser.
@@ -68,6 +71,7 @@ impl Display for ModelarDbStorageError {
             Self::ObjectStore(reason) => write!(f, "Object Store Error: {reason}"),
             Self::ObjectStorePath(reason) => write!(f, "Object Store Path Error: {reason}"),
             Self::ModelarDbCommon(reason) => write!(f, "ModelarDB Common Error: {reason}"),
+            Self::ModelarDbTypes(reason) => write!(f, "ModelarDB Types Error: {reason}"),
             Self::Parquet(reason) => write!(f, "Parquet Error: {reason}"),
             Self::Parser(reason) => write!(f, "Parser Error: {reason}"),
         }
@@ -86,6 +90,7 @@ impl Error for ModelarDbStorageError {
             Self::ObjectStore(reason) => Some(reason),
             Self::ObjectStorePath(reason) => Some(reason),
             Self::ModelarDbCommon(reason) => Some(reason),
+            Self::ModelarDbTypes(reason) => Some(reason),
             Self::Parquet(reason) => Some(reason),
             Self::Parser(reason) => Some(reason),
         }
@@ -131,6 +136,12 @@ impl From<ObjectStorePathError> for ModelarDbStorageError {
 impl From<ModelarDbCommonError> for ModelarDbStorageError {
     fn from(error: ModelarDbCommonError) -> Self {
         Self::ModelarDbCommon(error)
+    }
+}
+
+impl From<ModelarDbTypesError> for ModelarDbStorageError {
+    fn from(error: ModelarDbTypesError) -> Self {
+        Self::ModelarDbTypes(error)
     }
 }
 

--- a/crates/modelardb_storage/src/lib.rs
+++ b/crates/modelardb_storage/src/lib.rs
@@ -732,6 +732,20 @@ mod tests {
 
     // Tests for try_convert_record_batch_to_bytes() and try_convert_bytes_to_record_batch().
     #[test]
+    fn test_convert_record_batch_to_bytes_and_bytes_to_record_batch() {
+        let record_batch = test::normal_table_record_batch();
+
+        // Serialize the record batch to bytes.
+        let bytes = try_convert_record_batch_to_bytes(&record_batch).unwrap();
+
+        // Deserialize the bytes to the record batch.
+        let bytes_record_batch =
+            try_convert_bytes_to_record_batch(bytes, &record_batch.schema()).unwrap();
+
+        assert_eq!(record_batch, bytes_record_batch);
+    }
+
+    #[test]
     fn test_convert_invalid_bytes_to_record_batch() {
         let result = try_convert_bytes_to_record_batch(
             vec![1, 2, 4, 8],

--- a/crates/modelardb_storage/src/lib.rs
+++ b/crates/modelardb_storage/src/lib.rs
@@ -829,20 +829,7 @@ mod tests {
     // Tests for table_metadata_from_record_batch().
     #[test]
     fn test_table_metadata_from_record_batch() {
-        let normal_table_record_batch = normal_table_metadata_record_batch(
-            test::NORMAL_TABLE_NAME,
-            &test::normal_table_schema(),
-        )
-        .unwrap();
-
-        let metadata = test::model_table_metadata();
-        let model_table_record_batch = model_table_metadata_record_batch(&metadata).unwrap();
-
-        let table_record_batch = concat_batches(
-            &CREATE_TABLE_SCHEMA.0,
-            &vec![normal_table_record_batch, model_table_record_batch],
-        )
-        .unwrap();
+        let table_record_batch = test::table_metadata_record_batch();
 
         let (normal_table_metadata, model_table_metadata) =
             table_metadata_from_record_batch(&table_record_batch).unwrap();
@@ -851,8 +838,9 @@ mod tests {
         assert_eq!(normal_table_metadata[0].0, test::NORMAL_TABLE_NAME);
         assert_eq!(normal_table_metadata[0].1, test::normal_table_schema());
 
+        let metadata = test::model_table_metadata();
         assert_eq!(model_table_metadata.len(), 1);
-        assert_eq!(model_table_metadata[0].name, test::MODEL_TABLE_NAME);
+        assert_eq!(model_table_metadata[0].name, metadata.name);
         assert_eq!(model_table_metadata[0].query_schema, metadata.query_schema);
     }
 

--- a/crates/modelardb_storage/src/lib.rs
+++ b/crates/modelardb_storage/src/lib.rs
@@ -598,4 +598,29 @@ mod tests {
         let bytes_schema = try_convert_bytes_to_schema(bytes).unwrap();
         assert_eq!(*schema, bytes_schema);
     }
+
+    // Test for normal_table_metadata_record_batch().
+    #[test]
+    fn test_normal_table_metadata_record_batch() {
+        let record_batch = normal_table_metadata_record_batch(
+            test::NORMAL_TABLE_NAME,
+            &test::normal_table_schema(),
+        )
+        .unwrap();
+
+        assert_eq!(record_batch.num_rows(), 1);
+
+        assert_eq!(**record_batch.column(0), StringArray::from(vec!["normal"]));
+        assert_eq!(
+            **record_batch.column(1),
+            StringArray::from(vec![test::NORMAL_TABLE_NAME])
+        );
+
+        let expected_schema_bytes =
+            try_convert_schema_to_bytes(&test::normal_table_schema()).unwrap();
+        assert_eq!(
+            **record_batch.column(2),
+            BinaryArray::from_vec(vec![&expected_schema_bytes])
+        );
+    }
 }

--- a/crates/modelardb_storage/src/lib.rs
+++ b/crates/modelardb_storage/src/lib.rs
@@ -56,7 +56,7 @@ use datafusion::sql::parser::Statement as DFStatement;
 use deltalake::DeltaTable;
 use futures::StreamExt;
 use modelardb_types::schemas::{
-    CREATE_TABLE_SCHEMA, DISK_COMPRESSED_SCHEMA, QUERY_COMPRESSED_SCHEMA,
+    DISK_COMPRESSED_SCHEMA, QUERY_COMPRESSED_SCHEMA, TABLE_METADATA_SCHEMA,
 };
 use modelardb_types::types::ErrorBound;
 use object_store::path::Path;
@@ -378,7 +378,7 @@ pub fn normal_table_metadata_record_batch(
     let generated_columns_field = Arc::new(Field::new("item", DataType::Utf8, true));
 
     RecordBatch::try_new(
-        CREATE_TABLE_SCHEMA.0.clone(),
+        TABLE_METADATA_SCHEMA.0.clone(),
         vec![
             Arc::new(StringArray::from(vec!["normal"])),
             Arc::new(StringArray::from(vec![table_name])),
@@ -416,7 +416,7 @@ pub fn model_table_metadata_record_batch(
         generated_columns_to_list_array(model_table_metadata.generated_columns.clone());
 
     RecordBatch::try_new(
-        CREATE_TABLE_SCHEMA.0.clone(),
+        TABLE_METADATA_SCHEMA.0.clone(),
         vec![
             Arc::new(StringArray::from(vec!["model"])),
             Arc::new(StringArray::from(vec![model_table_metadata.name.clone()])),
@@ -477,7 +477,7 @@ fn generated_columns_to_list_array(generated_columns: Vec<Option<GeneratedColumn
 pub fn table_metadata_from_record_batch(
     record_batch: &RecordBatch,
 ) -> Result<(Vec<(String, Schema)>, Vec<ModelTableMetadata>)> {
-    if record_batch.schema() != CREATE_TABLE_SCHEMA.0 {
+    if record_batch.schema() != TABLE_METADATA_SCHEMA.0 {
         return Err(ModelarDbStorageError::InvalidArgument(
             "Record batch does not contain the expected table data.".to_owned(),
         ));
@@ -867,7 +867,7 @@ mod tests {
         columns[0] = Arc::new(StringArray::from(vec!["invalid"]));
 
         let invalid_table_record_batch =
-            RecordBatch::try_new(CREATE_TABLE_SCHEMA.0.clone(), columns).unwrap();
+            RecordBatch::try_new(TABLE_METADATA_SCHEMA.0.clone(), columns).unwrap();
 
         let result = table_metadata_from_record_batch(&invalid_table_record_batch);
 

--- a/crates/modelardb_storage/src/lib.rs
+++ b/crates/modelardb_storage/src/lib.rs
@@ -400,8 +400,7 @@ pub fn model_table_metadata_record_batch(
     // lossless error bounds are added for each generated column.
     let mut error_bounds_all = Vec::with_capacity(model_table_metadata.query_schema.fields().len());
 
-    // unwrap() is safe as zero is always a legal absolute error bound.
-    let lossless = ErrorBound::try_new_absolute(0.0).unwrap();
+    let lossless = ErrorBound::try_new_absolute(0.0)?;
 
     for field in model_table_metadata.query_schema.fields() {
         if let Ok(field_index) = model_table_metadata.schema.index_of(field.name()) {

--- a/crates/modelardb_storage/src/lib.rs
+++ b/crates/modelardb_storage/src/lib.rs
@@ -428,7 +428,7 @@ pub fn model_table_metadata_record_batch(
     .map_err(|error| error.into())
 }
 
-/// Convert a list of [`ErrorBounds`](ErrorBound) to a [`ListArray`] that can be sent to ModelarDB.
+/// Convert a list of [`ErrorBounds`](ErrorBound) to a [`ListArray`].
 fn error_bounds_to_list_array(error_bounds: Vec<ErrorBound>) -> ListArray {
     let mut error_bounds_builder = ListBuilder::new(Float32Builder::new());
 
@@ -448,8 +448,7 @@ fn error_bounds_to_list_array(error_bounds: Vec<ErrorBound>) -> ListArray {
     error_bounds_builder.finish()
 }
 
-/// Convert a list of optional [`GeneratedColumns`](GeneratedColumn) to a [`ListArray`] that can be
-/// sent to ModelarDB.
+/// Convert a list of optional [`GeneratedColumns`](GeneratedColumn) to a [`ListArray`].
 fn generated_columns_to_list_array(generated_columns: Vec<Option<GeneratedColumn>>) -> ListArray {
     let mut generated_columns_builder = ListBuilder::new(StringBuilder::new());
 
@@ -479,7 +478,7 @@ pub fn table_metadata_from_record_batch(
 ) -> Result<(Vec<(String, Schema)>, Vec<ModelTableMetadata>)> {
     if record_batch.schema() != TABLE_METADATA_SCHEMA.0 {
         return Err(ModelarDbStorageError::InvalidArgument(
-            "Record batch does not contain the expected table data.".to_owned(),
+            "Record batch does not contain the expected table metadata.".to_owned(),
         ));
     }
 
@@ -851,7 +850,7 @@ mod tests {
 
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Invalid Argument Error: Record batch does not contain the expected table data."
+            "Invalid Argument Error: Record batch does not contain the expected table metadata."
         );
     }
 

--- a/crates/modelardb_storage/src/metadata/model_table_metadata.rs
+++ b/crates/modelardb_storage/src/metadata/model_table_metadata.rs
@@ -319,7 +319,7 @@ mod test {
         ModelTableMetadata::try_new(
             test::MODEL_TABLE_NAME.to_owned(),
             Arc::new(query_schema),
-            vec![ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap()],
+            vec![ErrorBound::try_new_absolute(ERROR_BOUND_ZERO)?],
             vec![None],
         )
     }

--- a/crates/modelardb_storage/src/metadata/model_table_metadata.rs
+++ b/crates/modelardb_storage/src/metadata/model_table_metadata.rs
@@ -224,7 +224,7 @@ impl GeneratedColumn {
     /// is not valid or refers to columns that are not in the [`DFSchema`],
     /// a [`ModelarDbStorageError`] is returned.
     pub fn try_from_sql_expr(sql_expr: &str, df_schema: &DFSchema) -> Result<Self> {
-        let expr = tokenize_and_parse_sql_expression(&sql_expr, &df_schema)?;
+        let expr = tokenize_and_parse_sql_expression(sql_expr, df_schema)?;
 
         let source_columns: StdResult<Vec<usize>, DataFusionError> = expr
             .column_refs()

--- a/crates/modelardb_storage/src/metadata/model_table_metadata.rs
+++ b/crates/modelardb_storage/src/metadata/model_table_metadata.rs
@@ -319,7 +319,7 @@ mod test {
         ModelTableMetadata::try_new(
             test::MODEL_TABLE_NAME.to_owned(),
             Arc::new(query_schema),
-            vec![ErrorBound::try_new_absolute(ERROR_BOUND_ZERO)?],
+            vec![ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap()],
             vec![None],
         )
     }

--- a/crates/modelardb_storage/src/metadata/table_metadata_manager.rs
+++ b/crates/modelardb_storage/src/metadata/table_metadata_manager.rs
@@ -686,7 +686,7 @@ impl TableMetadataManager {
             // If generated_column_expr is null, it is saved as an empty string in the column values.
             if !generated_column_expr.is_empty() {
                 let generated_column =
-                    GeneratedColumn::try_from_sql_expr(generated_column_expr, &df_schema)?;
+                    GeneratedColumn::try_from_sql_expr(generated_column_expr, df_schema)?;
 
                 generated_columns[generated_column_index as usize] = Some(generated_column);
             }

--- a/crates/modelardb_storage/src/metadata/table_metadata_manager.rs
+++ b/crates/modelardb_storage/src/metadata/table_metadata_manager.rs
@@ -636,7 +636,7 @@ impl TableMetadataManager {
         let batch = sql_and_concat(&self.session_context, &sql).await?;
 
         let mut column_to_error_bound =
-            vec![ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(); query_schema_columns];
+            vec![ErrorBound::try_new_absolute(ERROR_BOUND_ZERO)?; query_schema_columns];
 
         let column_index_array = modelardb_types::array!(batch, 0, Int16Array);
         let error_bound_value_array = modelardb_types::array!(batch, 1, Float32Array);
@@ -647,13 +647,11 @@ impl TableMetadataManager {
             let error_bound_value = error_bound_value_array.value(row_index);
             let error_bound_is_relative = error_bound_is_relative_array.value(row_index);
 
-            // unwrap() is safe as the error bounds are checked before they are stored.
             let error_bound = if error_bound_is_relative {
                 ErrorBound::try_new_relative(error_bound_value)
             } else {
                 ErrorBound::try_new_absolute(error_bound_value)
-            }
-            .unwrap();
+            }?;
 
             column_to_error_bound[error_bound_index as usize] = error_bound;
         }

--- a/crates/modelardb_storage/src/optimizer/model_simple_aggregates.rs
+++ b/crates/modelardb_storage/src/optimizer/model_simple_aggregates.rs
@@ -793,7 +793,7 @@ mod tests {
             .unwrap();
 
         table_metadata_manager
-            .save_model_table_metadata(&model_table_metadata, test::MODEL_TABLE_SQL)
+            .save_model_table_metadata(&model_table_metadata)
             .await
             .unwrap();
 

--- a/crates/modelardb_storage/src/test.rs
+++ b/crates/modelardb_storage/src/test.rs
@@ -18,13 +18,15 @@
 use std::sync::Arc;
 
 use arrow::array::{BinaryArray, Float32Array, RecordBatch, UInt16Array, UInt64Array, UInt8Array};
+use arrow::compute::concat_batches;
 use arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
 use modelardb_common::test::{ERROR_BOUND_FIVE, ERROR_BOUND_ONE, ERROR_BOUND_ZERO};
 use modelardb_types::functions;
-use modelardb_types::schemas::COMPRESSED_SCHEMA;
+use modelardb_types::schemas::{COMPRESSED_SCHEMA, CREATE_TABLE_SCHEMA};
 use modelardb_types::types::{ArrowTimestamp, ArrowValue, ErrorBound, TimestampArray, ValueArray};
 
 use crate::metadata::model_table_metadata::ModelTableMetadata;
+use crate::{model_table_metadata_record_batch, normal_table_metadata_record_batch};
 
 /// SQL to create a normal table with a timestamp column and two floating point columns.
 pub const NORMAL_TABLE_SQL: &str =
@@ -39,6 +41,21 @@ pub const MODEL_TABLE_SQL: &str =
 
 /// Name of the model table used in tests.
 pub const MODEL_TABLE_NAME: &str = "model_table";
+
+/// Return a [`RecordBatch`] containing metadata for a normal table and a model table.
+pub fn table_metadata_record_batch() -> RecordBatch {
+    let normal_table_record_batch =
+        normal_table_metadata_record_batch(NORMAL_TABLE_NAME, &normal_table_schema()).unwrap();
+
+    let metadata = model_table_metadata();
+    let model_table_record_batch = model_table_metadata_record_batch(&metadata).unwrap();
+
+    concat_batches(
+        &CREATE_TABLE_SCHEMA.0,
+        &vec![normal_table_record_batch, model_table_record_batch],
+    )
+    .unwrap()
+}
 
 /// Return a [`Schema`] for a normal table with a timestamp column and two floating point columns.
 pub fn normal_table_schema() -> Schema {

--- a/crates/modelardb_storage/src/test.rs
+++ b/crates/modelardb_storage/src/test.rs
@@ -22,7 +22,7 @@ use arrow::compute::concat_batches;
 use arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
 use modelardb_common::test::{ERROR_BOUND_FIVE, ERROR_BOUND_ONE, ERROR_BOUND_ZERO};
 use modelardb_types::functions;
-use modelardb_types::schemas::{COMPRESSED_SCHEMA, CREATE_TABLE_SCHEMA};
+use modelardb_types::schemas::{COMPRESSED_SCHEMA, TABLE_METADATA_SCHEMA};
 use modelardb_types::types::{ArrowTimestamp, ArrowValue, ErrorBound, TimestampArray, ValueArray};
 
 use crate::metadata::model_table_metadata::ModelTableMetadata;
@@ -51,7 +51,7 @@ pub fn table_metadata_record_batch() -> RecordBatch {
     let model_table_record_batch = model_table_metadata_record_batch(&metadata).unwrap();
 
     concat_batches(
-        &CREATE_TABLE_SCHEMA.0,
+        &TABLE_METADATA_SCHEMA.0,
         &vec![normal_table_record_batch, model_table_record_batch],
     )
     .unwrap()

--- a/crates/modelardb_types/src/schemas.rs
+++ b/crates/modelardb_types/src/schemas.rs
@@ -22,7 +22,7 @@ use arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
 
 use crate::types::{
     ArrowTimestamp, ArrowUnivariateId, ArrowValue, CompressedSchema, ConfigurationSchema,
-    CreateTableSchema, MetricSchema, QueryCompressedSchema, QuerySchema, UncompressedSchema,
+    MetricSchema, QueryCompressedSchema, QuerySchema, TableMetadataSchema, UncompressedSchema,
 };
 
 /// Name of the column used to partition the compressed segments.
@@ -129,9 +129,9 @@ pub static CONFIGURATION_SCHEMA: LazyLock<ConfigurationSchema> = LazyLock::new(|
 });
 
 /// [`RecordBatch`](arrow::record_batch::RecordBatch) [`Schema`] used for creating tables using
-/// table data.
-pub static CREATE_TABLE_SCHEMA: LazyLock<CreateTableSchema> = LazyLock::new(|| {
-    CreateTableSchema(Arc::new(Schema::new(vec![
+/// table metadata.
+pub static TABLE_METADATA_SCHEMA: LazyLock<TableMetadataSchema> = LazyLock::new(|| {
+    TableMetadataSchema(Arc::new(Schema::new(vec![
         Field::new("type", DataType::Utf8, false),
         Field::new("name", DataType::Utf8, false),
         Field::new("schema", DataType::Binary, false),

--- a/crates/modelardb_types/src/schemas.rs
+++ b/crates/modelardb_types/src/schemas.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 use std::sync::LazyLock;
 
-use arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
+use arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Fields, Schema};
 
 use crate::types::{
     ArrowTimestamp, ArrowUnivariateId, ArrowValue, CompressedSchema, ConfigurationSchema,
@@ -137,20 +137,15 @@ pub static CREATE_TABLE_SCHEMA: LazyLock<CreateTableSchema> = LazyLock::new(|| {
         Field::new("schema", DataType::Binary, false),
         Field::new(
             "error_bounds",
-            DataType::List(Arc::new(Field::new(
-                "error_bound",
-                DataType::Float32,
-                false,
-            ))),
+            DataType::Struct(Fields::from(vec![
+                Field::new("value", DataType::Float32, false),
+                Field::new("is_relative", DataType::Boolean, false),
+            ])),
             true,
         ),
         Field::new(
             "generated_columns",
-            DataType::List(Arc::new(Field::new(
-                "generated_column_expr",
-                DataType::Utf8,
-                true,
-            ))),
+            DataType::Struct(Fields::from(vec![Field::new("expr", DataType::Utf8, true)])),
             true,
         ),
     ])))

--- a/crates/modelardb_types/src/schemas.rs
+++ b/crates/modelardb_types/src/schemas.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 use std::sync::LazyLock;
 
-use arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Fields, Schema};
+use arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
 
 use crate::types::{
     ArrowTimestamp, ArrowUnivariateId, ArrowValue, CompressedSchema, ConfigurationSchema,
@@ -137,15 +137,12 @@ pub static CREATE_TABLE_SCHEMA: LazyLock<CreateTableSchema> = LazyLock::new(|| {
         Field::new("schema", DataType::Binary, false),
         Field::new(
             "error_bounds",
-            DataType::Struct(Fields::from(vec![
-                Field::new("value", DataType::Float32, false),
-                Field::new("is_relative", DataType::Boolean, false),
-            ])),
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
             true,
         ),
         Field::new(
             "generated_columns",
-            DataType::Struct(Fields::from(vec![Field::new("expr", DataType::Utf8, true)])),
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
             true,
         ),
     ])))

--- a/crates/modelardb_types/src/schemas.rs
+++ b/crates/modelardb_types/src/schemas.rs
@@ -22,7 +22,7 @@ use arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
 
 use crate::types::{
     ArrowTimestamp, ArrowUnivariateId, ArrowValue, CompressedSchema, ConfigurationSchema,
-    MetricSchema, QueryCompressedSchema, QuerySchema, UncompressedSchema,
+    CreateTableSchema, MetricSchema, QueryCompressedSchema, QuerySchema, UncompressedSchema,
 };
 
 /// Name of the column used to partition the compressed segments.
@@ -125,5 +125,33 @@ pub static CONFIGURATION_SCHEMA: LazyLock<ConfigurationSchema> = LazyLock::new(|
     ConfigurationSchema(Arc::new(Schema::new(vec![
         Field::new("setting", DataType::Utf8, false),
         Field::new("value", DataType::UInt64, true),
+    ])))
+});
+
+/// [`RecordBatch`](arrow::record_batch::RecordBatch) [`Schema`] used for creating tables using
+/// table data.
+pub static CREATE_TABLE_SCHEMA: LazyLock<CreateTableSchema> = LazyLock::new(|| {
+    CreateTableSchema(Arc::new(Schema::new(vec![
+        Field::new("type", DataType::Utf8, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("schema", DataType::Binary, false),
+        Field::new(
+            "error_bounds",
+            DataType::List(Arc::new(Field::new(
+                "error_bound",
+                DataType::Float32,
+                false,
+            ))),
+            true,
+        ),
+        Field::new(
+            "generated_columns",
+            DataType::List(Arc::new(Field::new(
+                "generated_column_expr",
+                DataType::Utf8,
+                true,
+            ))),
+            true,
+        ),
     ])))
 });

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -66,6 +66,9 @@ pub struct QuerySchema(pub arrow::datatypes::SchemaRef);
 #[derive(Clone)]
 pub struct ConfigurationSchema(pub arrow::datatypes::SchemaRef);
 
+#[derive(Clone)]
+pub struct CreateTableSchema(pub arrow::datatypes::SchemaRef);
+
 /// Absolute or relative per-value error bound.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ErrorBound {

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -91,7 +91,7 @@ impl ErrorBound {
         }
     }
 
-    /// Return an [ErrorBound::Relative`] with `percentage` as its relative per-value bound. A
+    /// Return an [`ErrorBound::Relative`] with `percentage` as its relative per-value bound. A
     /// [`ModelarDbTypesError`] is returned if a value below 0% or a value above 100% is passed.
     pub fn try_new_relative(percentage: f32) -> Result<Self> {
         if !(0.0..=100.0).contains(&percentage) {

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -67,7 +67,7 @@ pub struct QuerySchema(pub arrow::datatypes::SchemaRef);
 pub struct ConfigurationSchema(pub arrow::datatypes::SchemaRef);
 
 #[derive(Clone)]
-pub struct CreateTableSchema(pub arrow::datatypes::SchemaRef);
+pub struct TableMetadataSchema(pub arrow::datatypes::SchemaRef);
 
 /// Absolute or relative per-value error bound.
 #[derive(Debug, Copy, Clone, PartialEq)]


### PR DESCRIPTION
This PR implements https://github.com/ModelarData/ModelarDB-RS/issues/272 by adding a new `CreateTables` action to the server and manager that can be used to create tables using table metadata instead of a `CREATE TABLE` SQL statement.

This new action takes a record batch encoded as bytes in the action body and creates the tables with the type, name, schema, potential error bounds, and potential generated columns in the record batch. Note that multiple tables can be created with a single call to `CreateTables`.

Since we can now create tables without SQL, the initialization process for server nodes in a cluster has been changed to no longer use SQL to initialize the database schema of the added node. Instead, the table metadata for the missing tables are transferred from the manager to the new server node, and the same process as in the new action is used to create the tables.

This means that it was no longer necessary to save `CREATE TABLE` SQL statements in the metadata delta lake so those columns have been removed as well as the metadata delta lake functionality related to the SQL columns.