### PR TITLE
Check for specific error messages instead of just checking for errors

### DIFF
--- a/crates/modelardb_compression/src/models/bits.rs
+++ b/crates/modelardb_compression/src/models/bits.rs
@@ -194,7 +194,12 @@ mod tests {
     // Tests for BitReader.
     #[test]
     fn test_bit_reader_cannot_be_empty() {
-        assert!(BitReader::try_new(&[]).is_err());
+        let result = BitReader::try_new(&[]);
+
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "Invalid Argument Error: The bytes slice must not be empty."
+        );
     }
 
     #[test]

--- a/crates/modelardb_manager/src/cluster.rs
+++ b/crates/modelardb_manager/src/cluster.rs
@@ -242,17 +242,25 @@ mod test {
         let mut cluster = Cluster::new();
 
         assert!(cluster.register_node(node.clone()).is_ok());
-        assert!(cluster.register_node(node).is_err());
+
+        let result = cluster.register_node(node);
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: A node with the url `localhost` is already registered."
+        );
     }
 
     #[tokio::test]
     async fn test_remove_node_invalid_url() {
         let mut cluster = Cluster::new();
-        assert!(
-            cluster
-                .remove_node("invalid_url", &Uuid::new_v4().to_string().parse().unwrap())
-                .await
-                .is_err()
+        let result = cluster
+            .remove_node("invalid_url", &Uuid::new_v4().to_string().parse().unwrap())
+            .await;
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: A node with the url `invalid_url` does not exist."
         );
     }
 
@@ -277,6 +285,12 @@ mod test {
         let mut cluster = Cluster::new();
 
         assert!(cluster.register_node(node).is_ok());
-        assert!(cluster.query_node().is_err());
+
+        let result = cluster.query_node();
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid State Error: There are no cloud nodes to execute the query in the cluster."
+        );
     }
 }

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -459,12 +459,7 @@ mod tests {
         );
 
         // The normal table should be registered in the Apache DataFusion catalog.
-        assert!(
-            context
-                .check_if_table_exists(NORMAL_TABLE_NAME)
-                .await
-                .is_err()
-        );
+        assert_check_if_table_exists_error(&context, NORMAL_TABLE_NAME).await;
     }
 
     #[tokio::test]
@@ -512,12 +507,7 @@ mod tests {
         );
 
         // The time series table should be registered in the Apache DataFusion catalog.
-        assert!(
-            context
-                .check_if_table_exists(TIME_SERIES_TABLE_NAME)
-                .await
-                .is_err()
-        );
+        assert_check_if_table_exists_error(&context, TIME_SERIES_TABLE_NAME).await;
     }
 
     #[tokio::test]
@@ -590,12 +580,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(
-            context
-                .check_if_table_exists(NORMAL_TABLE_NAME)
-                .await
-                .is_err()
-        );
+        assert_check_if_table_exists_error(&context, NORMAL_TABLE_NAME).await;
 
         context.drop_table(NORMAL_TABLE_NAME).await.unwrap();
 
@@ -632,12 +617,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(
-            context
-                .check_if_table_exists(TIME_SERIES_TABLE_NAME)
-                .await
-                .is_err()
-        );
+        assert_check_if_table_exists_error(&context, TIME_SERIES_TABLE_NAME).await;
 
         context.drop_table(TIME_SERIES_TABLE_NAME).await.unwrap();
 
@@ -940,11 +920,15 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(
-            context
-                .check_if_table_exists(TIME_SERIES_TABLE_NAME)
-                .await
-                .is_err()
+        assert_check_if_table_exists_error(&context, TIME_SERIES_TABLE_NAME).await;
+    }
+
+    async fn assert_check_if_table_exists_error(context: &Arc<Context>, table_name: &str) {
+        let result = context.check_if_table_exists(table_name).await;
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            format!("Invalid Argument Error: Table with name '{table_name}' already exists.")
         );
     }
 

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -660,11 +660,11 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        let result = context.drop_table(NORMAL_TABLE_NAME).await;
+        let result = context.drop_table("missing_table").await;
 
         assert_eq!(
             result.unwrap_err().to_string(),
-            table_does_not_exist_error(NORMAL_TABLE_NAME).to_string()
+            table_does_not_exist_error("missing_table").to_string()
         );
     }
 
