### PR TITLE
Switch all crates from edition 2021 to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [workspace]
 members = ["crates/*"]
-resolver = "2"
+resolver = "3"
 
 [workspace.dependencies]
 arrow = "53.3.0"

--- a/crates/modelardb_client/Cargo.toml
+++ b/crates/modelardb_client/Cargo.toml
@@ -16,7 +16,7 @@
 name = "modelardb_client"
 version = "0.1.0"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [[bin]]

--- a/crates/modelardb_common/Cargo.toml
+++ b/crates/modelardb_common/Cargo.toml
@@ -16,7 +16,7 @@
 name = "modelardb_common"
 version = "0.1.0"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]

--- a/crates/modelardb_common/src/test/data_generation.rs
+++ b/crates/modelardb_common/src/test/data_generation.rs
@@ -237,7 +237,7 @@ pub fn generate_values(
     match values_structure {
         // Generates constant values.
         ValuesStructure::Constant(maybe_add_noise_range) => {
-            let mut values = iter::repeat(std_rng.gen()).take(uncompressed_timestamps.len());
+            let mut values = iter::repeat(std_rng.r#gen()).take(uncompressed_timestamps.len());
             randomize_and_collect_iterator(maybe_add_noise_range, &mut values)
         }
         // Generates linear values.

--- a/crates/modelardb_compression/Cargo.toml
+++ b/crates/modelardb_compression/Cargo.toml
@@ -16,7 +16,7 @@
 name = "modelardb_compression"
 version = "0.1.0"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]

--- a/crates/modelardb_manager/Cargo.toml
+++ b/crates/modelardb_manager/Cargo.toml
@@ -16,7 +16,7 @@
 name = "modelardb_manager"
 version = "0.1.0"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [[bin]]

--- a/crates/modelardb_server/Cargo.toml
+++ b/crates/modelardb_server/Cargo.toml
@@ -16,7 +16,7 @@
 name = "modelardb_server"
 version = "0.1.0"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [[bin]]

--- a/crates/modelardb_storage/Cargo.toml
+++ b/crates/modelardb_storage/Cargo.toml
@@ -16,7 +16,7 @@
 name = "modelardb_storage"
 version = "0.1.0"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]

--- a/crates/modelardb_types/Cargo.toml
+++ b/crates/modelardb_types/Cargo.toml
@@ -16,7 +16,7 @@
 name = "modelardb_types"
 version = "0.1.0"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 authors = ["Soeren Kejser Jensen <devel@kejserjensen.dk>"]
 
 [dependencies]


### PR DESCRIPTION
This PR changes all crates from Rust Edition 2021 to Rust Edition 2024 which has been released as part of [Rust 1.85](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html). This is done to prevent use of the new reserved syntax to minimize the overhead of upgrading later, enable use of [`async`](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html#async-closures) [closures](https://rust-trends.com/posts/rust-s-async-closures/) to simplify writing `async` code, and allow [`let` chains](https://github.com/rust-lang/rust/pull/132833) to be used [when support for them is merged](https://github.com/rust-lang/rust/pull/132833#issuecomment-2580884688).