### PR TITLE
Add support for setting retention period using RETAIN syntax

### DIFF
--- a/crates/modelardb_embedded/bindings/python/modelardb/operations.py
+++ b/crates/modelardb_embedded/bindings/python/modelardb/operations.py
@@ -191,7 +191,8 @@ class Operations:
             
             int modelardb_embedded_vacuum(void* maybe_operations_ptr,
                                           bool is_data_folder,
-                                          char* table_name_ptr);
+                                          char* table_name_ptr
+                                          char* retention_period_in_seconds_ptr);
 
             char* modelardb_embedded_error();
             """
@@ -728,16 +729,26 @@ class Operations:
         )
         self.__check_return_code_and_raise_error(return_code)
 
-    def vacuum(self, table_name: str):
+    def vacuum(self, table_name: str, retention_period_in_seconds: None | int = None):
         """Vacuum the table with `table_name`.
 
         :param table_name: The name of the table to vacuum.
         :type table_name: str
+        :param retention_period_in_seconds: The retention period in seconds. Data older than the retention
+        period is deleted. If `None`, the default retention period of 7 days is used.
+        :type retention_period_in_seconds: int, optional
         :raises ValueError: If incorrect arguments are provided.
         """
         table_name_ptr = ffi.new("char[]", bytes(table_name, "UTF-8"))
+
+        if retention_period_in_seconds:
+            # Convert the retention period to a string to simplify the type conversion.
+            retention_period_in_seconds_ptr = ffi.new("char[]", bytes(str(retention_period_in_seconds), "UTF-8"))
+        else:
+            retention_period_in_seconds_ptr = ffi.NULL
+
         return_code = self.__library.modelardb_embedded_vacuum(
-            self.__operations_ptr, self.__is_data_folder, table_name_ptr
+            self.__operations_ptr, self.__is_data_folder, table_name_ptr, retention_period_in_seconds_ptr
         )
         self.__check_return_code_and_raise_error(return_code)
 

--- a/crates/modelardb_embedded/bindings/python/modelardb/operations.py
+++ b/crates/modelardb_embedded/bindings/python/modelardb/operations.py
@@ -191,7 +191,7 @@ class Operations:
             
             int modelardb_embedded_vacuum(void* maybe_operations_ptr,
                                           bool is_data_folder,
-                                          char* table_name_ptr
+                                          char* table_name_ptr,
                                           char* retention_period_in_seconds_ptr);
 
             char* modelardb_embedded_error();
@@ -741,7 +741,7 @@ class Operations:
         """
         table_name_ptr = ffi.new("char[]", bytes(table_name, "UTF-8"))
 
-        if retention_period_in_seconds:
+        if retention_period_in_seconds is not None:
             # Convert the retention period to a string to simplify the type conversion.
             retention_period_in_seconds_ptr = ffi.new("char[]", bytes(str(retention_period_in_seconds), "UTF-8"))
         else:

--- a/crates/modelardb_embedded/bindings/python/modelardb/operations.py
+++ b/crates/modelardb_embedded/bindings/python/modelardb/operations.py
@@ -742,7 +742,9 @@ class Operations:
         table_name_ptr = ffi.new("char[]", bytes(table_name, "UTF-8"))
 
         if retention_period_in_seconds is not None:
-            # Convert the retention period to a string to simplify the type conversion.
+            # Convert the retention period to a string to avoid issues with converting an int to a C type that uses
+            # an inconsistent amount of bits across platforms and then converting that to a 64-bit integer in Rust.
+            # The string is converted directly to an unsigned 64-bit integer in Rust.
             retention_period_in_seconds_ptr = ffi.new("char[]", bytes(str(retention_period_in_seconds), "UTF-8"))
         else:
             retention_period_in_seconds_ptr = ffi.NULL

--- a/crates/modelardb_embedded/bindings/python/tests/test_operations.py
+++ b/crates/modelardb_embedded/bindings/python/tests/test_operations.py
@@ -439,8 +439,6 @@ class TestOperations(unittest.TestCase):
 
     def test_data_folder_vacuum(self):
         with TemporaryDirectory() as temp_dir:
-            os.environ["MODELARDBD_RETENTION_PERIOD_IN_SECONDS"] = "0"
-
             data_folder = Operations.open_local(temp_dir)
             create_tables_in_data_folder(data_folder)
 
@@ -452,7 +450,7 @@ class TestOperations(unittest.TestCase):
             file_count = len(os.listdir(folder_path))
             self.assertEqual(file_count, 1)
 
-            data_folder.vacuum(TIME_SERIES_TABLE_NAME)
+            data_folder.vacuum(TIME_SERIES_TABLE_NAME, retention_period_in_seconds=0)
 
             # No files should remain in the column folder.
             file_count = len(os.listdir(folder_path))

--- a/crates/modelardb_embedded/src/capi.rs
+++ b/crates/modelardb_embedded/src/capi.rs
@@ -933,10 +933,12 @@ unsafe fn drop(
 }
 
 /// Vacuums the table with the name in `table_name_ptr` in the [`DataFolder`] or [`Client`] in
