### PR TITLE
Implement error-bounded lossy compression method MacaqueV 

### DIFF
--- a/crates/modelardb_compression/src/compression.rs
+++ b/crates/modelardb_compression/src/compression.rs
@@ -24,8 +24,8 @@ use arrow::record_batch::RecordBatch;
 use modelardb_types::types::{ErrorBound, TimestampArray, ValueArray};
 
 use crate::error::{ModelarDbCompressionError, Result};
-use crate::models::gorilla::Gorilla;
-use crate::models::{self, GORILLA_ID, timestamps};
+use crate::models::macaque_v::MacaqueV;
+use crate::models::{self, timestamps, MACAQUE_V_ID};
 use crate::types::{CompressedSegmentBatchBuilder, CompressedSegmentBuilder, ModelBuilder};
 
 /// Maximum number of residuals that can be stored as part of a compressed segment. The number of
@@ -238,13 +238,13 @@ fn compress_and_store_residuals_in_a_separate_segment(
 
     // Compute metadata and compress the values stored in this segment without residuals.
     let uncompressed_values = &uncompressed_values.values()[start_index..=end_index];
-    let mut gorilla = Gorilla::new(error_bound);
+    let mut gorilla = MacaqueV::new(error_bound);
     gorilla.compress_values(uncompressed_values);
 
     let (values, min_value, max_value) = gorilla.model();
 
     compressed_segment_batch_builder.append_compressed_segment(
-        GORILLA_ID,
+        MACAQUE_V_ID,
         start_time,
         end_time,
         &timestamps,
@@ -269,7 +269,7 @@ mod tests {
     use modelardb_types::schemas::COMPRESSED_SCHEMA;
     use modelardb_types::types::{TimestampBuilder, ValueBuilder};
 
-    use crate::{MODEL_TYPE_NAMES, models};
+    use crate::{models, MODEL_TYPE_NAMES};
 
     const TAG_VALUE: &str = "tag";
     const ADD_NOISE_RANGE: Option<Range<f32>> = Some(1.0..1.05);
@@ -470,7 +470,7 @@ mod tests {
             false,
             ValuesStructure::largest_random_without_overflow(),
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            &[models::GORILLA_ID],
+            &[models::MACAQUE_V_ID],
         );
     }
 
@@ -480,7 +480,7 @@ mod tests {
             false,
             ValuesStructure::largest_random_without_overflow(),
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            &[models::GORILLA_ID],
+            &[models::MACAQUE_V_ID],
         );
     }
 
@@ -490,7 +490,7 @@ mod tests {
             true,
             ValuesStructure::largest_random_without_overflow(),
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            &[models::GORILLA_ID],
+            &[models::MACAQUE_V_ID],
         );
     }
 
@@ -500,7 +500,7 @@ mod tests {
             true,
             ValuesStructure::largest_random_without_overflow(),
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            &[models::GORILLA_ID],
+            &[models::MACAQUE_V_ID],
         );
     }
 
@@ -534,89 +534,89 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_random_linear_constant_time_series_within_absolute_error_bound_zero()
-     {
+    fn test_try_compress_regular_random_linear_constant_time_series_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             false,
-            &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
-            &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
+            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
+            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
         );
     }
 
     #[test]
-    fn test_try_compress_regular_random_linear_constant_time_series_within_relative_error_bound_zero()
-     {
+    fn test_try_compress_regular_random_linear_constant_time_series_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             false,
-            &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
-            &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
+            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
+            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
         );
     }
 
     #[test]
-    fn test_try_compress_irregular_random_linear_constant_time_series_within_absolute_error_bound_zero()
-     {
+    fn test_try_compress_irregular_random_linear_constant_time_series_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
-            &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
-            &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
+            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
+            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
         );
     }
 
     #[test]
-    fn test_try_compress_irregular_random_linear_constant_time_series_within_relative_error_bound_zero()
-     {
+    fn test_try_compress_irregular_random_linear_constant_time_series_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
-            &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
-            &[models::GORILLA_ID, models::SWING_ID, models::PMC_MEAN_ID],
+            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
+            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
         );
     }
 
     #[test]
-    fn test_try_compress_regular_constant_linear_random_time_series_within_absolute_error_bound_zero()
-     {
+    fn test_try_compress_regular_constant_linear_random_time_series_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             false,
-            &[models::PMC_MEAN_ID, models::SWING_ID, models::GORILLA_ID],
+            &[models::PMC_MEAN_ID, models::SWING_ID, models::MACAQUE_V_ID],
             &[models::PMC_MEAN_ID, models::SWING_ID],
         );
     }
 
     #[test]
-    fn test_try_compress_regular_constant_linear_random_time_series_within_relative_error_bound_zero()
-     {
+    fn test_try_compress_regular_constant_linear_random_time_series_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             false,
-            &[models::PMC_MEAN_ID, models::SWING_ID, models::GORILLA_ID],
+            &[models::PMC_MEAN_ID, models::SWING_ID, models::MACAQUE_V_ID],
             &[models::PMC_MEAN_ID, models::SWING_ID],
         );
     }
 
     #[test]
-    fn test_try_compress_irregular_constant_linear_random_time_series_within_absolute_error_bound_zero()
-     {
+    fn test_try_compress_irregular_constant_linear_random_time_series_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
-            &[models::PMC_MEAN_ID, models::SWING_ID, models::GORILLA_ID],
+            &[models::PMC_MEAN_ID, models::SWING_ID, models::MACAQUE_V_ID],
             &[models::PMC_MEAN_ID, models::SWING_ID],
         );
     }
 
     #[test]
-    fn test_try_compress_irregular_constant_linear_random_time_series_within_relative_error_bound_zero()
-     {
+    fn test_try_compress_irregular_constant_linear_random_time_series_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
-            &[models::PMC_MEAN_ID, models::SWING_ID, models::GORILLA_ID],
+            &[models::PMC_MEAN_ID, models::SWING_ID, models::MACAQUE_V_ID],
             &[models::PMC_MEAN_ID, models::SWING_ID],
         );
     }
