### PR TITLE
Support relative paths in modelardb_client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2964,7 +2964,6 @@ dependencies = [
  "arrow-flight",
  "bytes",
  "dirs",
- "object_store",
  "rustyline",
  "tokio",
  "tonic",

--- a/crates/modelardb_client/Cargo.toml
+++ b/crates/modelardb_client/Cargo.toml
@@ -28,7 +28,6 @@ arrow-flight.workspace = true
 arrow.workspace = true
 bytes.workspace = true
 dirs.workspace = true
-object_store.workspace = true
 rustyline.workspace = true
 tokio.workspace = true
 tonic.workspace = true

--- a/crates/modelardb_client/src/error.rs
+++ b/crates/modelardb_client/src/error.rs
@@ -21,7 +21,6 @@ use std::io::Error as IoError;
 use std::result::Result as StdResult;
 
 use arrow::error::ArrowError;
-use object_store::Error as ObjectStoreError;
 use rustyline::error::ReadlineError as RustyLineError;
 use tonic::Status as TonicStatusError;
 use tonic::transport::Error as TonicTransportError;
@@ -38,8 +37,6 @@ pub enum ModelarDbClientError {
     InvalidArgument(String),
     /// Error returned from IO operations.
     Io(IoError),
-    /// Error returned by ObjectStore.
-    ObjectStore(ObjectStoreError),
     /// Error returned by RustyLine.
     RustyLine(RustyLineError),
     /// Status returned by Tonic.
@@ -54,7 +51,6 @@ impl Display for ModelarDbClientError {
             Self::Arrow(reason) => write!(f, "Arrow Error: {reason}"),
             Self::InvalidArgument(reason) => write!(f, "Invalid Argument Error: {reason}"),
             Self::Io(reason) => write!(f, "Io Error: {reason}"),
-            Self::ObjectStore(reason) => write!(f, "Object Store Error: {reason}"),
             Self::RustyLine(reason) => write!(f, "RustyLine Error: {reason}"),
             Self::TonicStatus(reason) => write!(f, "Tonic Status Error: {reason}"),
             Self::TonicTransport(reason) => write!(f, "Tonic Transport Error: {reason}"),
@@ -69,7 +65,6 @@ impl Error for ModelarDbClientError {
             Self::Arrow(reason) => Some(reason),
             Self::InvalidArgument(_reason) => None,
             Self::Io(reason) => Some(reason),
-            Self::ObjectStore(reason) => Some(reason),
             Self::RustyLine(reason) => Some(reason),
             Self::TonicStatus(reason) => Some(reason),
             Self::TonicTransport(reason) => Some(reason),
@@ -86,12 +81,6 @@ impl From<ArrowError> for ModelarDbClientError {
 impl From<IoError> for ModelarDbClientError {
     fn from(error: IoError) -> Self {
         Self::Io(error)
-    }
-}
-
-impl From<ObjectStoreError> for ModelarDbClientError {
-    fn from(error: ObjectStoreError) -> Self {
-        Self::ObjectStore(error)
     }
 }
 

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -106,6 +106,11 @@ fn parse_command_line_arguments(
         if arg_path.exists() {
             // Assumes all files contains queries.
             maybe_query_file = Some(arg_path.to_path_buf());
+        } else if arg.starts_with(&['.', '/']) {
+            // Prevent missing files from being used as host.
+            Err(ModelarDbClientError::InvalidArgument(format!(
+                "{arg} does not exist"
+            )))?;
         } else if arg.contains(':') {
             // Assumes anything with : is host:port.
             let host_and_port = arg.splitn(2, ':').collect::<Vec<&str>>();

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -109,7 +109,7 @@ fn parse_command_line_arguments(
         } else if arg.starts_with(['.', '/']) {
             // Prevent missing files from being used as host.
             Err(ModelarDbClientError::InvalidArgument(format!(
-                "{arg} does not exist"
+                "{arg} does not exist."
             )))?;
         } else if arg.contains(':') {
             // Assumes anything with : is host:port.

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -20,10 +20,10 @@ mod helper;
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::env::{self, Args};
+use std::env;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, IsTerminal, Write};
-use std::path::{Path as StdPath, PathBuf as StdPathBuf};
+use std::path::Path as StdPath;
 use std::process;
 use std::sync::Arc;
 use std::time::Instant;
@@ -62,24 +62,35 @@ const TRANSPORT_ERROR: &str = "transport error: no messages received.";
 #[tokio::main]
 async fn main() -> Result<()> {
     // Parse the command line arguments.
-    let args = env::args();
-    if args.len() > 3 {
-        // The errors are consciously ignored as the client is terminating.
-        let binary_path = env::current_exe().unwrap();
-        let binary_name = binary_path.file_name().unwrap().to_str().unwrap();
+    let args = env::args().collect::<Vec<String>>();
+    let (host, port, maybe_query_file) = match &args[1..] {
+        [] => (DEFAULT_HOST, DEFAULT_PORT, None),
+        [query_file] if StdPath::new(&query_file).exists() => {
+            let query_file = StdPath::new(&query_file).to_path_buf();
+            (DEFAULT_HOST, DEFAULT_PORT, Some(query_file))
+        }
+        [host_port] if !host_port.starts_with(['.', '/']) => {
+            let (host, port) = parse_host_port(host_port)?;
+            (host, port, None)
+        }
+        [host_port, query_file] if StdPath::new(&query_file).exists() => {
+            let (host, port) = Parse_host_port(host_port)?;
+            let query_file = StdPath::new(&query_file).to_path_buf();
+            (host, port, Some(query_file))
+        }
+        _ => {
+            // The errors are consciously ignored as the client is terminating.
+            let binary_path = env::current_exe().unwrap();
+            let binary_name = binary_path.file_name().unwrap().to_str().unwrap();
 
-        // Punctuation at the end does not seem to be common in the usage message of Unix tools.
-        eprintln!("Usage: {binary_name} [server host or host:port] [query_file]",);
-        process::exit(1);
-    }
-    let (maybe_host, maybe_port, maybe_query_file) = parse_command_line_arguments(args)?;
-
-    // Connect to the server.
-    let host = maybe_host.unwrap_or_else(|| DEFAULT_HOST.to_owned());
-    let port = maybe_port.unwrap_or_else(|| DEFAULT_PORT.to_owned());
-    let flight_service_client = connect(&host, port).await?;
+            // Punctuation at the end does not seem to be common in the usage message of Unix tools.
+            eprintln!("Usage: {binary_name} [host or host:port] [query_file]",);
+            process::exit(1);
+        }
+    };
 
     // Execute the queries.
+    let flight_service_client = connect(host, port).await?;
     if let Some(query_file) = maybe_query_file {
         execute_queries_from_a_file(flight_service_client, &query_file).await
     } else {
@@ -87,46 +98,21 @@ async fn main() -> Result<()> {
     }
 }
 
-/// Parse the command line arguments in `args` and return a triple with the host of the server to
-/// connect to, the port to connect to, and the file containing the queries to execute on the
-/// server. If one of these command line arguments is not provided it is replaced with [`None`].
-fn parse_command_line_arguments(
-    mut args: Args,
-) -> Result<(Option<String>, Option<u16>, Option<StdPathBuf>)> {
-    // Drop the path of the executable.
-    args.next();
+/// Parse the host and port in `maybe_host_port` and return a pair with the host of the server to
+/// connect to and the port to connect to. If the host is not included `DEFAULT_HOST` is used and if
+/// port is not included `DEFAULT_PORT` is used. Returns [`ModelarDbClientError`] if the port is not
+/// valid.
+fn parse_host_port(maybe_host_port: &str) -> Result<(&str, u16)> {
+    let mut parts = maybe_host_port.splitn(2, ':');
+    let host = parts.next().unwrap_or(DEFAULT_HOST);
+    let port = match parts.next() {
+        Some(port) => port.parse().map_err(|_| {
+            ModelarDbClientError::InvalidArgument("Port must be between 1 and 65535.".to_owned())
+        }),
+        None => Ok(DEFAULT_PORT.to_owned()),
+    }?;
 
-    // Parse command line arguments.
-    let mut maybe_host = None;
-    let mut maybe_port = None;
-    let mut maybe_query_file = None;
-
-    for arg in args {
-        let arg_path = &StdPath::new(arg.as_str());
-        if arg_path.exists() {
-            // Assumes all files contains queries.
-            maybe_query_file = Some(arg_path.to_path_buf());
-        } else if arg.starts_with(['.', '/']) {
-            // Prevent missing files from being used as host.
-            Err(ModelarDbClientError::InvalidArgument(format!(
-                "{arg} does not exist."
-            )))?;
-        } else if arg.contains(':') {
-            // Assumes anything with : is host:port.
-            let host_and_port = arg.splitn(2, ':').collect::<Vec<&str>>();
-            maybe_host = Some(host_and_port[0].to_owned());
-            maybe_port = Some(host_and_port[1].parse().map_err(|_| {
-                ModelarDbClientError::InvalidArgument(
-                    "Port must be between 1 and 65535.".to_owned(),
-                )
-            })?);
-        } else {
-            // Assumes anything else is a host.
-            maybe_host = Some(arg);
-        }
-    }
-
-    Ok((maybe_host, maybe_port, maybe_query_file))
+    Ok((host, port))
 }
 
 /// Connect to the server at `host`:`port`. Returns [`ModelarDbClientError`] if a connection to the

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -106,7 +106,7 @@ fn parse_command_line_arguments(
         if arg_path.exists() {
             // Assumes all files contains queries.
             maybe_query_file = Some(arg_path.to_path_buf());
-        } else if arg.starts_with(&['.', '/']) {
+        } else if arg.starts_with(['.', '/']) {
             // Prevent missing files from being used as host.
             Err(ModelarDbClientError::InvalidArgument(format!(
                 "{arg} does not exist"

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -105,12 +105,12 @@ async fn main() -> Result<()> {
 fn parse_host_port(maybe_host_port: &str) -> Result<(&str, u16)> {
     let mut parts = maybe_host_port.splitn(2, ':');
     let host = parts.next().unwrap_or(DEFAULT_HOST);
-    let port = match parts.next() {
-        Some(port) => port.parse().map_err(|_| {
+    let port = parts
+        .next()
+        .map_or(Ok(DEFAULT_PORT.to_owned()), |part| part.parse())
+        .map_err(|_| {
             ModelarDbClientError::InvalidArgument("Port must be between 1 and 65535.".to_owned())
-        }),
-        None => Ok(DEFAULT_PORT.to_owned()),
-    }?;
+        })?;
 
     Ok((host, port))
 }

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
             (host, port, None)
         }
         [host_port, query_file] if StdPath::new(&query_file).exists() => {
-            let (host, port) = Parse_host_port(host_port)?;
+            let (host, port) = parse_host_port(host_port)?;
             let query_file = StdPath::new(&query_file).to_path_buf();
             (host, port, Some(query_file))
         }

--- a/crates/modelardb_storage/src/delta_lake.rs
+++ b/crates/modelardb_storage/src/delta_lake.rs
@@ -67,8 +67,8 @@ impl DeltaLake {
     /// [`ModelarDbStorageError`] if `local_url` cannot be parsed.
     pub fn try_from_local_url(local_url: &str) -> Result<Self> {
         match local_url.split_once("://") {
-            Some(("file", local_path)) => Self::try_from_local_path(StdPath::new(local_path)),
             None => Self::try_from_local_path(StdPath::new(local_url)),
+            Some(("file", local_path)) => Self::try_from_local_path(StdPath::new(local_path)),
             Some(("memory", _)) => Ok(Self::new_in_memory()),
             _ => Err(ModelarDbStorageError::InvalidArgument(format!(
                 "{local_url} is not a valid local URL."


### PR DESCRIPTION
This PR fixes a bug in `modelardb_client` that prevents a relative path to a file with queries from being used. The problem was due to the use of `object_store` for local file paths as it explicitly does not allow [relative file paths](https://docs.rs/object_store/latest/object_store/path/struct.Path.html). Thus, it has been replaced with types from Rust's standard library. Like in #217, Rust's `Path` type is imported as `std::path::Path as StdPath` everywhere to keep the code consistent. Likewise, `PathBuf` is imported as `std::path::PathBuf as StdPathBuf` to be consistent with `Path`. In addition to fixing the bug, the PR also simplifies the code of `modelardb_client` as `object_store` could be removed. An additional check was also added to the simple command-line parameter parser to improve error messages. While looking at how local paths are implemented in `delta_lake.rs`, it was initially unclear that a path without a prefix was supported as `None` was surrounded by two `Some` in the `match` Thus, `None`  has been moved to the top to make it more clear.