### PR TITLE
Fix bug making it possible to start a server with an inconsistent database schema

### DIFF
--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -189,7 +189,8 @@ async fn validate_local_tables_exist_remotely(
 
     if !invalid_tables.is_empty() {
         return Err(ModelarDbServerError::InvalidState(format!(
-            "The following tables do not exist in the remote data folder: {invalid_tables:?}.",
+            "The following tables do not exist in the remote data folder: {}.",
+            invalid_tables.join(", ")
         )));
     }
 
@@ -218,7 +219,7 @@ async fn validate_normal_tables(
             if remote_schema != local_schema {
                 return Err(ModelarDbServerError::InvalidState(format!(
                     "The normal table '{table_name}' has a different schema in the local data \
-                    folder than in the remote data folder.",
+                    folder compared to the remote data folder.",
                 )));
             }
         } else {
@@ -265,7 +266,7 @@ async fn validate_time_series_tables(
             if remote_metadata != local_metadata {
                 return Err(ModelarDbServerError::InvalidState(format!(
                     "The time series table '{table_name}' has different metadata in the local data \
-                    folder than in the remote data folder.",
+                    folder compared to the remote data folder.",
                 )));
             }
         } else {

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -197,10 +197,10 @@ async fn validate_local_tables_exist_remotely(
     Ok(())
 }
 
-/// Validate that all normal tables in the local data folder exist in the remote data folder and have
-/// the same schema. If all normal tables are valid, return a vector of tuples containing the
-/// table name and schema of each normal table that is in the remote data folder but not in the local
-/// data folder. If any normal table is invalid, return [`ModelarDbServerError`].
+/// For each normal table in the remote data folder, if the table also exists in the local data
+/// folder, validate that the schemas are identical. If the schemas are not identical, return
+/// [`ModelarDbServerError`]. Return a vector containing the name and schema of each normal table
+/// that is in the remote data folder but not in the local data folder.
 async fn validate_normal_tables(
     local_data_folder: &DataFolder,
     remote_data_folder: &DataFolder,
@@ -237,10 +237,10 @@ async fn normal_table_schema(data_folder: &DataFolder, table_name: &str) -> Resu
     Ok(TableProvider::schema(&delta_table))
 }
 
-/// Validate that all time series tables in the local data folder exist in the remote data folder
-/// and have the same metadata. If all time series tables are valid, return a vector containing
-/// the metadata of each time series table that is in the remote data folder but not in the local
-/// data folder. If any time series table is invalid, return [`ModelarDbServerError`].
+/// For each time series table in the remote data folder, if the table also exists in the local
+/// data folder, validate that the metadata is identical. If the metadata is not identical, return
+/// [`ModelarDbServerError`]. Return a vector containing the metadata of each time series table
+/// that is in the remote data folder but not in the local data folder.
 async fn validate_time_series_tables(
     local_data_folder: &DataFolder,
     remote_data_folder: &DataFolder,

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -35,7 +35,7 @@ use crate::context::Context;
 use crate::error::{ModelarDbServerError, Result};
 
 /// Manages metadata related to the manager and provides functionality for interacting with the manager.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Manager {
     /// Key received from the manager when registering, used to validate future requests that are
     /// only allowed to come from the manager.
@@ -187,15 +187,6 @@ async fn do_action_and_extract_result(
             action.r#type
         ))
     })
-}
-
-/// Partial equality is implemented so PartialEq can be derived for [`ClusterMode`](crate::ClusterMode).
-/// It cannot be derived for [`Manager`] since both `flight_client` and `table_metadata_manager`
-/// does not support equality comparisons.
-impl PartialEq for Manager {
-    fn eq(&self, other: &Self) -> bool {
-        self.key == other.key
-    }
 }
 
 #[cfg(test)]

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -65,7 +65,7 @@ pub enum Table {
 }
 
 /// Metadata required to ingest data into a time series table and query a time series table.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TimeSeriesTableMetadata {
     /// Name of the time series table.
     pub name: String,


### PR DESCRIPTION
Closes #347 by changing the start up process for server nodes to check that the tables are identical if they have the same name. Previously we only checked the name which meant it was possible to start a server node with a table that was inconsistent with the cluster database schema.

Note that we purposely wait to create any tables until we have checked the local tables to ensure we do not create any tables before we know the local database is valid.

Currently we just return an error if there are tables in the local database that does not exist in the remote database. When reviewing, please consider whether we should change it so we just drop the local table instead.