### PR TITLE
Fix bug causing in-memory data folder to fail

### DIFF
--- a/crates/modelardb_storage/src/delta_lake.rs
+++ b/crates/modelardb_storage/src/delta_lake.rs
@@ -79,7 +79,7 @@ impl DeltaLake {
     /// Create a new [`DeltaLake`] that manages the Delta tables in memory.
     pub fn new_in_memory() -> Self {
         Self {
-            location: "memory://modelardb".to_owned(),
+            location: "memory:///modelardb".to_owned(),
             storage_options: HashMap::new(),
             object_store: Arc::new(InMemory::new()),
             delta_table_cache: DashMap::new(),


### PR DESCRIPTION
This PR fixes https://github.com/ModelarData/ModelarDB-RS/issues/339 by changing the location used for an in-memory `DeltaLake`. It is not clear what caused the issue, but it seems that a change to the `object_store` crate made it so a leading `/` is necessary when specifying the path. The same pattern is consistently used both in tests for the `object_store` crate and for the `delta_lake` crate.