### PR TITLE
Add lossless error bound enum variant 

### DIFF
--- a/crates/modelardb_compression/src/compression.rs
+++ b/crates/modelardb_compression/src/compression.rs
@@ -265,7 +265,7 @@ mod tests {
     use arrow::array::{ArrayBuilder, BinaryArray, Float32Array, Int8Array};
     use arrow::datatypes::{DataType, Field};
     use modelardb_test::data_generation::{self, ValuesStructure};
-    use modelardb_test::{ERROR_BOUND_FIVE, ERROR_BOUND_ZERO};
+    use modelardb_test::ERROR_BOUND_FIVE;
     use modelardb_types::schemas::COMPRESSED_SCHEMA;
     use modelardb_types::types::{TimestampBuilder, ValueBuilder};
 
@@ -277,11 +277,11 @@ mod tests {
 
     // Tests for try_compress().
     #[test]
-    fn test_try_compress_empty_time_series_within_absolute_error_bound_zero() {
+    fn test_try_compress_empty_time_series_within_lossless_error_bound() {
         let compressed_record_batch = try_compress(
             &TimestampBuilder::new().finish(),
             &ValueBuilder::new().finish(),
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             compressed_schema(),
             vec![TAG_VALUE.to_owned()],
             0,
@@ -291,55 +291,21 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_empty_time_series_within_relative_error_bound_zero() {
-        let compressed_record_batch = try_compress(
-            &TimestampBuilder::new().finish(),
-            &ValueBuilder::new().finish(),
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            compressed_schema(),
-            vec![TAG_VALUE.to_owned()],
-            0,
-        )
-        .unwrap();
-        assert_eq!(0, compressed_record_batch.num_rows());
-    }
-
-    #[test]
-    fn test_try_compress_regular_constant_time_series_within_absolute_error_bound_zero() {
+    fn test_try_compress_regular_constant_time_series_within_lossless_error_bound() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::Constant(None),
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             &[models::PMC_MEAN_ID],
         );
     }
 
     #[test]
-    fn test_try_compress_regular_constant_time_series_within_relative_error_bound_zero() {
-        generate_compress_and_assert_known_segment(
-            false,
-            ValuesStructure::Constant(None),
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            &[models::PMC_MEAN_ID],
-        );
-    }
-
-    #[test]
-    fn test_try_compress_irregular_constant_time_series_within_absolute_error_bound_zero() {
+    fn test_try_compress_irregular_constant_time_series_within_lossless_error_bound() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::Constant(None),
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            &[models::PMC_MEAN_ID],
-        );
-    }
-
-    #[test]
-    fn test_try_compress_irregular_constant_time_series_within_relative_error_bound_zero() {
-        generate_compress_and_assert_known_segment(
-            true,
-            ValuesStructure::Constant(None),
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             &[models::PMC_MEAN_ID],
         );
     }
@@ -385,41 +351,21 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_linear_time_series_within_absolute_error_bound_zero() {
+    fn test_try_compress_regular_linear_time_series_within_lossless_error_bound() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::Linear(None),
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             &[models::SWING_ID],
         );
     }
 
     #[test]
-    fn test_try_compress_regular_linear_time_series_within_relative_error_bound_zero() {
-        generate_compress_and_assert_known_segment(
-            false,
-            ValuesStructure::Linear(None),
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            &[models::SWING_ID],
-        );
-    }
-
-    #[test]
-    fn test_try_compress_irregular_linear_time_series_within_absolute_error_bound_zero() {
+    fn test_try_compress_irregular_linear_time_series_within_lossless_error_bound() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::Linear(None),
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            &[models::SWING_ID],
-        );
-    }
-
-    #[test]
-    fn test_try_compress_irregular_linear_time_series_within_relative_error_bound_zero() {
-        generate_compress_and_assert_known_segment(
-            true,
-            ValuesStructure::Linear(None),
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             &[models::SWING_ID],
         );
     }
@@ -465,41 +411,21 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_random_time_series_within_absolute_error_bound_zero() {
+    fn test_try_compress_regular_random_time_series_within_lossless_error_bound() {
         generate_compress_and_assert_known_segment(
             false,
             ValuesStructure::largest_random_without_overflow(),
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             &[models::MACAQUE_V_ID],
         );
     }
 
     #[test]
-    fn test_try_compress_regular_random_time_series_within_relative_error_bound_zero() {
-        generate_compress_and_assert_known_segment(
-            false,
-            ValuesStructure::largest_random_without_overflow(),
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            &[models::MACAQUE_V_ID],
-        );
-    }
-
-    #[test]
-    fn test_try_compress_irregular_random_time_series_within_absolute_error_bound_zero() {
+    fn test_try_compress_irregular_random_time_series_within_lossless_error_bound() {
         generate_compress_and_assert_known_segment(
             true,
             ValuesStructure::largest_random_without_overflow(),
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            &[models::MACAQUE_V_ID],
-        );
-    }
-
-    #[test]
-    fn test_try_compress_irregular_random_time_series_within_relative_error_bound_zero() {
-        generate_compress_and_assert_known_segment(
-            true,
-            ValuesStructure::largest_random_without_overflow(),
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             &[models::MACAQUE_V_ID],
         );
     }
@@ -534,10 +460,10 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_random_linear_constant_time_series_within_absolute_error_bound_zero()
+    fn test_try_compress_regular_random_linear_constant_time_series_within_lossless_error_bound()
      {
         generate_compress_and_assert_known_time_series(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             false,
             &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
             &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
@@ -545,21 +471,10 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_random_linear_constant_time_series_within_relative_error_bound_zero()
+    fn test_try_compress_irregular_random_linear_constant_time_series_within_lossless_error_bound()
      {
         generate_compress_and_assert_known_time_series(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            false,
-            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
-            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
-        );
-    }
-
-    #[test]
-    fn test_try_compress_irregular_random_linear_constant_time_series_within_absolute_error_bound_zero()
-     {
-        generate_compress_and_assert_known_time_series(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             true,
             &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
             &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
@@ -567,21 +482,10 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_random_linear_constant_time_series_within_relative_error_bound_zero()
+    fn test_try_compress_regular_constant_linear_random_time_series_within_lossless_error_bound()
      {
         generate_compress_and_assert_known_time_series(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            true,
-            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
-            &[models::MACAQUE_V_ID, models::SWING_ID, models::PMC_MEAN_ID],
-        );
-    }
-
-    #[test]
-    fn test_try_compress_regular_constant_linear_random_time_series_within_absolute_error_bound_zero()
-     {
-        generate_compress_and_assert_known_time_series(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             false,
             &[models::PMC_MEAN_ID, models::SWING_ID, models::MACAQUE_V_ID],
             &[models::PMC_MEAN_ID, models::SWING_ID],
@@ -589,32 +493,10 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_constant_linear_random_time_series_within_relative_error_bound_zero()
+    fn test_try_compress_irregular_constant_linear_random_time_series_within_lossless_error_bound()
      {
         generate_compress_and_assert_known_time_series(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            false,
-            &[models::PMC_MEAN_ID, models::SWING_ID, models::MACAQUE_V_ID],
-            &[models::PMC_MEAN_ID, models::SWING_ID],
-        );
-    }
-
-    #[test]
-    fn test_try_compress_irregular_constant_linear_random_time_series_within_absolute_error_bound_zero()
-     {
-        generate_compress_and_assert_known_time_series(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            true,
-            &[models::PMC_MEAN_ID, models::SWING_ID, models::MACAQUE_V_ID],
-            &[models::PMC_MEAN_ID, models::SWING_ID],
-        );
-    }
-
-    #[test]
-    fn test_try_compress_irregular_constant_linear_random_time_series_within_relative_error_bound_zero()
-     {
-        generate_compress_and_assert_known_time_series(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             true,
             &[models::PMC_MEAN_ID, models::SWING_ID, models::MACAQUE_V_ID],
             &[models::PMC_MEAN_ID, models::SWING_ID],
@@ -707,20 +589,10 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_without_noise_within_absolute_error_bound_zero()
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_lossless_error_bound()
      {
         generate_compress_and_assert_time_series(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            false,
-            None,
-        )
-    }
-
-    #[test]
-    fn test_try_compress_regular_synthetic_time_series_without_noise_within_relative_error_bound_zero()
-     {
-        generate_compress_and_assert_time_series(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             false,
             None,
         )
@@ -747,20 +619,10 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_with_noise_within_absolute_error_bound_zero()
+    fn test_try_compress_regular_synthetic_time_series_with_noise_within_lossless_error_bound()
     {
         generate_compress_and_assert_time_series(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            false,
-            ADD_NOISE_RANGE,
-        )
-    }
-
-    #[test]
-    fn test_try_compress_regular_synthetic_time_series_with_noise_within_relative_error_bound_zero()
-    {
-        generate_compress_and_assert_time_series(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             false,
             ADD_NOISE_RANGE,
         )
@@ -787,20 +649,10 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_absolute_error_bound_zero()
+    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_lossless_error_bound()
      {
         generate_compress_and_assert_time_series(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            true,
-            None,
-        )
-    }
-
-    #[test]
-    fn test_try_compress_irregular_synthetic_time_series_without_noise_within_relative_error_bound_zero()
-     {
-        generate_compress_and_assert_time_series(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             true,
             None,
         )
@@ -827,20 +679,10 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_absolute_error_bound_zero()
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_lossless_error_bound()
      {
         generate_compress_and_assert_time_series(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            true,
-            ADD_NOISE_RANGE,
-        )
-    }
-
-    #[test]
-    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_relative_error_bound_zero()
-     {
-        generate_compress_and_assert_time_series(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             true,
             ADD_NOISE_RANGE,
         )
@@ -967,7 +809,6 @@ mod tests {
     // Tests for compress_and_store_residuals_in_a_separate_segment().
     #[test]
     fn test_compress_and_store_residuals_in_a_separate_segment() {
-        let error_bound = ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap();
         let uncompressed_timestamps = TimestampArray::from_iter_values((100..=500).step_by(100));
         let uncompressed_values = ValueArray::from(vec![73.0, 37.0, 37.0, 37.0, 73.0]);
 
@@ -979,7 +820,7 @@ mod tests {
         );
 
         compress_and_store_residuals_in_a_separate_segment(
-            error_bound,
+            ErrorBound::Lossless,
             0,
             uncompressed_timestamps.len() - 1,
             &uncompressed_timestamps,

--- a/crates/modelardb_compression/src/compression.rs
+++ b/crates/modelardb_compression/src/compression.rs
@@ -264,8 +264,8 @@ mod tests {
 
     use arrow::array::{ArrayBuilder, BinaryArray, Float32Array, Int8Array};
     use arrow::datatypes::{DataType, Field};
-    use modelardb_test::data_generation::{self, ValuesStructure};
     use modelardb_test::ERROR_BOUND_FIVE;
+    use modelardb_test::data_generation::{self, ValuesStructure};
     use modelardb_types::schemas::COMPRESSED_SCHEMA;
     use modelardb_types::types::{TimestampBuilder, ValueBuilder};
 
@@ -460,8 +460,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_random_linear_constant_time_series_within_lossless_error_bound()
-     {
+    fn test_try_compress_regular_random_linear_constant_time_series_within_lossless_error_bound() {
         generate_compress_and_assert_known_time_series(
             ErrorBound::Lossless,
             false,
@@ -472,7 +471,7 @@ mod tests {
 
     #[test]
     fn test_try_compress_irregular_random_linear_constant_time_series_within_lossless_error_bound()
-     {
+    {
         generate_compress_and_assert_known_time_series(
             ErrorBound::Lossless,
             true,
@@ -482,8 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_constant_linear_random_time_series_within_lossless_error_bound()
-     {
+    fn test_try_compress_regular_constant_linear_random_time_series_within_lossless_error_bound() {
         generate_compress_and_assert_known_time_series(
             ErrorBound::Lossless,
             false,
@@ -494,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_try_compress_irregular_constant_linear_random_time_series_within_lossless_error_bound()
-     {
+    {
         generate_compress_and_assert_known_time_series(
             ErrorBound::Lossless,
             true,
@@ -589,13 +587,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_without_noise_within_lossless_error_bound()
-     {
-        generate_compress_and_assert_time_series(
-            ErrorBound::Lossless,
-            false,
-            None,
-        )
+    fn test_try_compress_regular_synthetic_time_series_without_noise_within_lossless_error_bound() {
+        generate_compress_and_assert_time_series(ErrorBound::Lossless, false, None)
     }
 
     #[test]
@@ -619,13 +612,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_regular_synthetic_time_series_with_noise_within_lossless_error_bound()
-    {
-        generate_compress_and_assert_time_series(
-            ErrorBound::Lossless,
-            false,
-            ADD_NOISE_RANGE,
-        )
+    fn test_try_compress_regular_synthetic_time_series_with_noise_within_lossless_error_bound() {
+        generate_compress_and_assert_time_series(ErrorBound::Lossless, false, ADD_NOISE_RANGE)
     }
 
     #[test]
@@ -650,12 +638,8 @@ mod tests {
 
     #[test]
     fn test_try_compress_irregular_synthetic_time_series_without_noise_within_lossless_error_bound()
-     {
-        generate_compress_and_assert_time_series(
-            ErrorBound::Lossless,
-            true,
-            None,
-        )
+    {
+        generate_compress_and_assert_time_series(ErrorBound::Lossless, true, None)
     }
 
     #[test]
@@ -679,13 +663,8 @@ mod tests {
     }
 
     #[test]
-    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_lossless_error_bound()
-     {
-        generate_compress_and_assert_time_series(
-            ErrorBound::Lossless,
-            true,
-            ADD_NOISE_RANGE,
-        )
+    fn test_try_compress_irregular_synthetic_time_series_with_noise_within_lossless_error_bound() {
+        generate_compress_and_assert_time_series(ErrorBound::Lossless, true, ADD_NOISE_RANGE)
     }
 
     #[test]

--- a/crates/modelardb_compression/src/models/macaque_v.rs
+++ b/crates/modelardb_compression/src/models/macaque_v.rs
@@ -98,7 +98,7 @@ impl MacaqueV {
 
     /// Compress `value` using XOR and a variable length binary encoding and then store it.
     fn compress_value_xor_last_value(&mut self, value: Value) {
-        let value = if models::is_lossless_compression(self.error_bound) {
+        let value = if self.error_bound == ErrorBound::Lossless {
             value
         } else {
             // The best case for MacaqueV is rewriting the current value with the previous one.

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -75,6 +75,7 @@ pub fn is_value_within_error_bound(
                 (result * 100.0) <= error_bound
             }
         }
+        ErrorBound::Lossless => equal_or_nan(real_value as f64, approximate_value as f64),
     }
 }
 
@@ -84,6 +85,7 @@ pub fn maximum_allowed_deviation(error_bound: ErrorBound, value: f64) -> f64 {
     match error_bound {
         ErrorBound::Absolute(error_bound) => error_bound as f64 * 0.99,
         ErrorBound::Relative(error_bound) => f64::abs(value * (error_bound as f64 / 100.1)),
+        ErrorBound::Lossless => 0.0,
     }
 }
 
@@ -92,6 +94,7 @@ pub fn is_lossless_compression(error_bound: ErrorBound) -> bool {
     match error_bound {
         ErrorBound::Absolute(error_bound) => error_bound == 0.0,
         ErrorBound::Relative(error_bound) => error_bound == 0.0,
+        ErrorBound::Lossless => true,
     }
 }
 

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -295,7 +295,6 @@ mod tests {
 
     use modelardb_test::{
         ERROR_BOUND_ABSOLUTE_MAX, ERROR_BOUND_ONE, ERROR_BOUND_RELATIVE_MAX, ERROR_BOUND_TEN,
-        ERROR_BOUND_ZERO,
     };
     use proptest::num;
     use proptest::num::f32 as ProptestValue;
@@ -304,13 +303,8 @@ mod tests {
     // Tests for is_value_within_error_bound().
     proptest! {
     #[test]
-    fn test_same_value_is_always_within_absolute_error_bound(value in ProptestValue::ANY) {
-        prop_assert!(is_value_within_error_bound(ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(), value, value));
-    }
-
-    #[test]
-    fn test_same_value_is_always_within_relative_error_bound(value in ProptestValue::ANY) {
-        prop_assert!(is_value_within_error_bound(ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(), value, value));
+    fn test_same_value_is_always_within_lossless_error_bound(value in ProptestValue::ANY) {
+        prop_assert!(is_value_within_error_bound(ErrorBound::Lossless, value, value));
     }
 
     #[test]

--- a/crates/modelardb_compression/src/models/mod.rs
+++ b/crates/modelardb_compression/src/models/mod.rs
@@ -89,15 +89,6 @@ pub fn maximum_allowed_deviation(error_bound: ErrorBound, value: f64) -> f64 {
     }
 }
 
-/// Returns true if compression is lossless i.e., `error_bound` value is 0.
-pub fn is_lossless_compression(error_bound: ErrorBound) -> bool {
-    match error_bound {
-        ErrorBound::Absolute(error_bound) => error_bound == 0.0,
-        ErrorBound::Relative(error_bound) => error_bound == 0.0,
-        ErrorBound::Lossless => true,
-    }
-}
-
 /// Returns true if `v1` and `v2` are equivalent or both values are NAN.
 fn equal_or_nan(v1: f64, v2: f64) -> bool {
     v1 == v2 || (v1.is_nan() && v2.is_nan())

--- a/crates/modelardb_compression/src/models/pmc_mean.rs
+++ b/crates/modelardb_compression/src/models/pmc_mean.rs
@@ -112,71 +112,31 @@ pub fn grid(value: Value, timestamps: &[Timestamp], value_builder: &mut ValueBui
 mod tests {
     use super::*;
 
-    use modelardb_test::{
-        ERROR_BOUND_ABSOLUTE_MAX, ERROR_BOUND_FIVE, ERROR_BOUND_RELATIVE_MAX, ERROR_BOUND_ZERO,
-    };
+    use modelardb_test::{ERROR_BOUND_ABSOLUTE_MAX, ERROR_BOUND_FIVE, ERROR_BOUND_RELATIVE_MAX};
     use proptest::num::f32 as ProptestValue;
     use proptest::{prop_assert, prop_assume, proptest};
 
     // Tests for PMCMean.
     proptest! {
     #[test]
-    fn test_can_fit_sequence_of_finite_value_with_absolute_error_bound_zero(value in ProptestValue::ANY) {
-        can_fit_sequence_of_value_within_error_bound(ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(), value)
-    }
-
-    #[test]
-    fn test_can_fit_sequence_of_finite_value_with_relative_error_bound_zero(value in ProptestValue::ANY) {
-        can_fit_sequence_of_value_within_error_bound(ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(), value)
+    fn test_can_fit_sequence_of_finite_value_with_lossless_error_bound(value in ProptestValue::ANY) {
+        can_fit_sequence_of_value_within_error_bound(ErrorBound::Lossless, value)
     }
     }
 
     #[test]
-    fn test_can_fit_sequence_of_positive_infinity_with_absolute_error_bound_zero() {
-        can_fit_sequence_of_value_within_error_bound(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            Value::INFINITY,
-        )
+    fn test_can_fit_sequence_of_positive_infinity_with_lossless_error_bound() {
+        can_fit_sequence_of_value_within_error_bound(ErrorBound::Lossless, Value::INFINITY)
     }
 
     #[test]
-    fn test_can_fit_sequence_of_positive_infinity_with_relative_error_bound_zero() {
-        can_fit_sequence_of_value_within_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            Value::INFINITY,
-        )
+    fn test_can_fit_sequence_of_negative_infinity_with_lossless_error_bound() {
+        can_fit_sequence_of_value_within_error_bound(ErrorBound::Lossless, Value::NEG_INFINITY)
     }
 
     #[test]
-    fn test_can_fit_sequence_of_negative_infinity_with_absolute_error_bound_zero() {
-        can_fit_sequence_of_value_within_error_bound(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            Value::NEG_INFINITY,
-        )
-    }
-
-    #[test]
-    fn test_can_fit_sequence_of_negative_infinity_with_relative_error_bound_zero() {
-        can_fit_sequence_of_value_within_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            Value::NEG_INFINITY,
-        )
-    }
-
-    #[test]
-    fn test_can_fit_sequence_of_nans_with_absolute_error_bound_zero() {
-        can_fit_sequence_of_value_within_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            Value::NAN,
-        )
-    }
-
-    #[test]
-    fn test_can_fit_sequence_of_nans_with_relative_error_bound_zero() {
-        can_fit_sequence_of_value_within_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            Value::NAN,
-        )
+    fn test_can_fit_sequence_of_nans_with_lossless_error_bound() {
+        can_fit_sequence_of_value_within_error_bound(ErrorBound::Lossless, Value::NAN)
     }
 
     fn can_fit_sequence_of_value_within_error_bound(error_bound: ErrorBound, value: Value) {
@@ -194,15 +154,8 @@ mod tests {
 
     proptest! {
     #[test]
-    fn test_can_fit_one_value_with_absolute_error_bound_zero(value in ProptestValue::ANY) {
-        let error_bound_zero = ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap();
-        prop_assert!(PMCMean::new(error_bound_zero).fit_value(value));
-    }
-
-    #[test]
-    fn test_can_fit_one_value_with_relative_error_bound_zero(value in ProptestValue::ANY) {
-        let error_bound_zero = ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap();
-        prop_assert!(PMCMean::new(error_bound_zero).fit_value(value));
+    fn test_can_fit_one_value_with_lossless_error_bound(value in ProptestValue::ANY) {
+        prop_assert!(PMCMean::new(ErrorBound::Lossless).fit_value(value));
     }
 
     #[test]
@@ -315,18 +268,9 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_fit_sequence_of_different_values_with_absolute_error_bound_zero() {
-        let error_bound_zero = ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap();
+    fn test_cannot_fit_sequence_of_different_values_with_lossless_error_bound() {
         assert!(!fit_sequence_of_different_values_with_error_bound(
-            error_bound_zero
-        ))
-    }
-
-    #[test]
-    fn test_cannot_fit_sequence_of_different_values_with_relative_error_bound_zero() {
-        let error_bound_zero = ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap();
-        assert!(!fit_sequence_of_different_values_with_error_bound(
-            error_bound_zero
+            ErrorBound::Lossless
         ))
     }
 

--- a/crates/modelardb_compression/src/models/swing.rs
+++ b/crates/modelardb_compression/src/models/swing.rs
@@ -348,9 +348,7 @@ mod tests {
 
     use arrow::array::{BinaryArray, Float32Array, Int8Array};
     use arrow::datatypes::{DataType, Field, Schema};
-    use modelardb_test::{
-        ERROR_BOUND_ABSOLUTE_MAX, ERROR_BOUND_FIVE, ERROR_BOUND_RELATIVE_MAX, ERROR_BOUND_ZERO,
-    };
+    use modelardb_test::{ERROR_BOUND_ABSOLUTE_MAX, ERROR_BOUND_FIVE, ERROR_BOUND_RELATIVE_MAX};
     use modelardb_types::schemas::COMPRESSED_SCHEMA;
     use modelardb_types::types::{TimestampArray, TimestampBuilder, ValueArray, ValueBuilder};
     use proptest::num::f32 as ProptestValue;
@@ -368,66 +366,26 @@ mod tests {
     // Tests for Swing.
     proptest! {
     #[test]
-    fn test_can_fit_sequence_of_finite_value_with_absolute_error_bound_zero(value in ProptestValue::ANY) {
+    fn test_can_fit_sequence_of_finite_value_with_lossless_error_bound(value in ProptestValue::ANY) {
         can_fit_sequence_of_value_with_error_bound(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            value)
-    }
-
-    #[test]
-    fn test_can_fit_sequence_of_finite_value_with_relative_error_bound_zero(value in ProptestValue::ANY) {
-        can_fit_sequence_of_value_with_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             value)
     }
     }
 
     #[test]
-    fn test_can_fit_sequence_of_positive_infinity_with_absolute_error_bound_zero() {
-        can_fit_sequence_of_value_with_error_bound(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            Value::INFINITY,
-        )
+    fn test_can_fit_sequence_of_positive_infinity_with_lossless_error_bound() {
+        can_fit_sequence_of_value_with_error_bound(ErrorBound::Lossless, Value::INFINITY)
     }
 
     #[test]
-    fn test_can_fit_sequence_of_positive_infinity_with_relative_error_bound_zero() {
-        can_fit_sequence_of_value_with_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            Value::INFINITY,
-        )
+    fn test_can_fit_sequence_of_negative_infinity_with_lossless_error_bound() {
+        can_fit_sequence_of_value_with_error_bound(ErrorBound::Lossless, Value::NEG_INFINITY)
     }
 
     #[test]
-    fn test_can_fit_sequence_of_negative_infinity_with_absolute_error_bound_zero() {
-        can_fit_sequence_of_value_with_error_bound(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            Value::NEG_INFINITY,
-        )
-    }
-
-    #[test]
-    fn test_can_fit_sequence_of_negative_infinity_with_relative_error_bound_zero() {
-        can_fit_sequence_of_value_with_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            Value::NEG_INFINITY,
-        )
-    }
-
-    #[test]
-    fn test_can_fit_sequence_of_nans_with_absolute_error_bound_zero() {
-        can_fit_sequence_of_value_with_error_bound(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            Value::NAN,
-        )
-    }
-
-    #[test]
-    fn test_can_fit_sequence_of_nans_with_relative_error_bound_zero() {
-        can_fit_sequence_of_value_with_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            Value::NAN,
-        )
+    fn test_can_fit_sequence_of_nans_with_lossless_error_bound() {
+        can_fit_sequence_of_value_with_error_bound(ErrorBound::Lossless, Value::NAN)
     }
 
     fn can_fit_sequence_of_value_with_error_bound(error_bound: ErrorBound, value: Value) {
@@ -456,35 +414,16 @@ mod tests {
 
     proptest! {
     #[test]
-    fn test_can_fit_one_value_with_absolute_error_bound_zero(value in ProptestValue::ANY) {
-        let error_bound_zero = ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap();
-        prop_assert!(Swing::new(error_bound_zero).fit_data_point(START_TIME, value));
+    fn test_can_fit_one_value_with_lossless_error_bound(value in ProptestValue::ANY) {
+        prop_assert!(Swing::new(ErrorBound::Lossless).fit_data_point(START_TIME, value));
     }
 
     #[test]
-    fn test_can_fit_one_value_with_relative_error_bound_zero(value in ProptestValue::ANY) {
-        let error_bound_zero = ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap();
-        prop_assert!(Swing::new(error_bound_zero).fit_data_point(START_TIME, value));
-    }
-
-    #[test]
-    fn test_can_fit_two_finite_value_with_absolute_error_bound_zero(
+    fn test_can_fit_two_finite_value_with_lossless_error_bound(
         first_value in ProptestValue::NORMAL,
         second_value in ProptestValue::NORMAL
     ) {
-        let error_bound_zero = ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap();
-        let mut model_type = Swing::new(error_bound_zero);
-        prop_assert!(model_type.fit_data_point(START_TIME, first_value));
-        prop_assert!(model_type.fit_data_point(END_TIME, second_value));
-    }
-
-    #[test]
-    fn test_can_fit_two_finite_value_with_relative_error_bound_zero(
-        first_value in ProptestValue::NORMAL,
-        second_value in ProptestValue::NORMAL
-    ) {
-        let error_bound_zero = ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap();
-        let mut model_type = Swing::new(error_bound_zero);
+        let mut model_type = Swing::new(ErrorBound::Lossless);
         prop_assert!(model_type.fit_data_point(START_TIME, first_value));
         prop_assert!(model_type.fit_data_point(END_TIME, second_value));
     }
@@ -599,33 +538,17 @@ mod tests {
     }
 
     #[test]
-    fn test_can_fit_sequence_of_linear_values_with_absolute_error_bound_zero() {
+    fn test_can_fit_sequence_of_linear_values_with_lossless_error_bound() {
         assert!(fit_sequence_of_values_with_error_bound(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             &[42.0, 84.0, 126.0, 168.0, 210.0],
         ))
     }
 
     #[test]
-    fn test_can_fit_sequence_of_linear_values_with_relative_error_bound_zero() {
-        assert!(fit_sequence_of_values_with_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            &[42.0, 84.0, 126.0, 168.0, 210.0],
-        ))
-    }
-
-    #[test]
-    fn test_cannot_fit_sequence_of_different_values_with_absolute_error_bound_zero() {
+    fn test_cannot_fit_sequence_of_different_values_with_lossless_error_bound() {
         assert!(!fit_sequence_of_values_with_error_bound(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            &[42.0, 42.0, 42.8, 42.0, 42.0],
-        ))
-    }
-
-    #[test]
-    fn test_cannot_fit_sequence_of_different_values_with_relative_error_bound_zero() {
-        assert!(!fit_sequence_of_values_with_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             &[42.0, 42.0, 42.8, 42.0, 42.0],
         ))
     }
@@ -793,43 +716,20 @@ mod tests {
     }
 
     #[test]
-    fn test_can_reconstruct_sequence_of_linear_increasing_values_within_absolute_error_bound_zero()
-    {
+    fn test_can_reconstruct_sequence_of_linear_increasing_values_within_lossless_error_bound() {
         assert_can_reconstruct_sequence_of_linear_values_within_error_bound(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             (42..=4200).step_by(42).map(|value| value as f32).collect(),
         )
     }
 
     #[test]
-    fn test_can_reconstruct_sequence_of_linear_increasing_values_within_relative_error_bound_zero()
-    {
-        assert_can_reconstruct_sequence_of_linear_values_within_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-            (42..=4200).step_by(42).map(|value| value as f32).collect(),
-        )
-    }
-
-    #[test]
-    fn test_can_reconstruct_sequence_of_linear_decreasing_values_within_absolute_error_bound_zero()
-    {
+    fn test_can_reconstruct_sequence_of_linear_decreasing_values_within_lossless_error_bound() {
         let mut values: Vec<Value> = (42..=4200).step_by(42).map(|value| value as f32).collect();
         values.reverse();
 
         assert_can_reconstruct_sequence_of_linear_values_within_error_bound(
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-            values,
-        );
-    }
-
-    #[test]
-    fn test_can_reconstruct_sequence_of_linear_decreasing_values_within_relative_error_bound_zero()
-    {
-        let mut values: Vec<Value> = (42..=4200).step_by(42).map(|value| value as f32).collect();
-        values.reverse();
-
-        assert_can_reconstruct_sequence_of_linear_values_within_error_bound(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             values,
         );
     }

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -511,8 +511,8 @@ mod tests {
 
     use arrow::array::BinaryArray;
     use arrow::datatypes::{DataType, Field};
-    use modelardb_test::data_generation::{self, ValuesStructure};
     use modelardb_test::ERROR_BOUND_TEN;
+    use modelardb_test::data_generation::{self, ValuesStructure};
     use modelardb_types::schemas::COMPRESSED_SCHEMA;
     use modelardb_types::types::{TimestampArray, ValueArray};
 

--- a/crates/modelardb_compression/src/types.rs
+++ b/crates/modelardb_compression/src/types.rs
@@ -512,7 +512,7 @@ mod tests {
     use arrow::array::BinaryArray;
     use arrow::datatypes::{DataType, Field};
     use modelardb_test::data_generation::{self, ValuesStructure};
-    use modelardb_test::{ERROR_BOUND_TEN, ERROR_BOUND_ZERO};
+    use modelardb_test::ERROR_BOUND_TEN;
     use modelardb_types::schemas::COMPRESSED_SCHEMA;
     use modelardb_types::types::{TimestampArray, ValueArray};
 
@@ -792,7 +792,7 @@ mod tests {
 
         let model = compression::fit_next_model(
             0,
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             &uncompressed_timestamps,
             uncompressed_values,
         );
@@ -819,7 +819,7 @@ mod tests {
             CompressedSegmentBatchBuilder::new(compressed_schema, vec!["tag".to_owned()], 0, 1);
 
         model.finish(
-            ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+            ErrorBound::Lossless,
             residuals_end_index,
             &uncompressed_timestamps,
             uncompressed_values,

--- a/crates/modelardb_embedded/bindings/python/modelardb/error_bound.py
+++ b/crates/modelardb_embedded/bindings/python/modelardb/error_bound.py
@@ -27,7 +27,7 @@ class AbsoluteErrorBound:
 
     def __init__(self, value: float):
         # Error checking is required as the C-API depends on the error bounds being valid.
-        if not math.isfinite(value) or value < 0:
+        if not math.isfinite(value) or value <= 0:
             raise ValueError("An absolute error bound must be a positive finite value.")
         self.value = value
 
@@ -36,15 +36,15 @@ class AbsoluteErrorBound:
 class RelativeErrorBound:
     """A per value relative error bound.
 
-    param value: A value between 0 and 100 that specifies the error bound.
+    param value: A positive value that is at most 100 that specifies the error bound as a percentage.
     :type value: float
-    :raises ValueError: If `value` is not between 0 and 100.
+    :raises ValueError: If `value` is not a positive value that is at most 100.
     """
 
     def __init__(self, value: float):
         # Error checking is required as the C-API depends on the error bounds being valid.
-        if not 0 <= value <= 100:
+        if not 0 < value <= 100:
             raise ValueError(
-                "A relative error bound must be a value from 0.0% to 100.0%."
+                "A relative error bound must be a positive value that is at most 100.0%."
             )
         self.value = value

--- a/crates/modelardb_embedded/bindings/python/modelardb/table.py
+++ b/crates/modelardb_embedded/bindings/python/modelardb/table.py
@@ -43,8 +43,7 @@ class TimeSeriesTable:
     :type schema: Schema
     :param error_bounds: Absolute or relative error bounds for the field columns
     with type :class:`pyarrow.float32()` in `schema`. If no error bound is
-    specified for a column, it will be zero so the values will be stored
-    losslessly.
+    specified for a column, the values will be stored losslessly.
     :type error_bounds: dict[str, AbsoluteErrorBound | RelativeErrorBound],
     optional
     :param generated_columns: SQL expressions for generating field columns of

--- a/crates/modelardb_embedded/bindings/python/tests/test_error_bound.py
+++ b/crates/modelardb_embedded/bindings/python/tests/test_error_bound.py
@@ -19,8 +19,8 @@ from modelardb import AbsoluteErrorBound, RelativeErrorBound
 
 class TestErrorBound(unittest.TestCase):
     # Tests for AbsoluteErrorBound.
-    def test_can_create_absolute_error_bound_with_float_zero(self):
-        _ = AbsoluteErrorBound(0)
+    def test_cannot_create_absolute_error_bound_with_float_zero(self):
+        self.assertRaises(ValueError, lambda: AbsoluteErrorBound(0))
 
     def test_can_create_absolute_error_bound_with_normal_positive_float(self):
         _ = AbsoluteErrorBound(1)
@@ -38,8 +38,8 @@ class TestErrorBound(unittest.TestCase):
         self.assertRaises(ValueError, lambda: AbsoluteErrorBound(float("nan")))
 
     # Tests for RelativeErrorBound.
-    def test_can_create_relative_error_bound_with_float_zero(self):
-        _ = RelativeErrorBound(0)
+    def test_cannot_create_relative_error_bound_with_float_zero(self):
+        self.assertRaises(ValueError, lambda: RelativeErrorBound(0))
 
     def test_can_create_relative_error_bound_with_normal_positive_float(self):
         _ = RelativeErrorBound(1)

--- a/crates/modelardb_embedded/src/capi.rs
+++ b/crates/modelardb_embedded/src/capi.rs
@@ -336,7 +336,7 @@ unsafe fn create(
     TOKIO_RUNTIME.block_on(modelardb.create(table_name, table_type))
 }
 
-/// Converts the [`MapArray`] in error_bounds_array` to a [`HashMap`]. If a value is zero the column
+/// Converts the [`MapArray`] in `error_bounds_array` to a [`HashMap`]. If a value is zero the column
 /// with that name is stored losslessly, if the value is positive it is interpreted as an absolute
 /// error bound, and if the value is negative it is interpreted as a relative error bound. Assumes
 /// the error bound values are finite [`f32`]s.

--- a/crates/modelardb_embedded/src/operations/data_folder.rs
+++ b/crates/modelardb_embedded/src/operations/data_folder.rs
@@ -1099,6 +1099,7 @@ mod tests {
             .map(|error_bound| match error_bound {
                 ErrorBound::Absolute(value) => *value,
                 ErrorBound::Relative(value) => -*value,
+                ErrorBound::Lossless => 0.0,
             })
             .collect();
 

--- a/crates/modelardb_embedded/src/operations/mod.rs
+++ b/crates/modelardb_embedded/src/operations/mod.rs
@@ -124,12 +124,14 @@ fn try_new_time_series_table_metadata(
     let schema = Arc::new(schema);
     let df_schema: DFSchema = schema.clone().try_into()?;
 
-    let lossless = ErrorBound::try_new_absolute(0.0)?;
-
     let mut error_bounds_all = Vec::with_capacity(schema.fields().len());
     let mut generated_columns_all = Vec::with_capacity(schema.fields().len());
     for field in schema.fields() {
-        error_bounds_all.push(error_bounds.remove(field.name()).unwrap_or(lossless));
+        error_bounds_all.push(
+            error_bounds
+                .remove(field.name())
+                .unwrap_or(ErrorBound::Lossless),
+        );
 
         if let Some(sql_expr) = generated_columns.get(field.name()) {
             let expr = tokenize_and_parse_sql_expression(sql_expr, &df_schema)?;

--- a/crates/modelardb_storage/src/metadata/table_metadata_manager.rs
+++ b/crates/modelardb_storage/src/metadata/table_metadata_manager.rs
@@ -355,6 +355,7 @@ impl TableMetadataManager {
                     match time_series_table_metadata.error_bounds[schema_index] {
                         ErrorBound::Absolute(value) => (value, false),
                         ErrorBound::Relative(value) => (value, true),
+                        ErrorBound::Lossless => (0.0, false),
                     }
                 } else {
                     (0.0, false)
@@ -540,8 +541,7 @@ impl TableMetadataManager {
         );
         let batch = sql_and_concat(&self.session_context, &sql).await?;
 
-        let mut column_to_error_bound =
-            vec![ErrorBound::try_new_absolute(0.0)?; query_schema_columns];
+        let mut column_to_error_bound = vec![ErrorBound::Lossless; query_schema_columns];
 
         let column_index_array = modelardb_types::array!(batch, 0, Int16Array);
         let error_bound_value_array = modelardb_types::array!(batch, 1, Float32Array);
@@ -552,13 +552,15 @@ impl TableMetadataManager {
             let error_bound_value = error_bound_value_array.value(row_index);
             let error_bound_is_relative = error_bound_is_relative_array.value(row_index);
 
-            let error_bound = if error_bound_is_relative {
-                ErrorBound::try_new_relative(error_bound_value)
-            } else {
-                ErrorBound::try_new_absolute(error_bound_value)
-            }?;
+            if error_bound_value != 0.0 {
+                let error_bound = if error_bound_is_relative {
+                    ErrorBound::try_new_relative(error_bound_value)
+                } else {
+                    ErrorBound::try_new_absolute(error_bound_value)
+                }?;
 
-            column_to_error_bound[error_bound_index as usize] = error_bound;
+                column_to_error_bound[error_bound_index as usize] = error_bound;
+            }
         }
 
         Ok(column_to_error_bound)
@@ -923,6 +925,7 @@ mod tests {
             .map(|error_bound| match error_bound {
                 ErrorBound::Absolute(value) => *value,
                 ErrorBound::Relative(value) => *value,
+                ErrorBound::Lossless => 0.0,
             })
             .collect();
 

--- a/crates/modelardb_storage/src/metadata/table_metadata_manager.rs
+++ b/crates/modelardb_storage/src/metadata/table_metadata_manager.rs
@@ -611,7 +611,6 @@ mod tests {
     use datafusion::arrow::datatypes::DataType;
     use datafusion::common::ScalarValue::Int64;
     use datafusion::logical_expr::Expr::Literal;
-    use modelardb_test::ERROR_BOUND_ZERO;
     use modelardb_test::table::{self, TIME_SERIES_TABLE_NAME};
     use modelardb_types::types::{ArrowTimestamp, ArrowValue};
     use tempfile::TempDir;
@@ -948,10 +947,7 @@ mod tests {
             Field::new("tag", DataType::Utf8, false),
         ]));
 
-        let error_bounds = vec![
-            ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap();
-            query_schema.fields.len()
-        ];
+        let error_bounds = vec![ErrorBound::Lossless; query_schema.fields.len()];
 
         let plus_one_column = Some(GeneratedColumn {
             expr: col("field_1") + Literal(Int64(Some(1))),

--- a/crates/modelardb_test/src/table.rs
+++ b/crates/modelardb_test/src/table.rs
@@ -24,7 +24,7 @@ use modelardb_types::types::{
     Value, ValueArray,
 };
 
-use crate::{ERROR_BOUND_FIVE, ERROR_BOUND_ONE, ERROR_BOUND_ZERO};
+use crate::{ERROR_BOUND_FIVE, ERROR_BOUND_ONE};
 
 /// SQL to create a normal table with a timestamp column and two floating point columns.
 pub const NORMAL_TABLE_SQL: &str =
@@ -90,10 +90,10 @@ pub fn time_series_table_metadata() -> TimeSeriesTableMetadata {
     ]));
 
     let error_bounds = vec![
-        ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
+        ErrorBound::Lossless,
         ErrorBound::try_new_absolute(ERROR_BOUND_ONE).unwrap(),
         ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
-        ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+        ErrorBound::Lossless,
     ];
 
     let generated_columns = vec![None, None, None, None];

--- a/crates/modelardb_types/src/flight/protocol.proto
+++ b/crates/modelardb_types/src/flight/protocol.proto
@@ -72,6 +72,7 @@ message TableMetadata {
       enum Type {
         ABSOLUTE = 0;
         RELATIVE = 1;
+        LOSSLESS = 2;
       }
       Type type = 1;
       float value = 2;

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -268,13 +268,15 @@ fn compute_indices_of_columns_with_data_type(schema: &Schema, data_type: DataTyp
         .collect()
 }
 
-/// Absolute or relative per-value error bound.
+/// Absolute, relative, or lossless per-value error bound.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ErrorBound {
     /// An error bound that guarantees each value cannot deviate more than the [`Value`].
     Absolute(Value),
     /// An error bound that guarantees each value cannot deviate more than 0.0% to 100.0%.
     Relative(f32),
+    /// An error bound that guarantees each value is stored losslessly.
+    Lossless,
 }
 
 impl ErrorBound {

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -385,8 +385,8 @@ mod tests {
     use proptest::num;
     use proptest::proptest;
 
-    use modelardb_test::ERROR_BOUND_ZERO;
     use modelardb_test::table::{self, TIME_SERIES_TABLE_NAME};
+    use modelardb_test::{ERROR_BOUND_FIVE, ERROR_BOUND_ZERO};
 
     // Tests for TimeSeriesTableMetadata.
     #[test]
@@ -454,11 +454,14 @@ mod tests {
     fn create_simple_time_series_table_metadata(
         query_schema: Schema,
     ) -> Result<TimeSeriesTableMetadata> {
+        let error_bounds = vec![ErrorBound::Lossless; query_schema.fields.len()];
+        let generated_columns = vec![None; query_schema.fields.len()];
+
         TimeSeriesTableMetadata::try_new(
             TIME_SERIES_TABLE_NAME.to_owned(),
             Arc::new(query_schema),
-            vec![ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap()],
-            vec![None],
+            error_bounds,
+            generated_columns,
         )
     }
 
@@ -529,13 +532,13 @@ mod tests {
                 Field::new("temperature", ArrowValue::DATA_TYPE, false),
             ])),
             vec![
-                ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-                ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-                ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-                ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-                ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).unwrap(),
-                ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
-                ErrorBound::try_new_relative(ERROR_BOUND_ZERO).unwrap(),
+                ErrorBound::Lossless,
+                ErrorBound::Lossless,
+                ErrorBound::Lossless,
+                ErrorBound::Lossless,
+                ErrorBound::try_new_absolute(ERROR_BOUND_FIVE).unwrap(),
+                ErrorBound::Lossless,
+                ErrorBound::try_new_relative(ERROR_BOUND_FIVE).unwrap(),
             ],
             vec![None, None, None, None, None, None, None],
         )


### PR DESCRIPTION
Closes #345 by adding a `Lossless` variant to the `ErrorBound` enum. The absolute and relative error bounds have also been changed both in the Rust API and in the Python bindings to no longer allow a value of 0.

When fixing some unit tests, a bug was found that allowed `TimeSeriesTableMetadata` to be created with unsupported types for specifically tag columns. This bug has been fixed and the test that checked for the issue has been fixed.