### PR TITLE
Upgrade Python version and remove typing_extensions

### DIFF
--- a/.github/workflows/build-lint-and-test.yml
+++ b/.github/workflows/build-lint-and-test.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Python Version
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13' 
+        python-version: '3.11' 
     - name: Pip Update
       run: python -m pip install pip --force-reinstall --break-system-packages --user
     - name: Pip Install

--- a/crates/modelardb_embedded/bindings/python/modelardb/__init__.py
+++ b/crates/modelardb_embedded/bindings/python/modelardb/__init__.py
@@ -21,11 +21,11 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from typing import Self
 
 import pyarrow
 from pyarrow import MapArray, RecordBatch, Schema, StringArray, Array
 from pyarrow.cffi import ffi
-from typing_extensions import Self
 
 
 @dataclass

--- a/crates/modelardb_embedded/bindings/python/pyproject.toml
+++ b/crates/modelardb_embedded/bindings/python/pyproject.toml
@@ -20,11 +20,10 @@ license = { text="Apache-2.0" }
 authors = [
   { name="Soeren Kejser Jensen",  email="devel@kejserjensen.dk" }
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.11"
 dependencies = [
     "pyarrow",
     "cffi",
-    "typing-extensions"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
This PR updates the minimum Python version required for the bindings from 3.7 to 3.11. This was done because Python 3.7 is[ unsupported](https://devguide.python.org/versions/), because we already implicitly required [Python 3.10 as `match`](https://docs.python.org/3/whatsnew/3.10.html) was used, Python 3.11 is the [oldest Python version that does not require `typing-extensions`](https://docs.python.org/3/whatsnew/3.11.html) as a dependency, and Python 3.11 is the oldest version support by all three of the [GitHub Action `*-latest` runners](https://github.com/actions/runner-images/) as `macos-latest` only provides Python version 3.11, 3.12, and 3.13. In addition, the Python version used for GitHub Actions was also changed to Python 3.11, so the tests are run with the oldest version of Python the bindings claim to support.