@@ -736,11 +736,11 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        let result = context.truncate_table(NORMAL_TABLE_NAME).await;
+        let result = context.truncate_table("missing_table").await;
 
         assert_eq!(
             result.unwrap_err().to_string(),
-            table_does_not_exist_error(NORMAL_TABLE_NAME).to_string()
+            table_does_not_exist_error("missing_table").to_string()
         );
     }
 
@@ -870,11 +870,11 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let context = create_context(&temp_dir).await;
 
-        let result = context.vacuum_table(NORMAL_TABLE_NAME, None).await;
+        let result = context.vacuum_table("missing_table", None).await;
 
         assert_eq!(
             result.unwrap_err().to_string(),
-            table_does_not_exist_error(NORMAL_TABLE_NAME).to_string()
+            table_does_not_exist_error("missing_table").to_string()
         );
     }
 
@@ -990,12 +990,12 @@ mod tests {
         let context = create_context(&temp_dir).await;
 
         let result = context
-            .schema_of_table_in_default_database_schema(TIME_SERIES_TABLE_NAME)
+            .schema_of_table_in_default_database_schema("missing_table")
             .await;
 
         assert_eq!(
             result.unwrap_err().to_string(),
-            table_does_not_exist_error(TIME_SERIES_TABLE_NAME).to_string()
+            table_does_not_exist_error("missing_table").to_string()
         );
     }
 