@@ -649,7 +649,7 @@ mod tests {
                         [uncompressed_timestamps_start_index..uncompressed_timestamps_end_index],
                     ValuesStructure::Linear(None),
                 ),
-                models::GORILLA_ID => data_generation::generate_values(
+                models::MACAQUE_V_ID => data_generation::generate_values(
                     &uncompressed_timestamps.values()
                         [uncompressed_timestamps_start_index..uncompressed_timestamps_end_index],
                     ValuesStructure::largest_random_without_overflow(),
@@ -707,8 +707,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_without_noise_within_absolute_error_bound_zero()
-     {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -717,8 +717,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_without_noise_within_relative_error_bound_zero()
-     {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -727,8 +727,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_without_noise_within_absolute_error_bound_five()
-     {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_absolute_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
             false,
@@ -737,8 +737,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_without_noise_within_relative_error_bound_five()
-     {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_relative_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             false,
@@ -787,8 +787,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_absolute_error_bound_zero()
-     {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -797,8 +797,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_relative_error_bound_zero()
-     {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -807,8 +807,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_absolute_error_bound_five()
-     {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_absolute_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
             true,
@@ -817,8 +817,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_relative_error_bound_five()
-     {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_relative_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             true,
@@ -827,8 +827,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_absolute_error_bound_zero()
-     {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_absolute_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -837,8 +837,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_relative_error_bound_zero()
-     {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_relative_error_bound_zero(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -847,8 +847,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_absolute_error_bound_five()
-     {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_absolute_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
             true,
@@ -857,8 +857,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_relative_error_bound_five()
-     {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_relative_error_bound_five(
+    ) {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             true,
@@ -1002,7 +1002,7 @@ mod tests {
         );
 
         assert_eq!(1, compressed_record_batch.num_rows());
-        assert_eq!(GORILLA_ID, model_type_ids.value(0));
+        assert_eq!(MACAQUE_V_ID, model_type_ids.value(0));
         assert_eq!(100, start_times.value(0));
         assert_eq!(500, end_times.value(0));
         assert_eq!(1, timestamps.value(0).len());

--- a/crates/modelardb_compression/src/compression.rs
+++ b/crates/modelardb_compression/src/compression.rs
@@ -238,10 +238,10 @@ fn compress_and_store_residuals_in_a_separate_segment(
 
     // Compute metadata and compress the values stored in this segment without residuals.
     let uncompressed_values = &uncompressed_values.values()[start_index..=end_index];
-    let mut gorilla = MacaqueV::new(error_bound);
-    gorilla.compress_values(uncompressed_values);
+    let mut macaque_v = MacaqueV::new(error_bound);
+    macaque_v.compress_values(uncompressed_values);
 
-    let (values, min_value, max_value) = gorilla.model();
+    let (values, min_value, max_value) = macaque_v.model();
 
     compressed_segment_batch_builder.append_compressed_segment(
         MACAQUE_V_ID,

--- a/crates/modelardb_compression/src/compression.rs
+++ b/crates/modelardb_compression/src/compression.rs
@@ -25,7 +25,7 @@ use modelardb_types::types::{ErrorBound, TimestampArray, ValueArray};
 
 use crate::error::{ModelarDbCompressionError, Result};
 use crate::models::macaque_v::MacaqueV;
-use crate::models::{self, timestamps, MACAQUE_V_ID};
+use crate::models::{self, MACAQUE_V_ID, timestamps};
 use crate::types::{CompressedSegmentBatchBuilder, CompressedSegmentBuilder, ModelBuilder};
 
 /// Maximum number of residuals that can be stored as part of a compressed segment. The number of
@@ -269,7 +269,7 @@ mod tests {
     use modelardb_types::schemas::COMPRESSED_SCHEMA;
     use modelardb_types::types::{TimestampBuilder, ValueBuilder};
 
-    use crate::{models, MODEL_TYPE_NAMES};
+    use crate::{MODEL_TYPE_NAMES, models};
 
     const TAG_VALUE: &str = "tag";
     const ADD_NOISE_RANGE: Option<Range<f32>> = Some(1.0..1.05);
@@ -534,8 +534,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_random_linear_constant_time_series_within_absolute_error_bound_zero(
-    ) {
+    fn test_try_compress_regular_random_linear_constant_time_series_within_absolute_error_bound_zero()
+     {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -545,8 +545,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_random_linear_constant_time_series_within_relative_error_bound_zero(
-    ) {
+    fn test_try_compress_regular_random_linear_constant_time_series_within_relative_error_bound_zero()
+     {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -556,8 +556,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_random_linear_constant_time_series_within_absolute_error_bound_zero(
-    ) {
+    fn test_try_compress_irregular_random_linear_constant_time_series_within_absolute_error_bound_zero()
+     {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -567,8 +567,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_random_linear_constant_time_series_within_relative_error_bound_zero(
-    ) {
+    fn test_try_compress_irregular_random_linear_constant_time_series_within_relative_error_bound_zero()
+     {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -578,8 +578,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_constant_linear_random_time_series_within_absolute_error_bound_zero(
-    ) {
+    fn test_try_compress_regular_constant_linear_random_time_series_within_absolute_error_bound_zero()
+     {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -589,8 +589,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_constant_linear_random_time_series_within_relative_error_bound_zero(
-    ) {
+    fn test_try_compress_regular_constant_linear_random_time_series_within_relative_error_bound_zero()
+     {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -600,8 +600,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_constant_linear_random_time_series_within_absolute_error_bound_zero(
-    ) {
+    fn test_try_compress_irregular_constant_linear_random_time_series_within_absolute_error_bound_zero()
+     {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -611,8 +611,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_constant_linear_random_time_series_within_relative_error_bound_zero(
-    ) {
+    fn test_try_compress_irregular_constant_linear_random_time_series_within_relative_error_bound_zero()
+     {
         generate_compress_and_assert_known_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -707,8 +707,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_without_noise_within_absolute_error_bound_zero(
-    ) {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_absolute_error_bound_zero()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -717,8 +717,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_without_noise_within_relative_error_bound_zero(
-    ) {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_relative_error_bound_zero()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             false,
@@ -727,8 +727,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_without_noise_within_absolute_error_bound_five(
-    ) {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_absolute_error_bound_five()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
             false,
@@ -737,8 +737,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_without_noise_within_relative_error_bound_five(
-    ) {
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_relative_error_bound_five()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             false,
@@ -787,8 +787,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_absolute_error_bound_zero(
-    ) {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_absolute_error_bound_zero()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -797,8 +797,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_relative_error_bound_zero(
-    ) {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_relative_error_bound_zero()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -807,8 +807,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_absolute_error_bound_five(
-    ) {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_absolute_error_bound_five()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
             true,
@@ -817,8 +817,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_relative_error_bound_five(
-    ) {
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_relative_error_bound_five()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             true,
@@ -827,8 +827,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_absolute_error_bound_zero(
-    ) {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_absolute_error_bound_zero()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -837,8 +837,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_relative_error_bound_zero(
-    ) {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_relative_error_bound_zero()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
             true,
@@ -847,8 +847,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_absolute_error_bound_five(
-    ) {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_absolute_error_bound_five()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
             true,
@@ -857,8 +857,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_relative_error_bound_five(
-    ) {
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_relative_error_bound_five()
+     {
         generate_compress_and_assert_time_series(
             ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             true,

--- a/crates/modelardb_compression/src/models/macaque_v.rs
+++ b/crates/modelardb_compression/src/models/macaque_v.rs
@@ -15,12 +15,12 @@
 
 //! Implementation of the MacaqueV model type which extends the lossless compression method for 
 //! floating-point values proposed for the time series management system Gorilla in the [Gorilla 
-//! paper] by 1) adding support for error-bounded lossy compression, and 2) optimizing flag bits
+//! paper] by adding support for error-bounded lossy compression, and optimizing flag bits
 //! for better compression of real-life sensor data. MacaqueV adds support for lossy compression by
-//! 1) rewriting the current value with the previous one if possible within the error bound, or 
-//! 2) rewriting the least mantissa bits of the value to zero within the error bound so that Gorilla 
+//! rewriting the current value with the previous one if possible within the error bound, or
+//! rewriting the least mantissa bits of the value to zero within the error bound so that Gorilla
 //! uses fewer bits for encoding. MacaqueV optimizes Gorilla's flag bits by swapping the flag bits
-//! 0 and 10. This modification proved to be effective when Gorilla is used alongside PMC-Mean 
+//! 0 and 10. This modification proved to be effective when Gorilla is used alongside PMC-Mean
 //! and Swing for multi-model compression. As this compression method uses Gorilla that compresses
 //! the values of a time series segment using XOR and a variable length binary encoding, aggregates
 //! are computed by iterating over all values in the segment.

--- a/crates/modelardb_compression/src/models/macaque_v.rs
+++ b/crates/modelardb_compression/src/models/macaque_v.rs
@@ -18,7 +18,7 @@
 //! paper] by adding support for error-bounded lossy compression, and optimizing flag bits
 //! for better compression of real-life sensor data. MacaqueV adds support for lossy compression by
 //! rewriting the current value with the previous one if possible within the error bound, or
-//! rewriting the least mantissa bits of the value to zero within the error bound so that Gorilla
+//! rewriting the least significant mantissa bits of the value to zero within the error bound so that Gorilla
 //! uses fewer bits for encoding. MacaqueV optimizes Gorilla's flag bits by swapping the flag bits
 //! 0 and 10. The experiments showed this modification's effectiveness when Gorilla is used alongside
 //! PMC-Mean and Swing for multi-model compression. As MacaqueV uses Gorilla that compresses the
@@ -105,7 +105,8 @@ impl MacaqueV {
                 self.last_value
             } else {
                 // When the value rewriting is not possible within the error bound,
-                // the least mantissa bits of the value are rewritten to zero within the error bound.
+                // the least significant mantissa bits of the value are rewritten to zero 
+                // within the error bound.
                 self.rewrite_least_mantissa_bits(value)
             }
         };

--- a/crates/modelardb_compression/src/models/macaque_v.rs
+++ b/crates/modelardb_compression/src/models/macaque_v.rs
@@ -26,7 +26,7 @@
 //! PMC-Mean and Swing for multi-model compression. As this compression method
 //! uses Gorilla that compresses the values of a time series segment using
 //! XOR and a variable length binary encoding, aggregates are computed by
-//! iterating over all values in the segment. A paper describing MacaqueV 
+//! iterating over all values in the segment. A paper describing MacaqueV
 //! was submitted to ICDE 2026.
 //!
 //! [Gorilla paper]: https://www.vldb.org/pvldb/vol8/p1816-teller.pdf
@@ -166,7 +166,7 @@ impl MacaqueV {
         self.update_min_max_and_last_value(value);
     }
 
-    /// MacaqueV's value rewrite method. 
+    /// MacaqueV's value rewrite method.
     fn rewrite_value_with_log_method(&self, value: Value) -> Value {
         if value == 0.0 || value.is_infinite() || value.is_nan() {
             return value;
@@ -176,10 +176,10 @@ impl MacaqueV {
             models::maximum_allowed_deviation(self.error_bound, value as f64) as f32;
         let exponent = get_exponent(value);
         let factorized_epsilon = abs_error_bound / 2f32.powi(exponent);
-        // Rewriting value using by 23 - ⌈log2 factorized_epsilon⌉ bits 
-        // never exceeds the error bound. However, one more bit can be 
-        // rewritten when the majority of the least mantissa bits are 0, 
-        // thus we use 23 - ⌊log2 factorized_epsilon⌋ and then 
+        // Rewriting value using by 23 - ⌈log2 factorized_epsilon⌉ bits
+        // never exceeds the error bound. However, one more bit can be
+        // rewritten when the majority of the least mantissa bits are 0,
+        // thus we use 23 - ⌊log2 factorized_epsilon⌋ and then
         // perform extra check if the error bound is not exceeded.
         let mut rewrite_position = 23 - factorized_epsilon.log2().abs().floor() as i32;
         // Extra check to ensure if the error is within the error_bound
@@ -262,7 +262,7 @@ pub fn sum(length: usize, values: &[u8], maybe_model_last_value: Option<Value>) 
 }
 
 /// Decompress all the values in `values` for the `timestamps` without matching values in
-/// `value_builder`. The values in `values` are compressed using MacaqueV. 
+/// `value_builder`. The values in `values` are compressed using MacaqueV.
 /// `values` are appended to `value_builder`. If `maybe_model_last_value`
 /// is provided, it is assumed the first value in `values` is compressed against it instead of being
 /// stored in full, i.e., uncompressed.

--- a/crates/modelardb_compression/src/models/macaque_v.rs
+++ b/crates/modelardb_compression/src/models/macaque_v.rs
@@ -167,7 +167,7 @@ impl MacaqueV {
 
     /// MacaqueV's value rewrite method.
     fn rewrite_value_with_log_method(&self, value: Value) -> Value {
-        if value == 0.0 || value.is_infinite() || value.is_nan() {
+        if value.abs() == 0.0 || value.is_infinite() || value.is_nan() {
             return value;
         }
         let value_as_u32 = value.to_bits();

--- a/crates/modelardb_compression/src/models/macaque_v.rs
+++ b/crates/modelardb_compression/src/models/macaque_v.rs
@@ -175,11 +175,11 @@ impl MacaqueV {
         let factorized_epsilon = abs_error_bound / 2f32.powi(exponent);
         // Rewriting the last 23 - ⌈log2 factorized_epsilon⌉ mantissa bits
         // never exceeds the error bound. However, in that case, one more bit
-        // can be rewritten if the majority of the least mantissa bits are 0.
-        // Thus, we rewrite bits using 23 - ⌊log2 factorized_epsilon⌋ and
+        // can be rewritten if the majority of the least significant mantissa bits
+        // are 0. Thus, we rewrite bits using 23 - ⌊log2 factorized_epsilon⌋ and
         // perform an extra check to ensure the error bound is not exceeded.
         // If the error bound is exceeded, we rewrite 23 - ⌈log2 factorized_epsilon⌉
-        // least mantissa bits.
+        // least significant mantissa bits.
         let mut rewrite_position = 23 - factorized_epsilon.log2().abs().floor() as i32;
         let mut rewritten_value = f32::from_bits(rewrite_bits_by_n(value_as_u32, rewrite_position));
 
@@ -319,7 +319,7 @@ pub fn grid(
     }
 }
 
-// Extract the unbiased exponent from single precision float.
+// Extract the unbiased exponent from `value`.
 fn get_exponent(value: f32) -> i32 {
     let n_bits: u32 = value.to_bits();
     let biased_exponent = ((n_bits >> 23) & 0xff) as i32;

--- a/crates/modelardb_compression/src/models/macaque_v.rs
+++ b/crates/modelardb_compression/src/models/macaque_v.rs
@@ -164,7 +164,7 @@ impl MacaqueV {
     /// Rewrite the highest number of mantissa bits possible for `value` within the `error_bound`
     /// starting from the least significant bits.
     fn rewrite_least_mantissa_bits(&self, value: Value) -> Value {
-        if value.abs() == 0.0 || value.is_infinite() || value.is_nan() {
+        if value.abs() == 0.0 || value.is_nan() || value.is_infinite() {
             return value;
         }
 

--- a/crates/modelardb_compression/src/models/macaque_v.rs
+++ b/crates/modelardb_compression/src/models/macaque_v.rs
@@ -33,8 +33,8 @@
 use modelardb_types::types::{Timestamp, Value, ValueBuilder};
 
 use crate::models;
-use crate::models::bits::{BitReader, BitVecBuilder};
 use crate::models::ErrorBound;
+use crate::models::bits::{BitReader, BitVecBuilder};
 
 /// The state the MacaqueV model type needs while compressing the values of a
 /// time series segment.
@@ -108,7 +108,7 @@ impl MacaqueV {
             if models::is_value_within_error_bound(self.error_bound, value, self.last_value) {
                 self.last_value
             } else {
-                // If value rewriting is not possible, the least mantissa bits of the 
+                // If value rewriting is not possible, the least mantissa bits of the
                 // value are rewritten to zero.
                 self.rewrite_value_with_log_method(value)
             }
@@ -586,9 +586,11 @@ mod tests {
         let values_array = value_builder.finish();
 
         assert!(values.len() == timestamps.len() && values.len() == values_array.len());
-        assert!(timestamps
-            .windows(2)
-            .all(|window| window[1] - window[0] == 1));
+        assert!(
+            timestamps
+                .windows(2)
+                .all(|window| window[1] - window[0] == 1)
+        );
         assert!(slice_of_value_equal(values_array.values(), values));
     }
 

--- a/crates/modelardb_compression/src/models/macaque_v.rs
+++ b/crates/modelardb_compression/src/models/macaque_v.rs
@@ -13,20 +13,21 @@
  * limitations under the License.
  */
 
-//! Implementation of MacaqueV model type which extends the lossless 
+//! Implementation of MacaqueV model type which extends the lossless
 //! compression method for floating-point values proposed for the time series
 //! management system Gorilla in the [Gorilla paper] by 1) adding support for
-//! error-bounded lossy compression, and 2) optimizing flag bits for better 
-//! compression of real-life sensor data. MacaqueV adds support for lossy 
-//! compression by 1) replacing values with the previous value if possible
-//! within the error bound, and 2) rewriting the least mantissa bits of a value 
-//! within the error bound so that Gorilla uses fewer bits for encoding. 
-//! MacaqueV optimizes Gorilla's flag bits by swapping the flag bits 0 and 10. 
-//! This modification proved to be effective when Gorilla is used alongside 
-//! PMC-Mean and Swing for multi-model compression. As this compression method 
-//! compresses the values of a time series segment using XOR and a 
-//! variable length binary encoding, aggregates are computed by iterating 
-//! over all values in the segment.
+//! error-bounded lossy compression, and 2) optimizing flag bits for better
+//! compression of real-life sensor data. MacaqueV adds support for lossy
+//! compression by 1) replacing a value with the previous value if possible
+//! within the error bound, or 2) rewriting the least mantissa bits of the value
+//! within the error bound so that Gorilla uses fewer bits for encoding.
+//! MacaqueV optimizes Gorilla's flag bits by swapping the flag bits 0 and 10.
+//! This modification proved to be effective when Gorilla is used alongside
+//! PMC-Mean and Swing for multi-model compression. As this compression method
+//! uses Gorilla that compresses the values of a time series segment using
+//! XOR and a variable length binary encoding, aggregates are computed by
+//! iterating over all values in the segment. A paper describing MacaqueV 
+//! was submitted to ICDE 2026.
 //!
 //! [Gorilla paper]: https://www.vldb.org/pvldb/vol8/p1816-teller.pdf
 
@@ -318,15 +319,16 @@ pub fn grid(
     }
 }
 
+// Extract the unbiased exponent from single precision float.
 fn get_exponent(value: f32) -> i32 {
     let n_bits: u32 = value.to_bits();
     let exponent_ = ((n_bits >> 23) & 0xff) as i32;
-    let exponent = exponent_ - 127;
-    exponent
+    exponent_ - 127
 }
 
-fn rewrite_bits_by_n(bits_to_rewrite: u32, erase_by_n: i32) -> u32 {
-    let mask = u32::MAX << erase_by_n;
+// Left shift unsigned 32-bit integer by a given number of places.
+fn rewrite_bits_by_n(bits_to_rewrite: u32, left_shift_by: i32) -> u32 {
+    let mask = u32::MAX << left_shift_by;
     bits_to_rewrite & mask
 }
 

--- a/crates/modelardb_compression/src/models/macaque_v.rs
+++ b/crates/modelardb_compression/src/models/macaque_v.rs
@@ -18,12 +18,13 @@
 //! paper] by adding support for error-bounded lossy compression, and optimizing flag bits
 //! for better compression of real-life sensor data. MacaqueV adds support for lossy compression by
 //! rewriting the current value with the previous one if possible within the error bound, or
-//! rewriting the least significant mantissa bits of the value to zero within the error bound so that Gorilla
-//! uses fewer bits for encoding. MacaqueV optimizes Gorilla's flag bits by swapping the flag bits
-//! 0 and 10. The experiments showed this modification's effectiveness when Gorilla is used alongside
-//! PMC-Mean and Swing for multi-model compression. As MacaqueV uses Gorilla that compresses the
-//! values of a time series segment using XOR and a variable length binary encoding, aggregates
-//! are computed by iterating over all values in the segment.
+//! rewriting the least significant mantissa bits of the value to zero within the error bound so
+//! that Gorilla uses fewer bits for encoding. MacaqueV optimizes Gorilla's flag bits by swapping the
+//! flag bits 0 and 10. Experiments showed that this modification is very effective when Gorilla is used
+//! after PMC-Mean and Swing i.e., for compressing residuals. This is because neighboring residuals
+//! have rarely the same value and they are mostly similar to each other. As MacaqueV uses Gorilla
+//! that compresses the values of a time series segment using XOR and a variable length binary encoding,
+//! aggregates are computed by iterating over all values in the segment.
 //!
 //! [Gorilla paper]: https://www.vldb.org/pvldb/vol8/p1816-teller.pdf
 
@@ -105,7 +106,7 @@ impl MacaqueV {
                 self.last_value
             } else {
                 // When the value rewriting is not possible within the error bound,
-                // the least significant mantissa bits of the value are rewritten to zero 
+                // the least significant mantissa bits of the value are rewritten to zero
                 // within the error bound.
                 self.rewrite_least_mantissa_bits(value)
             }

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -90,8 +90,8 @@ pub fn maximum_allowed_deviation(error_bound: ErrorBound, value: f64) -> f64 {
 /// Returns true is compression is lossless i.e., `error_bound` is 0.
 pub fn is_lossless_compression(error_bound: ErrorBound) -> bool {
     match error_bound {
-        ErrorBound::Absolute(error_bound) => return error_bound == 0.0,
-        ErrorBound::Relative(error_bound) => return error_bound == 0.0,
+        ErrorBound::Absolute(error_bound) => error_bound == 0.0,
+        ErrorBound::Relative(error_bound) => error_bound == 0.0,
     }
 }
 

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -18,7 +18,7 @@
 //! contains general functionality used by the model types.
 
 pub mod bits;
-pub mod gorilla;
+pub mod macaque_v;
 pub mod pmc_mean;
 pub mod swing;
 pub mod timestamps;
@@ -35,13 +35,13 @@ use crate::types::CompressedSegmentBuilder;
 /// to the ids must be reflected in all statements matching on them.
 pub const PMC_MEAN_ID: i8 = 0;
 pub const SWING_ID: i8 = 1;
-pub const GORILLA_ID: i8 = 2;
+pub const MACAQUE_V_ID: i8 = 2;
 
 /// Number of implemented model types. It is usize instead of u8 as it is used as an array length.
 pub const MODEL_TYPE_COUNT: usize = 3;
 
 /// Mapping of model type ids to names.
-pub const MODEL_TYPE_NAMES: [&str; MODEL_TYPE_COUNT] = ["pmc_mean", "swing", "gorilla"];
+pub const MODEL_TYPE_NAMES: [&str; MODEL_TYPE_COUNT] = ["pmc_mean", "swing", "macaque_v"];
 
 /// Size of [`Value`] in bytes.
 pub(super) const VALUE_SIZE_IN_BYTES: u8 = mem::size_of::<Value>() as u8;
@@ -84,6 +84,14 @@ pub fn maximum_allowed_deviation(error_bound: ErrorBound, value: f64) -> f64 {
     match error_bound {
         ErrorBound::Absolute(error_bound) => error_bound as f64 * 0.99,
         ErrorBound::Relative(error_bound) => f64::abs(value * (error_bound as f64 / 100.1)),
+    }
+}
+
+/// Returns true is compression is lossless i.e., `error_bound` is 0.
+pub fn is_lossless_compression(error_bound: ErrorBound) -> bool {
+    match error_bound {
+        ErrorBound::Absolute(error_bound) => return error_bound == 0.0,
+        ErrorBound::Relative(error_bound) => return error_bound == 0.0,
     }
 }
 
@@ -160,9 +168,9 @@ pub fn sum(
                 ),
             )
         }
-        GORILLA_ID => (
+        MACAQUE_V_ID => (
             f32::NAN, // A segment with values compressed by Gorilla never has residuals.
-            gorilla::sum(model_length, values, None),
+            macaque_v::sum(model_length, values, None),
         ),
         _ => panic!("Unknown model type."),
     };
@@ -171,7 +179,7 @@ pub fn sum(
     if residuals.is_empty() {
         model_sum
     } else {
-        let residuals_sum = gorilla::sum(
+        let residuals_sum = macaque_v::sum(
             residuals_length,
             &residuals[..residuals.len() - 1],
             Some(model_last_value),
@@ -228,7 +236,7 @@ pub fn grid(
                 value_builder,
             )
         }
-        GORILLA_ID => gorilla::grid(values, model_timestamps, value_builder, None),
+        MACAQUE_V_ID => macaque_v::grid(values, model_timestamps, value_builder, None),
         _ => panic!("Unknown model type."),
     }
 
@@ -236,7 +244,7 @@ pub fn grid(
     if !residuals.is_empty() {
         let model_last_value = value_builder.values_slice()[value_builder.len() - 1];
 
-        gorilla::grid(
+        macaque_v::grid(
             &residuals[..residuals.len() - 1],
             residuals_timestamps,
             value_builder,

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -87,7 +87,7 @@ pub fn maximum_allowed_deviation(error_bound: ErrorBound, value: f64) -> f64 {
     }
 }
 
-/// Returns true is compression is lossless i.e., `error_bound` is 0.
+/// Returns true if compression is lossless i.e., `error_bound` value is 0.
 pub fn is_lossless_compression(error_bound: ErrorBound) -> bool {
     match error_bound {
         ErrorBound::Absolute(error_bound) => error_bound == 0.0,

--- a/crates/modelardb_compression/src/models/timestamps.rs
+++ b/crates/modelardb_compression/src/models/timestamps.rs
@@ -13,22 +13,26 @@
  * limitations under the License.
  */
 
-//! Implementation of lossless compression for timestamps. Optimized compression
-//! methods are used depending on the number of data points in a compressed
-//! segment and if its timestamps have been sampled at a regular sampling
-//! interval.
+//! Implementation of MacaqueTS, a lossless compression for timestamps. MacaqueTS uses 
+//! optimized compression methods depending on the number of data points in a compressed segment
+//! and if its timestamps have been sampled at a regular sampling interval.
 //!
-//! If a segment only contains one data point its timestamp is stored as both
-//! the segment's `start_time` and `end_time`, and if a segment only contains
-//! two data points the timestamps are stored as the segment's `start_time` and
-//! `end_time`, respectively. If a segment contains more than two data points,
-//! the first and last timestamps are stored as the segment's `start_time` and
-//! `end_time`, respectively, while its residual timestamps are compressed using
-//! one of two methods. If the data points in the segment have been collected at
-//! a regular sampling interval, the residual timestamps are compressed as the
-//! segment's length with the prefix zero bits stripped. If none of the above
-//! apply, the compression method proposed for timestamps for the time series
-//! management system Gorilla in the [Gorilla paper] is used as a fallback.
+//! If a segment only contains one data point, its timestamp is stored as both the segment's
+//! `start_time` and `end_time`, and if a segment only contains two data points,
+//! the timestamps are stored as the segment's `start_time` and `end_time`, respectively.
+//! If a segment contains more than two data points, the first and last timestamps
+//! are stored as the segment's `start_time` and `end_time`, respectively, while its
+//! residual timestamps are compressed using one of two methods. If the data points
+//! in the segment have been collected at a regular sampling interval, the residual timestamps
+//! are compressed as the segment's length with the prefix zero bits stripped.
+//! If none of the above apply, an extended version of the compression method proposed
+//! for timestamps for the time series management system Gorilla in the [Gorilla paper]
+//! is used as a fallback. MacaqueTS extends Gorilla's timestamp compression method by
+//! using zero as the first delta instead of computing it explicitly. This avoids the need
+//! to encode the first delta as a special case. MacaqueTS also extends the flag ranges
+//! used by Gorilla for integer bit-packing to support encoding finer granularity timestamps
+//! with a sampling interval of lower than one second.
+//!
 //!
 //! [Gorilla paper]: https://www.vldb.org/pvldb/vol8/p1816-teller.pdf
 
@@ -150,8 +154,9 @@ fn compress_irregular_residual_timestamps(uncompressed_timestamps: &[Timestamp])
 /// Decompress all of a segment's timestamps which are compressed as
 /// `start_time` for segments of length one, `start_time` and `end_time` for
 /// segments of length two, the segment's length for regular time series, or
-/// using Gorilla's compression method for timestamps for irregular time series.
-/// The decompressed timestamps are appended to `timestamp_builder`.
+/// using extended version of Gorilla's compression method for timestamps
+/// for irregular time series. The decompressed timestamps are appended
+/// to `timestamp_builder`.
 pub fn decompress_all_timestamps(
     start_time: Timestamp,
     end_time: Timestamp,
@@ -215,9 +220,8 @@ fn decompress_all_regular_timestamps(
 }
 
 /// Decompress all of a segment's timestamps, which for this segment are sampled
-/// at an irregular sampling interval, and thus compressed using Gorilla's
-/// compression method for timestamps. The decompressed timestamps are appended
-/// to `timestamp_builder`.
+/// at an irregular sampling interval, and thus compressed using MacaqueTS. 
+/// The decompressed timestamps are appended to `timestamp_builder`.
 fn decompress_all_irregular_timestamps(
     start_time: Timestamp,
     end_time: Timestamp,
@@ -227,7 +231,7 @@ fn decompress_all_irregular_timestamps(
     // Add the first timestamp stored as `start_time` in the segment.
     timestamp_builder.append_value(start_time);
 
-    // Remove the one bit used as a flag to specify that Gorilla is used.
+    // Remove the one bit used as a flag to specify that MacaqueTS is used.
     let mut bits = BitReader::try_new(residual_timestamps).unwrap();
     bits.read_bit();
 

--- a/crates/modelardb_compression/src/models/timestamps.rs
+++ b/crates/modelardb_compression/src/models/timestamps.rs
@@ -13,25 +13,28 @@
  * limitations under the License.
  */
 
-//! Implementation of MacaqueTS, a lossless compression for timestamps. MacaqueTS uses 
+//! Implementation of MacaqueTS, a lossless compression for timestamps. MacaqueTS uses
 //! optimized compression methods depending on the number of data points in a compressed segment
 //! and if its timestamps have been sampled at a regular sampling interval.
 //!
-//! If a segment only contains one data point, its timestamp is stored as both the segment's
-//! `start_time` and `end_time`, and if a segment only contains two data points,
-//! the timestamps are stored as the segment's `start_time` and `end_time`, respectively.
-//! If a segment contains more than two data points, the first and last timestamps
-//! are stored as the segment's `start_time` and `end_time`, respectively, while its
-//! residual timestamps are compressed using one of two methods. If the data points
-//! in the segment have been collected at a regular sampling interval, the residual timestamps
-//! are compressed as the segment's length with the prefix zero bits stripped.
-//! If none of the above apply, an extended version of the compression method proposed
-//! for timestamps for the time series management system Gorilla in the [Gorilla paper]
-//! is used as a fallback. MacaqueTS extends Gorilla's timestamp compression method by
-//! using zero as the first delta instead of computing it explicitly. This avoids the need
-//! to encode the first delta as a special case. MacaqueTS also extends the flag ranges
-//! used by Gorilla for integer bit-packing to support encoding finer granularity timestamps
-//! with a sampling interval of lower than one second.
+//! - (1) If a segment only contains one data point, its timestamp is stored as both the segment's
+//!   `start_time` and `end_time`.
+//! - (2) If a segment only contains two data points, the timestamps are stored as the segment's
+//!   `start_time` and `end_time`, respectively.
+//! - (3) If a segment contains more than two data points, the first and last timestamps
+//!   are stored as the segment's `start_time` and `end_time`, respectively, while its
+//!   residual timestamps are compressed using one of two methods.
+//!    - (1) If the data points in the segment have been collected at a regular sampling interval,
+//!      the residual timestamps are compressed as the segment's length with the
+//!      prefix zero bits stripped.
+//!    - (2) If none of the above apply, an extended version of the compression method proposed
+//!      for timestamps for the time series management system Gorilla in the [Gorilla paper]
+//!      is used as a fallback.
+//!
+//! MacaqueTS extends Gorilla's timestamp compression method by using zero as the first delta
+//! instead of computing it explicitly. MacaqueTS also extends the flag ranges used by Gorilla
+//! for integer bit-packing to support encoding finer granularity timestamps with a sampling interval
+//! of lower than one second.
 //!
 //!
 //! [Gorilla paper]: https://www.vldb.org/pvldb/vol8/p1816-teller.pdf
@@ -220,7 +223,7 @@ fn decompress_all_regular_timestamps(
 }
 
 /// Decompress all of a segment's timestamps, which for this segment are sampled
-/// at an irregular sampling interval, and thus compressed using MacaqueTS. 
+/// at an irregular sampling interval, and thus compressed using MacaqueTS.
 /// The decompressed timestamps are appended to `timestamp_builder`.
 fn decompress_all_irregular_timestamps(
     start_time: Timestamp,

--- a/crates/modelardb_compression/src/models/timestamps.rs
+++ b/crates/modelardb_compression/src/models/timestamps.rs
@@ -15,21 +15,20 @@
 
 //! Implementation of MacaqueTS, a lossless compression for timestamps. MacaqueTS uses
 //! optimized compression methods depending on the number of data points in a compressed segment
-//! and if its timestamps have been sampled at a regular sampling interval.
-//!
-//! - (1) If a segment only contains one data point, its timestamp is stored as both the segment's
+//! and if its timestamps have been sampled at a regular sampling interval:
+//! * If a segment only contains one data point, its timestamp is stored as both the segment's
 //!   `start_time` and `end_time`.
-//! - (2) If a segment only contains two data points, the timestamps are stored as the segment's
+//! * If a segment only contains two data points, the timestamps are stored as the segment's
 //!   `start_time` and `end_time`, respectively.
-//! - (3) If a segment contains more than two data points, the first and last timestamps
+//! * If a segment contains more than two data points, the first and last timestamps
 //!   are stored as the segment's `start_time` and `end_time`, respectively, while its
-//!   residual timestamps are compressed using one of two methods.
-//!    - (1) If the data points in the segment have been collected at a regular sampling interval,
-//!      the residual timestamps are compressed as the segment's length with the
-//!      prefix zero bits stripped.
-//!    - (2) If none of the above apply, an extended version of the compression method proposed
-//!      for timestamps for the time series management system Gorilla in the [Gorilla paper]
-//!      is used as a fallback.
+//!   residual timestamps are compressed using one of two methods:
+//!   * If the data points in the segment have been collected at a regular sampling interval,
+//!     the residual timestamps are compressed as the segment's length with the
+//!     prefix zero bits stripped.
+//!   * If none of the above apply, an extended version of the compression method proposed
+//!     for timestamps for the time series management system Gorilla in the [Gorilla paper]
+//!     is used as a fallback.
 //!
 //! MacaqueTS extends Gorilla's timestamp compression method by using zero as the first delta
 //! instead of computing it explicitly. MacaqueTS also extends the flag ranges used by Gorilla

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -271,9 +271,9 @@ impl CompressedSegmentBuilder {
         error_bound: ErrorBound,
         uncompressed_residuals: &[Value],
     ) -> (Vec<u8>, Value, Value) {
-        let mut gorilla = MacaqueV::new(error_bound);
-        gorilla.compress_values_without_first(uncompressed_residuals, self.model_last_value);
-        gorilla.model()
+        let mut macaque_v = MacaqueV::new(error_bound);
+        macaque_v.compress_values_without_first(uncompressed_residuals, self.model_last_value);
+        macaque_v.model()
     }
 
     /// Encode the information required for a [`PMCMean`] model where the `residuals_min_value`

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::{debug_assert, iter};
 
 use arrow::array::{
-    ArrayBuilder, ArrayRef, BinaryBuilder, Float32Builder, Int16Array, Int8Builder, StringArray,
+    ArrayBuilder, ArrayRef, BinaryBuilder, Float32Builder, Int8Builder, Int16Array, StringArray,
 };
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
@@ -30,8 +30,8 @@ use modelardb_types::types::{
 use crate::models::macaque_v::MacaqueV;
 use crate::models::pmc_mean::PMCMean;
 use crate::models::swing::Swing;
-use crate::models::{timestamps, VALUE_SIZE_IN_BYTES};
 use crate::models::{PMC_MEAN_ID, SWING_ID};
+use crate::models::{VALUE_SIZE_IN_BYTES, timestamps};
 
 /// A model being built from an uncompressed segment using the potentially lossy model types in
 /// [`models`]. Each of the potentially lossy model types is used to fit models to the data points,

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::{debug_assert, iter};
 
 use arrow::array::{
-    ArrayBuilder, ArrayRef, BinaryBuilder, Float32Builder, Int8Builder, Int16Array, StringArray,
+    ArrayBuilder, ArrayRef, BinaryBuilder, Float32Builder, Int16Array, Int8Builder, StringArray,
 };
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
@@ -30,8 +30,8 @@ use modelardb_types::types::{
 use crate::models::macaque_v::MacaqueV;
 use crate::models::pmc_mean::PMCMean;
 use crate::models::swing::Swing;
+use crate::models::{timestamps, VALUE_SIZE_IN_BYTES};
 use crate::models::{PMC_MEAN_ID, SWING_ID};
-use crate::models::{VALUE_SIZE_IN_BYTES, timestamps};
 
 /// A model being built from an uncompressed segment using the potentially lossy model types in
 /// [`models`]. Each of the potentially lossy model types is used to fit models to the data points,

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -27,7 +27,7 @@ use modelardb_types::types::{
     ErrorBound, Timestamp, TimestampArray, TimestampBuilder, Value, ValueArray, ValueBuilder,
 };
 
-use crate::models::gorilla::Gorilla;
+use crate::models::macaque_v::MacaqueV;
 use crate::models::pmc_mean::PMCMean;
 use crate::models::swing::Swing;
 use crate::models::{PMC_MEAN_ID, SWING_ID};
@@ -271,7 +271,7 @@ impl CompressedSegmentBuilder {
         error_bound: ErrorBound,
         uncompressed_residuals: &[Value],
     ) -> (Vec<u8>, Value, Value) {
-        let mut gorilla = Gorilla::new(error_bound);
+        let mut gorilla = MacaqueV::new(error_bound);
         gorilla.compress_values_without_first(uncompressed_residuals, self.model_last_value);
         gorilla.model()
     }

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -215,7 +215,7 @@ impl CompressedSegmentBuilder {
             &uncompressed_timestamps.values()[self.start_index..=residuals_end_index],
         );
 
-        // Compress residual values using Gorilla if any exists.
+        // Compress residual values using MacaqueV if any exists.
         let residuals = if self.end_index < residuals_end_index {
             let residuals_start_index = self.end_index + 1;
 
@@ -265,7 +265,7 @@ impl CompressedSegmentBuilder {
         )
     }
 
-    /// Compress `uncompressed_residuals` within `error_bound` using [`Gorilla`].
+    /// Compress `uncompressed_residuals` within `error_bound` using [`MacaqueV`].
     fn compress_residuals(
         &self,
         error_bound: ErrorBound,
@@ -423,7 +423,7 @@ pub(crate) struct CompressedSegmentBatchBuilder {
     /// the values of each compressed segment in the batch within an error
     /// bound.
     values: BinaryBuilder,
-    /// Values between this and the next segment, compressed using [`Gorilla`],
+    /// Values between this and the next segment, compressed using [`MacaqueV`],
     /// that the models could not represent efficiently within the error bound
     /// and which are too few for a new segment due to the amount of metadata.
     residuals: BinaryBuilder,
@@ -808,7 +808,7 @@ mod tests {
         let model_end_index = model.end_index;
 
         // Create a segment that represents its values using a model of the expected type and its
-        // residuals using Gorilla, and then assert that the expected encoding is used for it.
+        // residuals using MacaqueV, and then assert that the expected encoding is used for it.
         let residuals_end_index = uncompressed_timestamps.len() - 1;
 
         let mut compressed_schema_fields = COMPRESSED_SCHEMA.0.fields.clone().to_vec();


### PR DESCRIPTION
This PR implements MacaqueV, a lossy error-bounded single floating point compression method, as a replacement for Gorilla model type. Macaque adds two value preprocessing methods. 
First, MacaqueV rewrites a value by 1) replacing it with the previous one within the error bound or 2) rewriting the least mantissa bits of the value within the error bound so that Gorilla uses fewer bits for encoding. Then the value is encoded using the modified version of Gorilla. Gorilla's flag bits 0 and 10 are swapped to achieve better compression when used alongside PMC-Mean and Swing. 
Experiments using real-life datasets showed that MacaqueV improves ModelarDB's compression by 1.5-2.5x.