### PR TITLE
Change CreateTables to CreateTable

### DIFF
--- a/crates/modelardb_embedded/src/operations/client.rs
+++ b/crates/modelardb_embedded/src/operations/client.rs
@@ -178,7 +178,7 @@ impl Operations for Client {
         };
 
         let action = Action {
-            r#type: "CreateTables".to_owned(),
+            r#type: "CreateTable".to_owned(),
             body: protobuf_bytes.into(),
         };
 

--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -576,8 +576,8 @@ impl FlightService for FlightServiceHandler {
 
     /// Perform a specific action based on the type of the action in `request`. Currently, the
     /// following actions are supported:
-    /// * `CreateTables`: Create the tables given in the [`TableMetadata`](protocol::TableMetadata)
-    /// protobuf message in the action body. The tables are created for each node in the cluster of
+    /// * `CreateTable`: Create the table given in the [`TableMetadata`](protocol::TableMetadata)
+    /// protobuf message in the action body. The table is created for each node in the cluster of
     /// nodes controlled by the manager.
     /// * `InitializeDatabase`: Given a list of existing table names in a
     /// [`DatabaseMetadata`](protocol::DatabaseMetadata) protobuf message, respond with the metadata
@@ -600,7 +600,7 @@ impl FlightService for FlightServiceHandler {
         let action = request.into_inner();
         info!("Received request to perform action '{}'.", action.r#type);
 
-        if action.r#type == "CreateTables" {
+        if action.r#type == "CreateTable" {
             // Deserialize and extract the table metadata from the protobuf message in the action body.
             let (normal_table_metadata, time_series_table_metadata) =
                 modelardb_types::flight::deserialize_and_extract_table_metadata(&action.body)
@@ -790,8 +790,8 @@ impl FlightService for FlightServiceHandler {
         _request: Request<Empty>,
     ) -> StdResult<Response<Self::ListActionsStream>, Status> {
         let create_tables_action = ActionType {
-            r#type: "CreateTables".to_owned(),
-            description: "Create the tables given in the protobuf message in the action body."
+            r#type: "CreateTable".to_owned(),
+            description: "Create the table given in the protobuf message in the action body."
                 .to_owned(),
         };
 

--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -201,7 +201,7 @@ impl FlightServiceHandler {
                 .map_err(error_to_status_internal)?;
 
         let action = Action {
-            r#type: "CreateTables".to_owned(),
+            r#type: "CreateTable".to_owned(),
             body: protobuf_bytes.into(),
         };
 
@@ -250,7 +250,7 @@ impl FlightServiceHandler {
             .map_err(error_to_status_internal)?;
 
         let action = Action {
-            r#type: "CreateTables".to_owned(),
+            r#type: "CreateTable".to_owned(),
             body: protobuf_bytes.into(),
         };
 

--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -35,7 +35,7 @@ use arrow_flight::{
 use futures::{Stream, stream};
 use modelardb_storage::parser;
 use modelardb_storage::parser::ModelarDbStatement;
-use modelardb_types::flight::{deserialize_and_extract_table_metadata, protocol};
+use modelardb_types::flight::protocol;
 use modelardb_types::types::{Table, TimeSeriesTableMetadata};
 use prost::Message;
 use tokio::runtime::Runtime;
@@ -597,8 +597,10 @@ impl FlightService for FlightServiceHandler {
         info!("Received request to perform action '{}'.", action.r#type);
 
         if action.r#type == "CreateTable" {
-            let table_metadata = deserialize_and_extract_table_metadata(&action.body)
-                .map_err(error_to_status_invalid_argument)?;
+            // Deserialize and extract the table metadata from the protobuf message in the action body.
+            let table_metadata =
+                modelardb_types::flight::deserialize_and_extract_table_metadata(&action.body)
+                    .map_err(error_to_status_invalid_argument)?;
 
             match table_metadata {
                 Table::NormalTable(table_name, schema) => {

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -262,11 +262,9 @@ mod tests {
 
     use std::sync::Arc;
 
-    use arrow_flight::flight_service_client::FlightServiceClient;
     use tempfile::TempDir;
     use tokio::runtime::Runtime;
     use tokio::sync::RwLock;
-    use tonic::transport::Channel;
     use uuid::Uuid;
 
     use crate::data_folders::{DataFolder, DataFolders};
@@ -471,11 +469,7 @@ mod tests {
             local_data_folder,
         );
 
-        let channel = Channel::builder("grpc://server:9999".parse().unwrap()).connect_lazy();
-        let lazy_flight_client = FlightServiceClient::new(channel);
-
         let manager = Manager::new(
-            Arc::new(RwLock::new(lazy_flight_client)),
             Uuid::new_v4().to_string(),
         );
 

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -469,9 +469,7 @@ mod tests {
             local_data_folder,
         );
 
-        let manager = Manager::new(
-            Uuid::new_v4().to_string(),
-        );
+        let manager = Manager::new(Uuid::new_v4().to_string());
 
         let configuration_manager = Arc::new(RwLock::new(ConfigurationManager::new(
             ClusterMode::MultiNode(manager),

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -130,7 +130,7 @@ impl Manager {
                     .await?;
 
                 let schema = TableProvider::schema(&delta_table);
-                context.create_normal_table(&table_name, &schema).await?;
+                context.create_normal_table(table_name, &schema).await?;
             } else {
                 let time_series_table_metadata = remote_metadata_manager
                     .time_series_table_metadata_for_time_series_table(table_name)

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -37,16 +37,14 @@ use crate::error::{ModelarDbServerError, Result};
 /// Manages metadata related to the manager and provides functionality for interacting with the manager.
 #[derive(Clone, Debug)]
 pub struct Manager {
-    /// Flight client that is connected to the Apache Arrow Flight server of the manager.
-    flight_client: Arc<RwLock<FlightServiceClient<Channel>>>,
     /// Key received from the manager when registering, used to validate future requests that are
     /// only allowed to come from the manager.
     key: String,
 }
 
 impl Manager {
-    pub fn new(flight_client: Arc<RwLock<FlightServiceClient<Channel>>>, key: String) -> Self {
-        Self { flight_client, key }
+    pub fn new(key: String) -> Self {
+        Self { key }
     }
 
     /// Register the server as a node in the cluster and retrieve the key and connection information
@@ -79,7 +77,7 @@ impl Manager {
 
         // unwrap() is safe since the manager always has a remote storage configuration.
         Ok((
-            Manager::new(flight_client, manager_metadata.key),
+            Manager::new(manager_metadata.key),
             manager_metadata.storage_configuration.unwrap(),
         ))
     }
@@ -234,12 +232,6 @@ mod tests {
     }
 
     fn create_manager() -> Manager {
-        let channel = Channel::builder("grpc://server:9999".parse().unwrap()).connect_lazy();
-        let lazy_flight_client = FlightServiceClient::new(channel);
-
-        Manager::new(
-            Arc::new(RwLock::new(lazy_flight_client)),
-            Uuid::new_v4().to_string(),
-        )
+        Manager::new(Uuid::new_v4().to_string())
     }
 }

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -83,7 +83,7 @@ impl Manager {
     }
 
     /// Initialize the local database schema with the normal tables and time series tables from the
-    /// managers database schema using the remote data folder. If the tables to create could not be
+    /// manager's database schema using the remote data folder. If the tables to create could not be
     /// retrieved from the remote data folder, or the tables could not be created,
     /// return [`ModelarDbServerError`].
     pub(crate) async fn retrieve_and_create_tables(&self, context: &Arc<Context>) -> Result<()> {

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -139,7 +139,7 @@ impl Manager {
                 context
                     .create_time_series_table(&time_series_table_metadata)
                     .await?;
-            };
+            }
         }
 
         Ok(())

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -615,7 +615,7 @@ impl FlightService for FlightServiceHandler {
 
     /// Perform a specific action based on the type of the action in `request`. Currently, the
     /// following actions are supported:
-    /// * `CreateTables`: Create the tables given in the [`TableMetadata`](protocol::TableMetadata)
+    /// * `CreateTable`: Create the table given in the [`TableMetadata`](protocol::TableMetadata)
     /// protobuf message in the action body.
     /// * `FlushMemory`: Flush all data that is currently in memory to disk. This compresses the
     /// uncompressed data currently in memory and then flushes all compressed data in the storage
@@ -642,7 +642,7 @@ impl FlightService for FlightServiceHandler {
         let action = request.get_ref();
         info!("Received request to perform action '{}'.", action.r#type);
 
-        if action.r#type == "CreateTables" {
+        if action.r#type == "CreateTable" {
             self.validate_request(request.metadata()).await?;
 
             self.context
@@ -789,8 +789,8 @@ impl FlightService for FlightServiceHandler {
         _request: Request<Empty>,
     ) -> StdResult<Response<Self::ListActionsStream>, Status> {
         let create_tables_action = ActionType {
-            r#type: "CreateTables".to_owned(),
-            description: "Create the tables given in the protobuf message in the action body."
+            r#type: "CreateTable".to_owned(),
+            description: "Create the table given in the protobuf message in the action body."
                 .to_owned(),
         };
 

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -42,7 +42,7 @@ use deltalake::arrow::datatypes::Schema;
 use futures::StreamExt;
 use futures::stream::{self, BoxStream, SelectAll};
 use modelardb_storage::parser::{self, ModelarDbStatement};
-use modelardb_types::flight::{deserialize_and_extract_table_metadata, protocol};
+use modelardb_types::flight::protocol;
 use modelardb_types::functions;
 use modelardb_types::types::{Table, TimeSeriesTableMetadata};
 use prost::Message;
@@ -645,8 +645,9 @@ impl FlightService for FlightServiceHandler {
         if action.r#type == "CreateTable" {
             self.validate_request(request.metadata()).await?;
 
-            let table_metadata = deserialize_and_extract_table_metadata(&action.body)
-                .map_err(error_to_status_invalid_argument)?;
+            let table_metadata =
+                modelardb_types::flight::deserialize_and_extract_table_metadata(&action.body)
+                    .map_err(error_to_status_invalid_argument)?;
 
             match table_metadata {
                 Table::NormalTable(table_name, schema) => {

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -37,9 +37,7 @@ use datafusion::arrow::ipc::writer::{DictionaryTracker, IpcDataGenerator, IpcWri
 use datafusion::arrow::record_batch::RecordBatch;
 use futures::{StreamExt, stream};
 use modelardb_test::data_generation;
-use modelardb_test::table::{
-    NORMAL_TABLE_NAME, TIME_SERIES_TABLE_NAME, normal_table_schema, time_series_table_metadata,
-};
+use modelardb_test::table::{self, NORMAL_TABLE_NAME, TIME_SERIES_TABLE_NAME};
 use modelardb_types::flight::protocol;
 use modelardb_types::types::ErrorBound;
 use prost::Message;
@@ -1408,12 +1406,7 @@ async fn test_can_get_node_type() {
 #[tokio::test]
 async fn test_can_create_normal_table_from_metadata() {
     let mut test_context = TestContext::new().await;
-
-    let protobuf_bytes = modelardb_types::flight::encode_and_serialize_normal_table_metadata(
-        NORMAL_TABLE_NAME,
-        &normal_table_schema(),
-    )
-    .unwrap();
+    let protobuf_bytes = table::normal_table_metadata_protobuf_bytes();
 
     let action = Action {
         r#type: "CreateTable".to_owned(),
@@ -1433,11 +1426,7 @@ async fn test_can_create_normal_table_from_metadata() {
 #[tokio::test]
 async fn test_can_create_time_series_table_from_metadata() {
     let mut test_context = TestContext::new().await;
-
-    let protobuf_bytes = modelardb_types::flight::encode_and_serialize_time_series_table_metadata(
-        &time_series_table_metadata(),
-    )
-    .unwrap();
+    let protobuf_bytes = table::time_series_table_metadata_protobuf_bytes();
 
     let action = Action {
         r#type: "CreateTable".to_owned(),

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -830,7 +830,7 @@ async fn test_can_list_actions() {
     assert_eq!(
         actions,
         vec![
-            "CreateTables",
+            "CreateTable",
             "FlushMemory",
             "FlushNode",
             "GetConfiguration",
@@ -1410,8 +1410,8 @@ async fn test_can_create_tables() {
     let protobuf_bytes = table::table_metadata_protobuf_bytes();
 
     let action = Action {
-        r#type: "CreateTables".to_owned(),
         body: protobuf_bytes.into(),
+        r#type: "CreateTable".to_owned(),
     };
 
     test_context

--- a/crates/modelardb_test/src/table.rs
+++ b/crates/modelardb_test/src/table.rs
@@ -39,24 +39,6 @@ pub const TIME_SERIES_TABLE_SQL: &str = "CREATE TIME SERIES TABLE time_series_ta
 /// Name of the time series table used in tests.
 pub const TIME_SERIES_TABLE_NAME: &str = "time_series_table";
 
-/// Return protobuf message bytes containing metadata for a normal table and a time series table.
-pub fn table_metadata_protobuf_bytes() -> Vec<u8> {
-    let encoded_normal_table = modelardb_types::flight::encode_normal_table_metadata(
-        NORMAL_TABLE_NAME,
-        &normal_table_schema(),
-    )
-    .unwrap();
-
-    let encoded_time_series_table =
-        modelardb_types::flight::encode_time_series_table_metadata(&time_series_table_metadata())
-            .unwrap();
-
-    modelardb_types::flight::serialize_table_metadata(
-        vec![encoded_normal_table],
-        vec![encoded_time_series_table],
-    )
-}
-
 /// Return a [`Schema`] for a normal table with a timestamp column and two floating point columns.
 pub fn normal_table_schema() -> Schema {
     Schema::new(vec![

--- a/crates/modelardb_test/src/table.rs
+++ b/crates/modelardb_test/src/table.rs
@@ -39,6 +39,23 @@ pub const TIME_SERIES_TABLE_SQL: &str = "CREATE TIME SERIES TABLE time_series_ta
 /// Name of the time series table used in tests.
 pub const TIME_SERIES_TABLE_NAME: &str = "time_series_table";
 
+/// Return protobuf message bytes containing metadata for a normal table.
+pub fn normal_table_metadata_protobuf_bytes() -> Vec<u8> {
+    modelardb_types::flight::encode_and_serialize_normal_table_metadata(
+        NORMAL_TABLE_NAME,
+        &normal_table_schema(),
+    )
+    .unwrap()
+}
+
+/// Return protobuf message bytes containing metadata for a time series table.
+pub fn time_series_table_metadata_protobuf_bytes() -> Vec<u8> {
+    modelardb_types::flight::encode_and_serialize_time_series_table_metadata(
+        &time_series_table_metadata(),
+    )
+    .unwrap()
+}
+
 /// Return a [`Schema`] for a normal table with a timestamp column and two floating point columns.
 pub fn normal_table_schema() -> Schema {
     Schema::new(vec![

--- a/crates/modelardb_types/src/flight/mod.rs
+++ b/crates/modelardb_types/src/flight/mod.rs
@@ -118,7 +118,7 @@ pub fn encode_and_serialize_normal_table_metadata(
     let table_metadata = protocol::TableMetadata {
         table_metadata: Some(protocol::table_metadata::TableMetadata::NormalTable(
             protocol::table_metadata::NormalTableMetadata {
-                name: table_name.to_string(),
+                name: table_name.to_owned(),
                 schema: try_convert_schema_to_bytes(schema)?,
             },
         )),

--- a/crates/modelardb_types/src/flight/mod.rs
+++ b/crates/modelardb_types/src/flight/mod.rs
@@ -115,26 +115,16 @@ pub fn encode_and_serialize_normal_table_metadata(
     table_name: &str,
     schema: &Schema,
 ) -> Result<Vec<u8>> {
-    let normal_table_metadata = encode_normal_table_metadata(table_name, schema)?;
     let table_metadata = protocol::TableMetadata {
-        normal_tables: vec![normal_table_metadata],
-        time_series_tables: vec![],
+        table_metadata: Some(protocol::table_metadata::TableMetadata::NormalTable(
+            protocol::table_metadata::NormalTableMetadata {
+                name: table_name.to_string(),
+                schema: try_convert_schema_to_bytes(schema)?,
+            },
+        )),
     };
 
     Ok(table_metadata.encode_to_vec())
-}
-
-/// If `schema` can be converted to bytes, encode the normal table metadata into a
-/// [`NormalTableMetadata`](protocol::table_metadata::NormalTableMetadata) protobuf message,
-/// otherwise return [`ModelarDbTypesError`].
-pub fn encode_normal_table_metadata(
-    table_name: &str,
-    schema: &Schema,
-) -> Result<protocol::table_metadata::NormalTableMetadata> {
-    Ok(protocol::table_metadata::NormalTableMetadata {
-        name: table_name.to_string(),
-        schema: try_convert_schema_to_bytes(schema)?,
-    })
 }
 
 /// Encode the metadata for a time series table into a [`TableMetadata`](protocol::TableMetadata)

--- a/crates/modelardb_types/src/flight/mod.rs
+++ b/crates/modelardb_types/src/flight/mod.rs
@@ -108,19 +108,6 @@ pub fn decode_node_metadata(node_metadata: &protocol::NodeMetadata) -> Result<No
     Ok(Node::new(node_metadata.url.clone(), server_mode))
 }
 
-/// Serialize the table metadata into a [`TableMetadata`](protocol::TableMetadata) protobuf message.
-pub fn serialize_table_metadata(
-    normal_table_metadata: Vec<protocol::table_metadata::NormalTableMetadata>,
-    time_series_table_metadata: Vec<protocol::table_metadata::TimeSeriesTableMetadata>,
-) -> Vec<u8> {
-    let table_metadata = protocol::TableMetadata {
-        normal_tables: normal_table_metadata,
-        time_series_tables: time_series_table_metadata,
-    };
-
-    table_metadata.encode_to_vec()
-}
-
 /// Encode the metadata for a normal table into a [`TableMetadata`](protocol::TableMetadata)
 /// protobuf message and serialize it. If the schema cannot be converted to bytes, return
 /// [`ModelarDbTypesError`].

--- a/crates/modelardb_types/src/flight/protocol.proto
+++ b/crates/modelardb_types/src/flight/protocol.proto
@@ -58,40 +58,8 @@ message NodeMetadata {
   ServerMode server_mode = 2;
 }
 
-// Metadata for multiple normal tables and time series tables.
-message TableMetadata {
-  // Metadata for a normal table, including its name and schema.
-  message NormalTableMetadata {
-    string name = 1;
-    bytes schema = 2;
-  }
-
-  // Metadata for a time series table, including its name, schema, error bounds, and generated column expressions.
-  message TimeSeriesTableMetadata {
-    message ErrorBound {
-      enum Type {
-        ABSOLUTE = 0;
-        RELATIVE = 1;
-      }
-      Type type = 1;
-      float value = 2;
-    }
-
-    string name = 1;
-    bytes schema = 2;
-    repeated ErrorBound error_bounds = 3;
-    repeated bytes generated_column_expressions = 4;
-  }
-
-  // Normal tables included in the table metadata.
-  repeated NormalTableMetadata normal_tables = 1;
-
-  // Time series tables included in the table metadata.
-  repeated TimeSeriesTableMetadata time_series_tables = 2;
-}
-
 // Metadata for a normal table or a time series tables.
-message TableMetadataTemp {
+message TableMetadata {
   // Metadata for a normal table, including its name and schema.
   message NormalTableMetadata {
     string name = 1;

--- a/crates/modelardb_types/src/flight/protocol.proto
+++ b/crates/modelardb_types/src/flight/protocol.proto
@@ -58,7 +58,7 @@ message NodeMetadata {
   ServerMode server_mode = 2;
 }
 
-// Metadata for a normal table or a time series tables.
+// Metadata for a normal table or a time series table.
 message TableMetadata {
   // Metadata for a normal table, including its name and schema.
   message NormalTableMetadata {

--- a/crates/modelardb_types/src/flight/protocol.proto
+++ b/crates/modelardb_types/src/flight/protocol.proto
@@ -90,6 +90,38 @@ message TableMetadata {
   repeated TimeSeriesTableMetadata time_series_tables = 2;
 }
 
+// Metadata for a normal table or a time series tables.
+message TableMetadataTemp {
+  // Metadata for a normal table, including its name and schema.
+  message NormalTableMetadata {
+    string name = 1;
+    bytes schema = 2;
+  }
+
+  // Metadata for a time series table, including its name, schema, error bounds, and generated column expressions.
+  message TimeSeriesTableMetadata {
+    message ErrorBound {
+      enum Type {
+        ABSOLUTE = 0;
+        RELATIVE = 1;
+      }
+      Type type = 1;
+      float value = 2;
+    }
+
+    string name = 1;
+    bytes schema = 2;
+    repeated ErrorBound error_bounds = 3;
+    repeated bytes generated_column_expressions = 4;
+  }
+
+  // Either a normal table or a time series table.
+  oneof table_metadata {
+    NormalTableMetadata normal_table = 1;
+    TimeSeriesTableMetadata time_series_table = 2;
+  }
+}
+
 // Configuration of a ModelarDB node.
 message Configuration {
   // Amount of memory to reserve for storing multivariate time series.

--- a/crates/modelardb_types/src/flight/protocol.proto
+++ b/crates/modelardb_types/src/flight/protocol.proto
@@ -169,9 +169,3 @@ message UpdateConfiguration {
   // New value for the setting.
   optional uint64 new_value = 2;
 }
-
-// Metadata for a ModelarDB database instance.
-message DatabaseMetadata {
-  // Names of the tables in the database.
-  repeated string table_names = 1;
-}

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -58,6 +58,12 @@ pub struct QueryCompressedSchema(pub Arc<Schema>);
 #[derive(Clone)]
 pub struct GridSchema(pub Arc<Schema>);
 
+/// Types of tables supported by ModelarDB.
+pub enum Table {
+    NormalTable(String, Schema),
+    TimeSeriesTable(TimeSeriesTableMetadata),
+}
+
 /// Metadata required to ingest data into a time series table and query a time series table.
 #[derive(Debug, Clone)]
 pub struct TimeSeriesTableMetadata {


### PR DESCRIPTION
This PR implements https://github.com/ModelarData/ModelarDB-RS/issues/338 to make the API more consistent and to avoid issues with partial table creation. 

Since the old `TableMetadata` protobuf message was used for the response in `InitializeDatabase` as well, this PR also changes the start up flow for cluster nodes to no longer use `InitializeDatabase`. Now edge nodes use the remote data folder to initialize the local data folder with potentially missing tables. This change has already been discussed as part of the discussion on how to remove the manager. Therefore, it was determined that it was simpler to just do it now, instead of having to implement a temporary workaround.