--- a/crates/modelardb_server/src/data_folders.rs
+++ b/crates/modelardb_server/src/data_folders.rs
@@ -175,10 +175,11 @@ mod tests {
     // Tests for try_from_command_line_arguments().
     #[tokio::test]
     async fn test_try_from_empty_command_line_arguments() {
-        assert!(
-            DataFolders::try_from_command_line_arguments(&[])
-                .await
-                .is_err()
+        let result = DataFolders::try_from_command_line_arguments(&[]).await;
+
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "Invalid Argument Error: Too few, too many, or malformed arguments.".to_owned()
         );
     }
 
@@ -212,10 +213,13 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let temp_dir_str = temp_dir.path().to_str().unwrap();
 
-        assert!(
-            DataFolders::try_from_command_line_arguments(&["cloud", temp_dir_str])
-                .await
-                .is_err()
-        )
+        let result = DataFolders::try_from_command_line_arguments(&["cloud", temp_dir_str]).await;
+
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            format!(
+                "Invalid Argument Error: Could not connect to manager at '{temp_dir_str}': transport error",
+            )
+        );
     }
 }

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -304,16 +304,28 @@ mod tests {
         let manager = create_manager();
         let request_metadata = MetadataMap::new();
 
-        assert!(manager.validate_request(&request_metadata).is_err());
+        let result = manager.validate_request(&request_metadata);
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid State Error: Missing manager key."
+        );
     }
 
     #[tokio::test]
     async fn test_validate_request_with_invalid_key() {
         let manager = create_manager();
         let mut request_metadata = MetadataMap::new();
-        request_metadata.append("x-manager-key", Uuid::new_v4().to_string().parse().unwrap());
 
-        assert!(manager.validate_request(&request_metadata).is_err());
+        let key = Uuid::new_v4().to_string();
+        request_metadata.append("x-manager-key", key.parse().unwrap());
+
+        let result = manager.validate_request(&request_metadata);
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            format!("Invalid State Error: Manager key '\"{key}\"' is invalid.")
+        );
     }
 
     fn create_manager() -> Manager {

--- a/crates/modelardb_server/src/manager.rs
+++ b/crates/modelardb_server/src/manager.rs
@@ -57,7 +57,13 @@ impl Manager {
         server_mode: ServerMode,
     ) -> Result<(Self, protocol::manager_metadata::StorageConfiguration)> {
         let flight_client = Arc::new(RwLock::new(
-            FlightServiceClient::connect(manager_url.to_owned()).await?,
+            FlightServiceClient::connect(manager_url.to_owned())
+                .await
+                .map_err(|error| {
+                    ModelarDbServerError::InvalidArgument(format!(
+                        "Could not connect to manager at '{manager_url}': {error}",
+                    ))
+                })?,
         ));
 
         let ip_address = env::var("MODELARDBD_IP_ADDRESS").unwrap_or("127.0.0.1".to_string());

--- a/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
+++ b/crates/modelardb_server/src/storage/uncompressed_data_manager.rs
@@ -1002,12 +1002,11 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let (data_manager, _time_series_table_metadata) = create_managers(&temp_dir).await;
 
-        assert!(
-            data_manager
-                .channels
-                .uncompressed_data_receiver
-                .try_recv()
-                .is_err()
+        let result = data_manager.channels.uncompressed_data_receiver.try_recv();
+
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            "receiving on an empty channel"
         );
     }
 

--- a/crates/modelardb_server/tests/integration_test.rs
+++ b/crates/modelardb_server/tests/integration_test.rs
@@ -633,8 +633,12 @@ async fn test_can_drop_time_series_table() {
 async fn test_cannot_drop_missing_table() {
     let mut test_context = TestContext::new().await;
 
-    let result = test_context.drop_table(NORMAL_TABLE_NAME).await;
-    assert!(result.is_err());
+    let response = test_context.drop_table(NORMAL_TABLE_NAME).await;
+
+    assert_eq!(
+        response.err().unwrap().message(),
+        format!("Invalid Argument Error: Table with name '{NORMAL_TABLE_NAME}' does not exist.")
+    );
 }
 
 #[tokio::test]
@@ -695,8 +699,12 @@ async fn test_can_truncate_time_series_table() {
 async fn test_cannot_truncate_missing_table() {
     let mut test_context = TestContext::new().await;
 
-    let result = test_context.truncate_table(NORMAL_TABLE_NAME).await;
-    assert!(result.is_err());
+    let response = test_context.truncate_table(NORMAL_TABLE_NAME).await;
+
+    assert_eq!(
+        response.err().unwrap().message(),
+        format!("Invalid Argument Error: Table with name '{NORMAL_TABLE_NAME}' does not exist.")
+    );
 }
 
 #[tokio::test]
@@ -777,8 +785,12 @@ async fn test_can_vacuum_time_series_table() {
 async fn test_cannot_vacuum_missing_table() {
     let mut test_context = TestContext::new().await;
 
-    let result = test_context.vacuum_table(NORMAL_TABLE_NAME, None).await;
-    assert!(result.is_err());
+    let response = test_context.vacuum_table(NORMAL_TABLE_NAME, None).await;
+
+    assert_eq!(
+        response.err().unwrap().message(),
+        format!("Invalid Argument Error: Table with name '{NORMAL_TABLE_NAME}' does not exist.")
+    );
 }
 
 #[tokio::test]
@@ -1048,11 +1060,12 @@ async fn test_cannot_ingest_invalid_time_series() {
         .create_table(TIME_SERIES_TABLE_NAME, TableType::TimeSeriesTable)
         .await;
 
-    assert!(
-        test_context
-            .send_time_series_to_server(flight_data)
-            .await
-            .is_err()
+    let response = test_context.send_time_series_to_server(flight_data).await;
+
+    assert_eq!(
+        response.err().unwrap().message(),
+        "Schema error: Invalid data for schema. Field { name: \"tag\", data_type: Utf8, nullable: \
+        false, dict_id: 0, dict_is_ordered: false, metadata: {} } refers to node not found in schema"
     );
 
     test_context.flush_data_to_disk().await;
@@ -1375,7 +1388,6 @@ async fn update_configuration_and_assert_error(setting: i32, new_value: Option<u
     let mut test_context = TestContext::new().await;
     let response = test_context.update_configuration(setting, new_value).await;
 
-    assert!(response.is_err());
     assert_eq!(response.err().unwrap().message(), error);
 }
 

--- a/crates/modelardb_storage/src/lib.rs
+++ b/crates/modelardb_storage/src/lib.rs
@@ -312,17 +312,14 @@ mod tests {
         let object_store = Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
 
         let path = Path::from("test.parquet");
-        let full_path = temp_dir.path().join("test.parquet");
 
         let result = read_record_batch_from_apache_parquet_file(&path, object_store).await;
 
-        let error_message = format!(
-            "Parquet Error: Parquet error: Object at location {} not found:",
-            full_path.display()
-        );
-
-        // The specific error message is OS-dependent, so we only check that it contains the expected prefix.
-        assert!(result.unwrap_err().to_string().contains(&error_message));
+        // The specific error message is OS-dependent, so we only check that it contains the
+        // expected prefix and OS error code.
+        let actual_error_message = result.unwrap_err().to_string();
+        assert!(actual_error_message.contains("Parquet error: Object at location"));
+        assert!(actual_error_message.contains("os error 2"));
     }
 
     // Tests for write_record_batch_to_apache_parquet_file().

--- a/crates/modelardb_storage/src/lib.rs
+++ b/crates/modelardb_storage/src/lib.rs
@@ -316,14 +316,13 @@ mod tests {
 
         let result = read_record_batch_from_apache_parquet_file(&path, object_store).await;
 
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            format!(
-                "Parquet Error: Parquet error: Object at location {} not found: \
-                The system cannot find the file specified. (os error 2)",
-                full_path.display()
-            )
+        let error_message = format!(
+            "Parquet Error: Parquet error: Object at location {} not found:",
+            full_path.display()
         );
+
+        // The specific error message is OS-dependent, so we only check that it contains the expected prefix.
+        assert!(result.unwrap_err().to_string().contains(&error_message));
     }
 
     // Tests for write_record_batch_to_apache_parquet_file().

--- a/crates/modelardb_storage/src/metadata/table_metadata_manager.rs
+++ b/crates/modelardb_storage/src/metadata/table_metadata_manager.rs
@@ -840,11 +840,11 @@ mod tests {
     async fn test_drop_table_metadata_for_missing_table() {
         let (_temp_dir, metadata_manager) = create_metadata_manager_and_save_normal_tables().await;
 
-        assert!(
-            metadata_manager
-                .drop_table_metadata("missing_table")
-                .await
-                .is_err()
+        let result = metadata_manager.drop_table_metadata("missing_table").await;
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: Table with name 'missing_table' does not exist."
         );
     }
 
@@ -902,11 +902,14 @@ mod tests {
         let (_temp_dir, metadata_manager) =
             create_metadata_manager_and_save_time_series_table().await;
 
-        let time_series_table_metadata = metadata_manager
+        let result = metadata_manager
             .time_series_table_metadata_for_time_series_table("missing_table")
             .await;
 
-        assert!(time_series_table_metadata.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: No metadata for time series table named 'missing_table'."
+        );
     }
 
     #[tokio::test]

--- a/crates/modelardb_storage/src/parser.rs
+++ b/crates/modelardb_storage/src/parser.rs
@@ -1834,77 +1834,146 @@ mod tests {
 
     #[test]
     fn test_tokenize_and_parse_vacuum_trailing_comma() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM table_name,").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM table_name,");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: word, found: EOF"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_leading_comma() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM ,table_name").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM ,table_name");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: end of statement, found: , at Line: 1, Column: 8"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_only_comma() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM,").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM,");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: end of statement, found: , at Line: 1, Column: 7"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_quoted_table_name() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM 'table_name'").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM 'table_name'");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: end of statement, found: 'table_name' at Line: 1, Column: 8"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_retain_without_number() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM RETAIN").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM RETAIN");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: literal integer, found: EOF"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_number_without_retain() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM 30").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM 30");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: end of statement, found: 30 at Line: 1, Column: 8"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_retain_with_float() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM RETAIN 30.5").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM RETAIN 30.5");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Failed to parse '30.5' into a u64 due to: invalid digit found in string"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_retain_with_non_numeric() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM RETAIN thirty").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM RETAIN thirty");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: literal integer, found: thirty at Line: 1, Column: 15"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_retain_with_negative() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM RETAIN -30").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM RETAIN -30");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: literal integer, found: - at Line: 1, Column: 15"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_retain_with_max_plus_one() {
