### PR TITLE
Add missing imports for Python bindings

### DIFF
--- a/crates/modelardb_bulkloader/src/main.rs
+++ b/crates/modelardb_bulkloader/src/main.rs
@@ -218,8 +218,8 @@ async fn import_time_series_table(
         // Write the current batch if it uses more than half the memory so concatenation is
         // possible. The amount of available memory is reduced by 20% for other variables.
         system.refresh_memory();
-        if current_batch_size > (system.available_memory() as usize / 10 * 8) {
-            if let Err(write_error) = import_and_clear_time_series_table_batch(
+        if current_batch_size > (system.available_memory() as usize / 10 * 8)
+            && let Err(write_error) = import_and_clear_time_series_table_batch(
                 data_folder,
                 &mut delta_table_writer,
                 time_series_table_metadata,
@@ -227,10 +227,9 @@ async fn import_time_series_table(
                 &mut current_batch_size,
             )
             .await
-            {
-                delta_table_writer.rollback().await?;
-                return Err(write_error);
-            }
+        {
+            delta_table_writer.rollback().await?;
+            return Err(write_error);
         }
     }
 

--- a/crates/modelardb_embedded/bindings/python/modelardb/__init__.py
+++ b/crates/modelardb_embedded/bindings/python/modelardb/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .operations import Aggregate, Operations
+from .operations import Aggregate, Operations, open_memory, open_local, open_s3, open_azure, connect
 from .node import Server, Manager
 from .error_bound import AbsoluteErrorBound, RelativeErrorBound
 from .table import NormalTable, TimeSeriesTable

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -17,7 +17,6 @@
 
 use std::collections::HashMap;
 use std::error::Error;
-use std::{iter, slice};
 use std::ops::Range;
 use std::process::Stdio;
 use std::str;
@@ -25,6 +24,7 @@ use std::string::String;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
+use std::{iter, slice};
 
 use arrow_flight::flight_service_client::FlightServiceClient;
 use arrow_flight::{Action, Criteria, FlightData, FlightDescriptor, PutResult, Ticket, utils};

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 use std::error::Error;
-use std::iter;
+use std::{iter, slice};
 use std::ops::Range;
 use std::process::Stdio;
 use std::str;
@@ -626,7 +626,7 @@ async fn test_can_truncate_normal_table() {
 
     ingest_time_series_and_flush_data(
         &mut test_context,
-        &[time_series.clone()],
+        slice::from_ref(&time_series),
         TableType::NormalTable,
     )
     .await;
@@ -649,7 +649,7 @@ async fn test_can_truncate_time_series_table() {
 
     ingest_time_series_and_flush_data(
         &mut test_context,
-        &[time_series.clone()],
+        slice::from_ref(&time_series),
         TableType::TimeSeriesTable,
     )
     .await;
@@ -736,7 +736,7 @@ async fn test_do_put_can_ingest_time_series_with_tags() {
 
     ingest_time_series_and_flush_data(
         &mut test_context,
-        &[time_series.clone()],
+        slice::from_ref(&time_series),
         TableType::TimeSeriesTable,
     )
     .await;
@@ -787,7 +787,7 @@ async fn test_do_put_can_ingest_time_series_without_tags() {
 
     ingest_time_series_and_flush_data(
         &mut test_context,
-        &[time_series.clone()],
+        slice::from_ref(&time_series),
         TableType::TimeSeriesTableNoTag,
     )
     .await;
@@ -838,7 +838,7 @@ async fn test_do_put_can_ingest_time_series_with_generated_field() {
 
     ingest_time_series_and_flush_data(
         &mut test_context,
-        &[time_series.clone()],
+        slice::from_ref(&time_series),
         TableType::TimeSeriesTableAsField,
     )
     .await;

--- a/crates/modelardb_storage/src/parser.rs
+++ b/crates/modelardb_storage/src/parser.rs
@@ -182,22 +182,22 @@ impl ModelarDbDialect {
     /// [`false`] is returned. The method does not consume tokens.
     fn next_tokens_are_create_time_series_table(&self, parser: &Parser) -> bool {
         // CREATE.
-        if let Token::Word(word) = parser.peek_nth_token(0).token {
-            if word.keyword == Keyword::CREATE {
-                // TIME.
-                if let Token::Word(word) = parser.peek_nth_token(1).token {
-                    if word.value.to_uppercase() == "TIME" {
-                        // SERIES.
-                        if let Token::Word(word) = parser.peek_nth_token(2).token {
-                            if word.value.to_uppercase() == "SERIES" {
-                                // TABLE.
-                                if let Token::Word(word) = parser.peek_nth_token(3).token {
-                                    if word.keyword == Keyword::TABLE {
-                                        return true;
-                                    }
-                                }
-                            }
-                        }
+        if let Token::Word(word) = parser.peek_nth_token(0).token
+            && word.keyword == Keyword::CREATE
+        {
+            // TIME.
+            if let Token::Word(word) = parser.peek_nth_token(1).token
+                && word.value.to_uppercase() == "TIME"
+            {
+                // SERIES.
+                if let Token::Word(word) = parser.peek_nth_token(2).token
+                    && word.value.to_uppercase() == "SERIES"
+                {
+                    // TABLE.
+                    if let Token::Word(word) = parser.peek_nth_token(3).token
+                        && word.keyword == Keyword::TABLE
+                    {
+                        return true;
                     }
                 }
             }
@@ -298,10 +298,10 @@ impl ModelarDbDialect {
     /// Return [`Ok`] if the next [`Token`] is a [`Token::Word`] with the value `expected`,
     /// otherwise a [`ParserError`] is returned.
     fn expect_word_value(&self, parser: &mut Parser, expected: &str) -> StdResult<(), ParserError> {
-        if let Ok(string) = self.parse_word_value(parser) {
-            if string.to_uppercase() == expected.to_uppercase() {
-                return Ok(());
-            }
+        if let Ok(string) = self.parse_word_value(parser)
+            && string.to_uppercase() == expected.to_uppercase()
+        {
+            return Ok(());
         }
         parser.expected(expected, parser.peek_token())
     }

--- a/crates/modelardb_storage/src/query/grid_exec.rs
+++ b/crates/modelardb_storage/src/query/grid_exec.rs
@@ -21,6 +21,7 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::fmt::{Formatter, Result as FmtResult};
 use std::pin::Pin;
+use std::slice;
 use std::sync::Arc;
 use std::task::{Context as StdTaskContext, Poll};
 
@@ -86,7 +87,7 @@ impl GridExec {
         // assumes the data it receives from all of its inputs uses the same sort order.
         let equivalence_properties = EquivalenceProperties::new_with_orderings(
             schema.clone(),
-            &[query_order_data_point.clone()],
+            slice::from_ref(&query_order_data_point),
         );
 
         let plan_properties = PlanProperties::new(

--- a/crates/modelardb_storage/src/query/normal_table.rs
+++ b/crates/modelardb_storage/src/query/normal_table.rs
@@ -82,7 +82,7 @@ impl TableProvider for NormalTable {
     }
 
     /// Get the [`LogicalPlan`] of this normal table, if available.
-    fn get_logical_plan(&self) -> Option<Cow<LogicalPlan>> {
+    fn get_logical_plan(&self) -> Option<Cow<'_, LogicalPlan>> {
         self.delta_table.get_logical_plan()
     }
 


### PR DESCRIPTION
This PR fixes a small bug in the Python bindings that was caused by the convenience functions not being imported in the `__init__.py` file from `operations.py`. With this PR it should now be possible to use both `modelardb.Operations.open_local()` and `modelardb.open_local()`.

Note that most of the changes are from Clippy issues. The relevant change that fixes the bug is in `crates/modelardb_embedded/bindings/python/modelardb/__init__.py`.