-/// `maybe_operations_ptr` by deleting all files that are older than `retention_period_in_seconds_ptr`
+/// `maybe_operations_ptr` by deleting stale files that are older than `retention_period_in_seconds_ptr`
 /// seconds. Assumes `maybe_operations_ptr` points to a [`DataFolder`] or [`Client`];
 /// `table_name_ptr` points to a valid C string; and `retention_period_in_seconds_ptr` points to a
-/// valid C string.
+/// valid C string. A C string is used for the retention period to avoid issues with different
+/// platforms using an inconsistent amount of bits for integer types. The string is converted
+/// directly to an unsigned 64-bit integer in Rust.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn modelardb_embedded_vacuum(
     maybe_operations_ptr: *mut c_void,

--- a/crates/modelardb_embedded/src/capi.rs
+++ b/crates/modelardb_embedded/src/capi.rs
@@ -933,15 +933,25 @@ unsafe fn drop(
 }
 
 /// Vacuums the table with the name in `table_name_ptr` in the [`DataFolder`] or [`Client`] in
-/// `maybe_operations_ptr`. Assumes `maybe_operations_ptr` points to a [`DataFolder`] or [`Client`];
-/// and `table_name_ptr` points to a valid C string.
+/// `maybe_operations_ptr` by deleting all files that are older than `retention_period_in_seconds_ptr`
+/// seconds. Assumes `maybe_operations_ptr` points to a [`DataFolder`] or [`Client`];
+/// `table_name_ptr` points to a valid C string; and `retention_period_in_seconds_ptr` points to a
+/// valid C string.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn modelardb_embedded_vacuum(
     maybe_operations_ptr: *mut c_void,
     is_data_folder: bool,
     table_name_ptr: *const c_char,
+    retention_period_in_seconds_ptr: *const c_char,
 ) -> c_int {
-    let maybe_unit = unsafe { vacuum(maybe_operations_ptr, is_data_folder, table_name_ptr) };
+    let maybe_unit = unsafe {
+        vacuum(
+            maybe_operations_ptr,
+            is_data_folder,
+            table_name_ptr,
+            retention_period_in_seconds_ptr,
+        )
+    };
     set_error_and_return_code(maybe_unit)
 }
 
@@ -950,11 +960,26 @@ unsafe fn vacuum(
     maybe_operations_ptr: *mut c_void,
     is_data_folder: bool,
     table_name_ptr: *const c_char,
+    retention_period_in_seconds_ptr: *const c_char,
 ) -> Result<()> {
     let modelardb = unsafe { c_void_to_operations(maybe_operations_ptr, is_data_folder)? };
     let table_name = unsafe { c_char_ptr_to_str(table_name_ptr)? };
+    let maybe_retention_period_in_seconds_str =
+        unsafe { c_char_ptr_to_maybe_str(retention_period_in_seconds_ptr)? };
 
-    TOKIO_RUNTIME.block_on(modelardb.vacuum(table_name))
+    let maybe_retention_period_in_seconds = maybe_retention_period_in_seconds_str
+        .map(|retention_period_in_seconds_str| {
+            retention_period_in_seconds_str
+                .parse::<u64>()
+                .map_err(|error| {
+                    ModelarDbEmbeddedError::InvalidArgument(format!(
+                        "Retention period is not a valid u64: {error}"
+                    ))
+                })
+        })
+        .transpose()?;
+
+    TOKIO_RUNTIME.block_on(modelardb.vacuum(table_name, maybe_retention_period_in_seconds))
 }
 
 /// Return a read-only [`*const c_char`] with a human-readable representation of the last error the