-        assert!(
-            tokenize_and_parse_sql_statement(&format!(
-                "VACUUM RETAIN {}",
-                MAX_RETENTION_PERIOD_IN_SECONDS + 1
-            ))
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(&format!(
+            "VACUUM RETAIN {}",
+            MAX_RETENTION_PERIOD_IN_SECONDS + 1
+        ));
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            format!(
+                "Parser Error: sql parser error: Retention period cannot be more than {MAX_RETENTION_PERIOD_IN_SECONDS} seconds."
+            )
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_retain_twice() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM RETAIN 30 RETAIN 30").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM RETAIN 30 RETAIN 30");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: end of statement, found: RETAIN at Line: 1, Column: 18"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_multiple_tables_retain_without_number() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM table_1, table_2 RETAIN").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM table_1, table_2 RETAIN");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: literal integer, found: EOF"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_tables_and_retain_mixed() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM table_1, RETAIN 30, table_2").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM table_1, RETAIN 30, table_2");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: end of statement, found: 30 at Line: 1, Column: 24"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_vacuum_retain_first() {
-        assert!(tokenize_and_parse_sql_statement("VACUUM RETAIN 30 table_1, table_2").is_err());
+        let result = tokenize_and_parse_sql_statement("VACUUM RETAIN 30 table_1, table_2");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: end of statement, found: table_1 at Line: 1, Column: 18"
+        );
     }
 }

--- a/crates/modelardb_storage/src/parser.rs
+++ b/crates/modelardb_storage/src/parser.rs
@@ -1215,7 +1215,12 @@ mod tests {
     // Tests for tokenize_and_parse_sql_statement().
     #[test]
     fn test_tokenize_and_parse_empty_sql() {
-        assert!(tokenize_and_parse_sql_statement("").is_err());
+        let result = tokenize_and_parse_sql_statement("");
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: An empty string cannot be tokenized and parsed."
+        );
     }
 
     #[test]
@@ -1277,246 +1282,296 @@ mod tests {
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_create() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: an SQL statement, found: TIME at Line: 1, Column: 1"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_create_time_space() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATETIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATETIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: an SQL statement, found: CREATETIME at Line: 1, Column: 1"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_time() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: an object type after CREATE, found: SERIES at Line: 1, Column: 8"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_time_series_space() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIMESERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIMESERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: an object type after CREATE, found: TIMESERIES at Line: 1, Column: 8"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_series() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: an object type after CREATE, found: TIME at Line: 1, Column: 8"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_series_table_space() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIESTABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIESTABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: an object type after CREATE, found: TIME at Line: 1, Column: 8"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_time_and_series() {
         // Tracks if sqlparser at some point can parse fields/tags in a TABLE.
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TABLE table_name(timestamp TIMESTAMP, field FIELD,
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TABLE table_name(timestamp TIMESTAMP, field FIELD,
              field_one FIELD(10.5), field_two FIELD(1%), tag TAG)",
-            )
-            .is_err()
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: type modifiers, found: % at Line: 2, Column: 54"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_table_name() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE(timestamp TIMESTAMP, field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: word, found: ( at Line: 1, Column: 25"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_table_table_name_space() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLEtable_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLEtable_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: an object type after CREATE, found: TIME at Line: 1, Column: 8"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_start_parentheses() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE table_name timestamp TIMESTAMP, field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE table_name timestamp TIMESTAMP, field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: (, found: timestamp at Line: 1, Column: 37"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_with_option() {
-        assert!(tokenize_and_parse_sql_statement(
+        let result = tokenize_and_parse_sql_statement(
             "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP PRIMARY KEY, field FIELD, tag TAG)",
-        )
-        .is_err());
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: ,, found: PRIMARY at Line: 1, Column: 57"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_with_sql_types() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field REAL, tag VARCHAR)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field REAL, tag VARCHAR)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected TIMESTAMP, FIELD, or TAG, found: REAL."
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_column_name() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE table_name(TIMESTAMP, field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE table_name(TIMESTAMP, field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: word, found: , at Line: 1, Column: 46"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_with_generated_timestamps() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP AS (37), field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP AS (37), field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: ,, found: AS at Line: 1, Column: 57"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_with_generated_tags() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG AS (37))",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG AS (37))",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: ,, found: AS at Line: 1, Column: 79"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_with_generated_fields_without_parentheses()
     {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD AS 37, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD AS 37, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: (, found: 37 at Line: 1, Column: 73"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_with_generated_fields_without_start_parentheses()
      {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD AS 37), tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD AS 37), tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: (, found: 37 at Line: 1, Column: 73"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_with_generated_fields_without_end_parentheses()
      {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD AS (37, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD AS (37, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: ), found: , at Line: 1, Column: 76"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_with_generated_fields_with_absolute_error_bound()
      {
-        assert!(tokenize_and_parse_sql_statement(
+        let result = tokenize_and_parse_sql_statement(
             "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD(1.0) AS (37), tag TAG)",
-        )
-        .is_err());
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: ,, found: AS at Line: 1, Column: 75"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_with_generated_fields_with_relative_error_bound()
      {
-        assert!(tokenize_and_parse_sql_statement(
+        let result = tokenize_and_parse_sql_statement(
             "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD(1.0%) AS (37), tag TAG)",
-        )
-        .is_err());
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: ,, found: AS at Line: 1, Column: 76"
+        );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_column_type() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE table_name(timestamp, field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE table_name(timestamp, field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: word, found: , at Line: 1, Column: 46"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_comma() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP field FIELD, tag TAG)",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP field FIELD, tag TAG)",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: ,, found: field at Line: 1, Column: 57"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_create_time_series_table_without_end_parentheses() {
-        assert!(
-            tokenize_and_parse_sql_statement(
-                "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG",
-            )
-            .is_err()
+        let result = tokenize_and_parse_sql_statement(
+            "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG",
+        );
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Parser Error: sql parser error: Expected: ,, found: EOF"
         );
     }
 
     #[test]
     fn test_tokenize_and_parse_two_create_time_series_table_statements() {
-        let error = tokenize_and_parse_sql_statement(
+        let result = tokenize_and_parse_sql_statement(
             "CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG);
              CREATE TIME SERIES TABLE table_name(timestamp TIMESTAMP, field FIELD, tag TAG)",
         );
 
-        assert!(error.is_err());
-
         assert_eq!(
-            error.unwrap_err().to_string(),
+            result.unwrap_err().to_string(),
             "Invalid Argument Error: Multiple SQL statements are not supported."
         );
     }

--- a/crates/modelardb_types/src/functions.rs
+++ b/crates/modelardb_types/src/functions.rs
@@ -89,6 +89,11 @@ mod tests {
 
     #[test]
     fn test_invalid_bytes_to_schema() {
-        assert!(try_convert_bytes_to_schema(vec!(1, 2, 4, 8)).is_err());
+        let result = try_convert_bytes_to_schema(vec!(1, 2, 4, 8));
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Arrow Error: Parser error: The buffer length (0) is less than the encapsulated message's reported length (134480385)"
+        );
     }
 }

--- a/crates/modelardb_types/src/functions.rs
+++ b/crates/modelardb_types/src/functions.rs
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn test_invalid_bytes_to_schema() {
-        let result = try_convert_bytes_to_schema(vec!(1, 2, 4, 8));
+        let result = try_convert_bytes_to_schema(vec![1, 2, 4, 8]);
 
         assert_eq!(
             result.unwrap_err().to_string(),

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -407,7 +407,7 @@ impl fmt::Display for ServerMode {
 mod tests {
     use super::*;
 
-    use arrow::datatypes::Field;
+    use arrow::datatypes::{Field, TimestampMillisecondType};
     use proptest::num;
     use proptest::proptest;
 
@@ -433,12 +433,16 @@ mod tests {
     fn test_cannot_create_time_series_table_metadata_with_invalid_timestamp_type() {
         let schema = Schema::new(vec![
             Field::new("tag", DataType::Utf8, false),
-            Field::new("timestamp", DataType::UInt8, false),
+            Field::new("timestamp", TimestampMillisecondType::DATA_TYPE, false),
             Field::new("value", ArrowValue::DATA_TYPE, false),
         ]);
 
         let result = create_simple_time_series_table_metadata(schema);
-        assert!(result.is_err());
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: The data type 'Timestamp(Millisecond, None)' of column 'timestamp' is not supported in a time series table."
+        );
     }
 
     #[test]
@@ -450,7 +454,11 @@ mod tests {
         ]);
 
         let result = create_simple_time_series_table_metadata(schema);
-        assert!(result.is_err());
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: The data type 'UInt8' of column 'tag' is not supported in a time series table."
+        );
     }
 
     #[test]
@@ -461,7 +469,11 @@ mod tests {
         ]);
 
         let result = create_simple_time_series_table_metadata(schema);
-        assert!(result.is_err());
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: There needs to be at least one field column."
+        );
     }
 
     #[test]
@@ -473,7 +485,11 @@ mod tests {
         ]);
 
         let result = create_simple_time_series_table_metadata(schema);
-        assert!(result.is_err());
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: The data type 'UInt8' of column 'value' is not supported in a time series table."
+        );
     }
 
     /// Return metadata for a time series table with one tag column and the timestamp column at index 1.
@@ -502,7 +518,10 @@ mod tests {
             generated_columns,
         );
 
-        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: An error bound must be defined for each column."
+        );
     }
 
     #[test]
@@ -516,7 +535,10 @@ mod tests {
             vec![],
         );
 
-        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: A generated column or None must be defined for each column."
+        );
     }
 
     #[test]
@@ -542,7 +564,10 @@ mod tests {
             generated_columns,
         );
 
-        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: A generated field column cannot depend on generated field columns."
+        );
     }
 
     fn time_series_table_schema_error_bounds_and_generated_columns()

--- a/crates/modelardb_types/src/types.rs
+++ b/crates/modelardb_types/src/types.rs
@@ -659,7 +659,7 @@ mod tests {
     // Tests for ErrorBound.
     #[test]
     fn test_absolute_error_bound_cannot_be_zero() {
-        assert!(ErrorBound::try_new_absolute(ERROR_BOUND_ZERO).is_err())
+        assert_absolute_error_bound_error(ERROR_BOUND_ZERO);
     }
 
     proptest! {
@@ -670,28 +670,37 @@ mod tests {
 
         #[test]
         fn test_absolute_error_bound_cannot_be_negative(value in num::f32::NEGATIVE) {
-            assert!(ErrorBound::try_new_absolute(value).is_err())
+            assert_absolute_error_bound_error(value);
         }
     }
 
     #[test]
     fn test_absolute_error_bound_cannot_be_positive_infinity() {
-        assert!(ErrorBound::try_new_absolute(f32::INFINITY).is_err())
+        assert_absolute_error_bound_error(f32::INFINITY);
     }
 
     #[test]
     fn test_absolute_error_bound_cannot_be_negative_infinity() {
-        assert!(ErrorBound::try_new_absolute(f32::NEG_INFINITY).is_err())
+        assert_absolute_error_bound_error(f32::NEG_INFINITY);
     }
 
     #[test]
     fn test_absolute_error_bound_cannot_be_nan() {
-        assert!(ErrorBound::try_new_absolute(f32::NAN).is_err())
+        assert_absolute_error_bound_error(f32::NAN);
+    }
+
+    fn assert_absolute_error_bound_error(value: f32) {
+        let result = ErrorBound::try_new_absolute(value);
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: An absolute error bound must be a positive finite value."
+        );
     }
 
     #[test]
     fn test_relative_error_bound_cannot_be_zero() {
-        assert!(ErrorBound::try_new_relative(ERROR_BOUND_ZERO).is_err())
+        assert_relative_error_bound_error(ERROR_BOUND_ZERO);
     }
 
     proptest! {
@@ -700,28 +709,37 @@ mod tests {
             if percentage <= 100.0 {
                 assert!(ErrorBound::try_new_relative(percentage).is_ok())
             } else {
-                assert!(ErrorBound::try_new_relative(percentage).is_err())
+                assert_relative_error_bound_error(percentage);
             }
         }
 
         #[test]
         fn test_relative_error_bound_cannot_be_negative(percentage in num::f32::NEGATIVE) {
-            assert!(ErrorBound::try_new_relative(percentage).is_err())
+            assert_relative_error_bound_error(percentage);
         }
     }
 
     #[test]
     fn test_relative_error_bound_cannot_be_positive_infinity() {
-        assert!(ErrorBound::try_new_relative(f32::INFINITY).is_err())
+        assert_relative_error_bound_error(f32::INFINITY);
     }
 
     #[test]
     fn test_relative_error_bound_cannot_be_negative_infinity() {
-        assert!(ErrorBound::try_new_relative(f32::NEG_INFINITY).is_err())
+        assert_relative_error_bound_error(f32::NEG_INFINITY);
     }
 
     #[test]
     fn test_relative_error_bound_cannot_be_nan() {
-        assert!(ErrorBound::try_new_relative(f32::NAN).is_err())
+        assert_relative_error_bound_error(f32::NAN);
+    }
+
+    fn assert_relative_error_bound_error(value: f32) {
+        let result = ErrorBound::try_new_relative(value);
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid Argument Error: A relative error bound must be a positive value that is at most 100.0%."
+        );
     }
 }


### PR DESCRIPTION
Closes https://github.com/ModelarData/ModelarDB-RS/issues/255 by updating all tests that use `is_err()` to instead check the specific error message. This ensures that the error messages are understandable and that we test for the correct errors.