--- a/crates/modelardb_embedded/src/operations/client.rs
+++ b/crates/modelardb_embedded/src/operations/client.rs
@@ -360,7 +360,9 @@ impl Operations for Client {
 
     /// Vacuum the table with the name in `table_name` by deleting stale files that are older than
     /// `maybe_retention_period_in_seconds` seconds. If a retention period is not given, the
-    /// default retention period of 7 days is used. If the table could not be vacuumed,
+    /// default retention period of 7 days is used. If the table does not exist, the table could
+    /// not be vacuumed, or the retention period is larger than
+    /// [`MAX_RETENTION_PERIOD_IN_SECONDS`](modelardb_types::types::MAX_RETENTION_PERIOD_IN_SECONDS),
     /// [`ModelarDbEmbeddedError`] is returned.
     async fn vacuum(
         &mut self,

--- a/crates/modelardb_embedded/src/operations/client.rs
+++ b/crates/modelardb_embedded/src/operations/client.rs
@@ -358,7 +358,7 @@ impl Operations for Client {
         Ok(())
     }
 
-    /// Vacuum the table with the name in `table_name` by deleting all files that are older than
+    /// Vacuum the table with the name in `table_name` by deleting stale files that are older than
     /// `maybe_retention_period_in_seconds` seconds. If a retention period is not given, the
     /// default retention period of 7 days is used. If the table could not be vacuumed,
     /// [`ModelarDbEmbeddedError`] is returned.

--- a/crates/modelardb_embedded/src/operations/data_folder.rs
+++ b/crates/modelardb_embedded/src/operations/data_folder.rs
@@ -854,8 +854,10 @@ impl Operations for DataFolder {
 
     /// Vacuum the table with the name in `table_name` by deleting stale files that are older than
     /// `maybe_retention_period_in_seconds` seconds. If a retention period is not given, the
-    /// default retention period of 7 days is used. If the table does not exist or the table could
-    /// not be vacuumed, [`ModelarDbEmbeddedError`] is returned.
+    /// default retention period of 7 days is used. If the table does not exist, the table could
+    /// not be vacuumed, or the retention period is larger than
+    /// [`MAX_RETENTION_PERIOD_IN_SECONDS`](modelardb_types::types::MAX_RETENTION_PERIOD_IN_SECONDS),
+    /// [`ModelarDbEmbeddedError`] is returned.
     async fn vacuum(
         &mut self,
         table_name: &str,

--- a/crates/modelardb_embedded/src/operations/data_folder.rs
+++ b/crates/modelardb_embedded/src/operations/data_folder.rs
@@ -852,7 +852,7 @@ impl Operations for DataFolder {
         Ok(())
     }
 
-    /// Vacuum the table with the name in `table_name` by deleting all files that are older than
+    /// Vacuum the table with the name in `table_name` by deleting stale files that are older than
     /// `maybe_retention_period_in_seconds` seconds. If a retention period is not given, the
     /// default retention period of 7 days is used. If the table does not exist or the table could
     /// not be vacuumed, [`ModelarDbEmbeddedError`] is returned.

--- a/crates/modelardb_embedded/src/operations/mod.rs
+++ b/crates/modelardb_embedded/src/operations/mod.rs
@@ -108,8 +108,14 @@ pub trait Operations: Sync + Send {
     /// Drop the table with the name in `table_name`.
     async fn drop(&mut self, table_name: &str) -> Result<()>;
 
-    /// Vacuum the table with the name in `table_name`.
-    async fn vacuum(&mut self, table_name: &str) -> Result<()>;
+    /// Vacuum the table with the name in `table_name` by deleting all files that are older than
+    /// `maybe_retention_period_in_seconds` seconds. If a retention period is not given, the
+    /// default retention period of 7 days is used.
+    async fn vacuum(
+        &mut self,
+        table_name: &str,
+        maybe_retention_period_in_seconds: Option<u64>,
+    ) -> Result<()>;
 }
 
 /// Use the time series table metadata in `table_name`, `schema`, `error_bounds`, and `generated_columns`

--- a/crates/modelardb_embedded/src/operations/mod.rs
+++ b/crates/modelardb_embedded/src/operations/mod.rs
@@ -108,7 +108,7 @@ pub trait Operations: Sync + Send {
     /// Drop the table with the name in `table_name`.
     async fn drop(&mut self, table_name: &str) -> Result<()>;
 
-    /// Vacuum the table with the name in `table_name` by deleting all files that are older than
+    /// Vacuum the table with the name in `table_name` by deleting stale files that are older than
     /// `maybe_retention_period_in_seconds` seconds. If a retention period is not given, the
     /// default retention period of 7 days is used.
     async fn vacuum(

--- a/crates/modelardb_manager/src/remote.rs
+++ b/crates/modelardb_manager/src/remote.rs
@@ -21,8 +21,8 @@ use std::error::Error;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::result::Result as StdResult;
+use std::str;
 use std::sync::Arc;
-use std::{env, str};
 
 use arrow::datatypes::Schema;
 use arrow::ipc::writer::IpcWriteOptions;
@@ -340,21 +340,18 @@ impl FlightServiceHandler {
     async fn vacuum_cluster_table(
         &self,
         table_name: &str,
-        maybe_retention_period: Option<u64>,
+        maybe_retention_period_in_seconds: Option<u64>,
     ) -> StdResult<(), Status> {
-        let retention_period_in_seconds = env::var("MODELARDBD_RETENTION_PERIOD_IN_SECONDS")
-            .map_or(60 * 60 * 24 * 7, |value| value.parse().unwrap());
-
         // Vacuum the table in the remote data folder Delta lake.
         self.context
             .remote_data_folder
             .delta_lake
-            .vacuum_table(table_name, retention_period_in_seconds)
+            .vacuum_table(table_name, maybe_retention_period_in_seconds)
             .await
             .map_err(error_to_status_internal)?;
 
         // Vacuum the table in the nodes controlled by the manager.
-        let vacuum_sql = if let Some(retention_period) = maybe_retention_period {
+        let vacuum_sql = if let Some(retention_period) = maybe_retention_period_in_seconds {
             format!("VACUUM {table_name} RETAIN {retention_period}")
         } else {
             format!("VACUUM {table_name}")
@@ -534,7 +531,7 @@ impl FlightService for FlightServiceHandler {
                     self.drop_cluster_table(&table_name).await?;
                 }
             }
-            ModelarDbStatement::Vacuum(mut table_names, maybe_retention_period) => {
+            ModelarDbStatement::Vacuum(mut table_names, maybe_retention_period_in_seconds) => {
                 // Vacuum all tables if no table names are provided.
                 if table_names.is_empty() {
                     table_names = self
@@ -548,7 +545,7 @@ impl FlightService for FlightServiceHandler {
                 }
 
                 for table_name in table_names {
-                    self.vacuum_cluster_table(&table_name, maybe_retention_period)
+                    self.vacuum_cluster_table(&table_name, maybe_retention_period_in_seconds)
                         .await?;
                 }
             }

--- a/crates/modelardb_server/src/configuration.rs
+++ b/crates/modelardb_server/src/configuration.rs
@@ -45,8 +45,6 @@ pub struct ConfigurationManager {
     /// The number of seconds between each transfer of data to the remote object store. If [`None`],
     /// data is not transferred based on time.
     transfer_time_in_seconds: Option<usize>,
-    /// The number of seconds to retain deleted data in storage before it can be removed by vacuum.
-    retention_period_in_seconds: usize,
     /// Number of threads to allocate for converting multivariate time series to univariate
     /// time series.
     pub(crate) ingestion_threads: usize,
@@ -76,9 +74,6 @@ impl ConfigurationManager {
         let transfer_time_in_seconds = env::var("MODELARDBD_TRANSFER_TIME_IN_SECONDS")
             .map_or(None, |value| Some(value.parse().unwrap()));
 
-        let retention_period_in_seconds = env::var("MODELARDBD_RETENTION_PERIOD_IN_SECONDS")
-            .map_or(60 * 60 * 24 * 7, |value| value.parse().unwrap());
-
         Self {
             cluster_mode,
             multivariate_reserved_memory_in_bytes,
@@ -86,7 +81,6 @@ impl ConfigurationManager {
             compressed_reserved_memory_in_bytes,
             transfer_batch_size_in_bytes,
             transfer_time_in_seconds,
-            retention_period_in_seconds,
             // TODO: Add support for running multiple threads per component. The individual
             // components in the storage engine have not been validated with multiple threads, e.g.,
             // UncompressedDataManager may have race conditions finishing buffers if multiple
@@ -223,18 +217,6 @@ impl ConfigurationManager {
         Ok(())
     }
 
-    pub(crate) fn retention_period_in_seconds(&self) -> usize {
-        self.retention_period_in_seconds
-    }
-
-    /// Set the new value for the retention period in seconds.
-    pub(crate) fn set_retention_period_in_seconds(
-        &mut self,
-        new_retention_period_in_seconds: usize,
-    ) {
-        self.retention_period_in_seconds = new_retention_period_in_seconds;
-    }
-
     /// Encode the current configuration into a [`Configuration`](protocol::Configuration)
     /// protobuf message and serialize it.
     pub(crate) fn encode_and_serialize(&self) -> Vec<u8> {
@@ -246,7 +228,6 @@ impl ConfigurationManager {
             compressed_reserved_memory_in_bytes: self.compressed_reserved_memory_in_bytes as u64,
             transfer_batch_size_in_bytes: self.transfer_batch_size_in_bytes.map(|v| v as u64),
             transfer_time_in_seconds: self.transfer_time_in_seconds.map(|v| v as u64),
-            retention_period_in_seconds: self.retention_period_in_seconds as u64,
             ingestion_threads: self.ingestion_threads as u32,
             compression_threads: self.compression_threads as u32,
             writer_threads: self.writer_threads as u32,
@@ -417,34 +398,6 @@ mod tests {
                 .read()
                 .await
                 .transfer_time_in_seconds(),
-            new_value
-        );
-    }
-
-    #[tokio::test]
-    async fn test_set_retention_period_in_seconds() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let (_, configuration_manager) = create_components(&temp_dir).await;
-
-        assert_eq!(
-            configuration_manager
-                .read()
-                .await
-                .retention_period_in_seconds(),
-            60 * 60 * 24 * 7
-        );
-
-        let new_value = 60;
-        configuration_manager
-            .write()
-            .await
-            .set_retention_period_in_seconds(new_value);
-
-        assert_eq!(
-            configuration_manager
-                .read()
-                .await
-                .retention_period_in_seconds(),
             new_value
         );
     }

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -332,8 +332,9 @@ impl Context {
     }
 
     /// Vacuum the table with `table_name` if it exists. If a retention period is not given, the
-    /// default retention period of 7 days is used. If the retention period is larger than i64::MAX
-    /// milliseconds, the table does not exist, or if it could not be vacuumed,
+    /// default retention period of 7 days is used. If the retention period is larger than
+    /// [`MAX_RETENTION_PERIOD_IN_SECONDS`](modelardb_types::types::MAX_RETENTION_PERIOD_IN_SECONDS)
+    /// seconds, the table does not exist, or if it could not be vacuumed,
     /// [`ModelarDbServerError`] is returned.
     pub async fn vacuum_table(
         &self,

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -426,6 +426,7 @@ mod tests {
     use super::*;
 
     use modelardb_test::table::{self, NORMAL_TABLE_NAME, TIME_SERIES_TABLE_NAME};
+    use modelardb_types::types::MAX_RETENTION_PERIOD_IN_SECONDS;
     use tempfile::TempDir;
 
     use crate::data_folders::DataFolder;
@@ -834,10 +835,12 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context_with_time_series_table(&temp_dir).await;
 
-        let retention_period_in_seconds = (i64::MAX / 1000 + 1) as u64;
         assert!(
             context
-                .vacuum_table(TIME_SERIES_TABLE_NAME, Some(retention_period_in_seconds))
+                .vacuum_table(
+                    TIME_SERIES_TABLE_NAME,
+                    Some(MAX_RETENTION_PERIOD_IN_SECONDS + 1)
+                )
                 .await
                 .is_err()
         );

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -516,7 +516,7 @@ impl FlightService for FlightServiceHandler {
 
                 Ok(empty_record_batch_stream())
             }
-            ModelarDbStatement::Vacuum(mut table_names, maybe_retention_period) => {
+            ModelarDbStatement::Vacuum(mut table_names, maybe_retention_period_in_seconds) => {
                 // Vacuum all tables if no table names are provided.
                 if table_names.is_empty() {
                     table_names = self
@@ -528,7 +528,7 @@ impl FlightService for FlightServiceHandler {
 
                 for table_name in table_names {
                     self.context
-                        .vacuum_table(&table_name)
+                        .vacuum_table(&table_name, maybe_retention_period_in_seconds)
                         .await
                         .map_err(error_to_status_invalid_argument)?;
                 }

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -770,13 +770,6 @@ impl FlightService for FlightServiceHandler {
                         .await
                         .map_err(error_to_status_internal)
                 }
-                Ok(protocol::update_configuration::Setting::RetentionPeriodInSeconds) => {
-                    let new_value = new_value.ok_or(invalid_null_error)?;
-
-                    configuration_manager.set_retention_period_in_seconds(new_value);
-
-                    Ok(())
-                }
                 _ => Err(Status::unimplemented(format!(
                     "{setting} is not an updatable setting in the server configuration."
                 ))),

--- a/crates/modelardb_server/src/remote.rs
+++ b/crates/modelardb_server/src/remote.rs
@@ -516,7 +516,7 @@ impl FlightService for FlightServiceHandler {
 
                 Ok(empty_record_batch_stream())
             }
-            ModelarDbStatement::Vacuum(mut table_names) => {
+            ModelarDbStatement::Vacuum(mut table_names, maybe_retention_period) => {
                 // Vacuum all tables if no table names are provided.
                 if table_names.is_empty() {
                     table_names = self

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -1273,7 +1273,6 @@ async fn test_can_get_configuration() {
         Some(64 * 1024 * 1024)
     );
     assert_eq!(configuration.transfer_time_in_seconds, None);
-    assert_eq!(configuration.retention_period_in_seconds, 60 * 60 * 24 * 7);
     assert_eq!(configuration.ingestion_threads, 1);
     assert_eq!(configuration.compression_threads, 1);
     assert_eq!(configuration.writer_threads, 1);
@@ -1313,16 +1312,6 @@ async fn test_can_update_compressed_reserved_memory_in_bytes() {
     .await;
 
     assert_eq!(updated_configuration.compressed_reserved_memory_in_bytes, 1);
-}
-
-#[tokio::test]
-async fn test_can_update_retention_period_in_seconds() {
-    let updated_configuration = update_and_get_configuration(
-        protocol::update_configuration::Setting::RetentionPeriodInSeconds as i32,
-    )
-    .await;
-
-    assert_eq!(updated_configuration.retention_period_in_seconds, 1);
 }
 
 async fn update_and_get_configuration(setting: i32) -> protocol::Configuration {
@@ -1376,7 +1365,6 @@ async fn test_cannot_update_non_nullable_setting_with_null_value() {
         protocol::update_configuration::Setting::MultivariateReservedMemoryInBytes as i32,
         protocol::update_configuration::Setting::UncompressedReservedMemoryInBytes as i32,
         protocol::update_configuration::Setting::CompressedReservedMemoryInBytes as i32,
-        protocol::update_configuration::Setting::RetentionPeriodInSeconds as i32,
     ] {
         update_configuration_and_assert_error(
             setting,

--- a/crates/modelardb_storage/src/delta_lake.rs
+++ b/crates/modelardb_storage/src/delta_lake.rs
@@ -468,8 +468,9 @@ impl DeltaLake {
 
     /// Vacuum the Delta Lake table with `table_name` by deleting all files that are older than
     /// `maybe_retention_period_in_seconds` seconds. If a retention period is not given, the
-    /// default retention period of 7 days is used. If the retention period is larger than i64::MAX
-    /// milliseconds or the files could not be deleted, a [`ModelarDbStorageError`] is returned.
+    /// default retention period of 7 days is used. If the retention period is larger than
+    /// [`MAX_RETENTION_PERIOD_IN_SECONDS`] seconds or the files could not be deleted, a
+    /// [`ModelarDbStorageError`] is returned.
     pub async fn vacuum_table(
         &self,
         table_name: &str,

--- a/crates/modelardb_storage/src/delta_lake.rs
+++ b/crates/modelardb_storage/src/delta_lake.rs
@@ -483,7 +483,7 @@ impl DeltaLake {
 
         let retention_period = TimeDelta::new(retention_period_in_seconds as i64, 0).ok_or(
             ModelarDbStorageError::InvalidArgument(format!(
-                "Retention period in seconds cannot be more than {MAX_RETENTION_PERIOD_IN_SECONDS} seconds."
+                "Retention period cannot be more than {MAX_RETENTION_PERIOD_IN_SECONDS} seconds."
             )),
         )?;
 

--- a/crates/modelardb_storage/src/delta_lake.rs
+++ b/crates/modelardb_storage/src/delta_lake.rs
@@ -37,7 +37,7 @@ use deltalake::{DeltaOps, DeltaTable, DeltaTableError};
 use futures::{StreamExt, TryStreamExt};
 use modelardb_types::flight::protocol;
 use modelardb_types::schemas::{COMPRESSED_SCHEMA, FIELD_COLUMN};
-use modelardb_types::types::TimeSeriesTableMetadata;
+use modelardb_types::types::{MAX_RETENTION_PERIOD_IN_SECONDS, TimeSeriesTableMetadata};
 use object_store::ObjectStore;
 use object_store::aws::AmazonS3Builder;
 use object_store::local::LocalFileSystem;
@@ -480,10 +480,9 @@ impl DeltaLake {
         let retention_period_in_seconds =
             maybe_retention_period_in_seconds.unwrap_or(60 * 60 * 24 * 7);
 
-        let max_retention_period_in_seconds = i64::MAX / 1000;
         let retention_period = TimeDelta::new(retention_period_in_seconds as i64, 0).ok_or(
             ModelarDbStorageError::InvalidArgument(format!(
-                "Retention period in seconds cannot be more than {max_retention_period_in_seconds} seconds."
+                "Retention period in seconds cannot be more than {MAX_RETENTION_PERIOD_IN_SECONDS} seconds."
             )),
         )?;
 

--- a/crates/modelardb_storage/src/delta_lake.rs
+++ b/crates/modelardb_storage/src/delta_lake.rs
@@ -467,18 +467,21 @@ impl DeltaLake {
     }
 
     /// Vacuum the Delta Lake table with `table_name` by deleting all files that are older than
-    /// `retention_period_in_seconds` seconds. If the retention period is out of bounds or the
-    /// files could not be deleted, a [`ModelarDbStorageError`] is returned.
+    /// `maybe_retention_period_in_seconds` seconds. If a retention period is not given, the
+    /// default retention period of 7 days is used. If the retention period is larger than i64::MAX
+    /// milliseconds or the files could not be deleted, a [`ModelarDbStorageError`] is returned.
     pub async fn vacuum_table(
         &self,
         table_name: &str,
-        retention_period_in_seconds: usize,
+        maybe_retention_period_in_seconds: Option<i64>,
     ) -> Result<()> {
         let delta_table_ops = self.delta_ops(table_name).await?;
 
-        let retention_period = TimeDelta::new(retention_period_in_seconds as i64, 0).ok_or(
+        let retention_period_in_seconds =
+            maybe_retention_period_in_seconds.unwrap_or(60 * 60 * 24 * 7);
+        let retention_period = TimeDelta::new(retention_period_in_seconds, 0).ok_or(
             ModelarDbStorageError::InvalidArgument(format!(
-                "Retention period of {retention_period_in_seconds} seconds is out of bounds."
+                "Retention period of {retention_period_in_seconds} seconds is larger than i64::MAX milliseconds."
             )),
         )?;
 

--- a/crates/modelardb_storage/src/delta_lake.rs
+++ b/crates/modelardb_storage/src/delta_lake.rs
@@ -479,9 +479,11 @@ impl DeltaLake {
 
         let retention_period_in_seconds =
             maybe_retention_period_in_seconds.unwrap_or(60 * 60 * 24 * 7);
+
+        let max_retention_period_in_seconds = i64::MAX / 1000;
         let retention_period = TimeDelta::new(retention_period_in_seconds as i64, 0).ok_or(
             ModelarDbStorageError::InvalidArgument(format!(
-                "Retention period of {retention_period_in_seconds} seconds is larger than i64::MAX milliseconds."
+                "Retention period in seconds cannot be more than {max_retention_period_in_seconds} seconds."
             )),
         )?;
 

--- a/crates/modelardb_storage/src/delta_lake.rs
+++ b/crates/modelardb_storage/src/delta_lake.rs
@@ -466,7 +466,7 @@ impl DeltaLake {
         Ok(())
     }
 
-    /// Vacuum the Delta Lake table with `table_name` by deleting all files that are older than
+    /// Vacuum the Delta Lake table with `table_name` by deleting stale files that are older than
     /// `maybe_retention_period_in_seconds` seconds. If a retention period is not given, the
     /// default retention period of 7 days is used. If the retention period is larger than
     /// [`MAX_RETENTION_PERIOD_IN_SECONDS`] seconds or the files could not be deleted, a

--- a/crates/modelardb_storage/src/delta_lake.rs
+++ b/crates/modelardb_storage/src/delta_lake.rs
@@ -473,13 +473,13 @@ impl DeltaLake {
     pub async fn vacuum_table(
         &self,
         table_name: &str,
-        maybe_retention_period_in_seconds: Option<i64>,
+        maybe_retention_period_in_seconds: Option<u64>,
     ) -> Result<()> {
         let delta_table_ops = self.delta_ops(table_name).await?;
 
         let retention_period_in_seconds =
             maybe_retention_period_in_seconds.unwrap_or(60 * 60 * 24 * 7);
-        let retention_period = TimeDelta::new(retention_period_in_seconds, 0).ok_or(
+        let retention_period = TimeDelta::new(retention_period_in_seconds as i64, 0).ok_or(
             ModelarDbStorageError::InvalidArgument(format!(
                 "Retention period of {retention_period_in_seconds} seconds is larger than i64::MAX milliseconds."
             )),

--- a/crates/modelardb_storage/src/parser.rs
+++ b/crates/modelardb_storage/src/parser.rs
@@ -504,7 +504,7 @@ impl ModelarDbDialect {
     /// field. Note that [`Statement::NOTIFY`] is used since [`Statement`] does not have a `Vacuum`
     /// variant. A [`ParserError`] is returned if VACUUM is not the first word, the table names
     /// cannot be extracted, or the retention period is not a valid positive integer that is at
-    /// most i64::MAX milliseconds.
+    /// most [`MAX_RETENTION_PERIOD_IN_SECONDS`] seconds.
     fn parse_vacuum(&self, parser: &mut Parser) -> StdResult<Statement, ParserError> {
         // VACUUM.
         parser.expect_keyword(Keyword::VACUUM)?;

--- a/crates/modelardb_storage/src/parser.rs
+++ b/crates/modelardb_storage/src/parser.rs
@@ -540,7 +540,7 @@ impl ModelarDbDialect {
 
             if retention_period_in_seconds > MAX_RETENTION_PERIOD_IN_SECONDS {
                 return Err(ParserError::ParserError(format!(
-                    "Retention period in seconds cannot be more than {MAX_RETENTION_PERIOD_IN_SECONDS} seconds."
+                    "Retention period cannot be more than {MAX_RETENTION_PERIOD_IN_SECONDS} seconds."
                 )));
             }
 

--- a/crates/modelardb_storage/src/parser.rs
+++ b/crates/modelardb_storage/src/parser.rs
@@ -507,7 +507,12 @@ impl ModelarDbDialect {
 
         let mut table_names = vec![];
 
-        if Token::EOF != parser.peek_nth_token(0).token {
+
+        // If the next token is not EOF or RETAIN, attempt to parse table names.
+        if Token::EOF != parser.peek_nth_token(0).token
+            && let Token::Word(word) = parser.peek_nth_token(0).token
+            && word.keyword != Keyword::RETAIN
+        {
             loop {
                 match self.parse_word_value(parser) {
                     Ok(table_name) => {

--- a/crates/modelardb_storage/src/parser.rs
+++ b/crates/modelardb_storage/src/parser.rs
@@ -502,7 +502,8 @@ impl ModelarDbDialect {
     /// with the table names in the `channel` field and the optional retention period in the `payload`
     /// field. Note that [`Statement::NOTIFY`] is used since [`Statement`] does not have a `Vacuum`
     /// variant. A [`ParserError`] is returned if VACUUM is not the first word, the table names
-    /// cannot be extracted, or the retention period is not a valid positive integer.
+    /// cannot be extracted, or the retention period is not a valid positive integer that is at
+    /// most i64::MAX milliseconds.
     fn parse_vacuum(&self, parser: &mut Parser) -> StdResult<Statement, ParserError> {
         // VACUUM.
         parser.expect_keyword(Keyword::VACUUM)?;
@@ -534,7 +535,16 @@ impl ModelarDbDialect {
             && word.keyword == Keyword::RETAIN
         {
             parser.expect_keyword(Keyword::RETAIN)?;
-            Some(self.parse_unsigned_literal_u64(parser)?)
+            let retention_period_in_seconds = self.parse_unsigned_literal_u64(parser)?;
+
+            let max_retention_period_in_seconds = (i64::MAX / 1000) as u64;
+            if retention_period_in_seconds > max_retention_period_in_seconds {
+                return Err(ParserError::ParserError(format!(
+                    "Retention period in seconds cannot be more than {max_retention_period_in_seconds} seconds."
+                )));
+            }
+
+            Some(retention_period_in_seconds)
         } else {
             None
         };
@@ -1798,8 +1808,8 @@ mod tests {
     }
 
     #[test]
-    fn test_tokenize_and_parse_vacuum_retain_with_u64_max_plus_one() {
-        let max_plus_one = u64::MAX as u128 + 1;
+    fn test_tokenize_and_parse_vacuum_retain_with_max_plus_one() {
+        let max_plus_one = (i64::MAX / 1000) + 1;
         assert!(
             tokenize_and_parse_sql_statement(&format!("VACUUM RETAIN {}", max_plus_one)).is_err()
         );

--- a/crates/modelardb_storage/src/parser.rs
+++ b/crates/modelardb_storage/src/parser.rs
@@ -1804,12 +1804,12 @@ mod tests {
 
     #[test]
     fn test_tokenize_and_parse_vacuum_retain_with_negative() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM RETAIN -5").is_err());
+        assert!(tokenize_and_parse_sql_statement("VACUUM RETAIN -30").is_err());
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_retain_with_max_plus_one() {
-        let max_plus_one = (i64::MAX / 1000) + 1;
+        let max_plus_one = i64::MAX / 1000 + 1;
         assert!(
             tokenize_and_parse_sql_statement(&format!("VACUUM RETAIN {}", max_plus_one)).is_err()
         );

--- a/crates/modelardb_types/src/flight/protocol.proto
+++ b/crates/modelardb_types/src/flight/protocol.proto
@@ -107,17 +107,14 @@ message Configuration {
   // The number of seconds between each transfer of data to the remote object store.
   optional uint64 transfer_time_in_seconds = 5;
 
-  // The number of seconds to retain deleted data in storage before it can be removed by vacuum.
-  uint64 retention_period_in_seconds = 6;
-
   // Number of threads to allocate for converting multivariate time series to univariate time series.
-  uint32 ingestion_threads = 7;
+  uint32 ingestion_threads = 6;
 
   // Number of threads to allocate for compressing univariate time series to segments.
-  uint32 compression_threads = 8;
+  uint32 compression_threads = 7;
 
   // Number of threads to allocate for writing segments to a local and/or remote data folder.
-  uint32 writer_threads = 9;
+  uint32 writer_threads = 8;
 }
 
 // Request to update the configuration of a ModelarDB node.
@@ -128,7 +125,6 @@ message UpdateConfiguration {
     COMPRESSED_RESERVED_MEMORY_IN_BYTES = 2;
     TRANSFER_BATCH_SIZE_IN_BYTES = 3;
     TRANSFER_TIME_IN_SECONDS = 4;
-    RETENTION_PERIOD_IN_SECONDS = 5;
   }
 
   // Setting to update in the configuration.

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -59,7 +59,7 @@ pub struct QueryCompressedSchema(pub Arc<Schema>);
 pub struct GridSchema(pub Arc<Schema>);
 
 /// Maximum period in seconds that data can be retained in ModelarDB before it is deleted by a
-/// VACUUM operation. The period is equal to the maximum value of an i64 in milliseconds,
+/// VACUUM operation. The period is equal to the maximum value of an i64 in milliseconds.
 pub const MAX_RETENTION_PERIOD_IN_SECONDS: u64 = (i64::MAX / 1000) as u64;
 
 /// Types of tables supported by ModelarDB.

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -58,6 +58,10 @@ pub struct QueryCompressedSchema(pub Arc<Schema>);
 #[derive(Clone)]
 pub struct GridSchema(pub Arc<Schema>);
 
+/// Maximum period in seconds that data can be retained in ModelarDB before it is deleted by a
+/// VACUUM operation. The period is equal to the maximum value of an i64 in milliseconds,
+pub const MAX_RETENTION_PERIOD_IN_SECONDS: u64 = (i64::MAX / 1000) as u64;
+
 /// Types of tables supported by ModelarDB.
 pub enum Table {
     NormalTable(String, Schema),

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -60,6 +60,8 @@ pub struct GridSchema(pub Arc<Schema>);
 
 /// Maximum period in seconds that data can be retained in ModelarDB before it is deleted by a
 /// VACUUM operation. The period is equal to the maximum value of an i64 in milliseconds.
+/// The limitation is imposed by the use of `chrono::TimeDelta` when vacuuming data, which uses
+/// an i64 internally to represent time in milliseconds.
 pub const MAX_RETENTION_PERIOD_IN_SECONDS: u64 = (i64::MAX / 1000) as u64;
 
 /// Types of tables supported by ModelarDB.


### PR DESCRIPTION
Closes #343 by changing the parser to support the syntax `VACUUM table_name RETAIN num_seconds`. Note that `RETAIN` is optional. 

The PR also removes the previous method for setting the retention period which was through the environment variable `MODELARDBD_RETENTION_PERIOD_IN_SECONDS` and the configuration `retention_period_in_seconds`. This method was removed to avoid confusion between the two ways to set the retention period and since the setting was also only supposed to be used in the server (modelardbd). It could have been kept in the server but this might cause confusion on how it is handled in the manager and `Operations` API.