### PR TITLE
Fix link in README due to renaming actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 :warning: **The current version of ModelarDB is alpha software and not yet ready for production use.**
 
 [![Ast-grep Scan](https://github.com/ModelarData/ModelarDB-RS/actions/workflows/ast-grep-scan.yml/badge.svg)](https://github.com/ModelarData/ModelarDB-RS/actions/workflows/ast-grep-scan.yml/badge.yml)
-[![Build, Lint, and Test](https://github.com/ModelarData/ModelarDB-RS/actions/workflows/build-lint-and-test.yml/badge.svg)](https://github.com/ModelarData/ModelarDB-RS/actions/workflows/build-lint-and-test.yml)
+[![Build, Lint, Test, and Upload](https://github.com/ModelarData/ModelarDB-RS/actions/workflows/build-lint-test-and-upload.yml/badge.svg)](https://github.com/ModelarData/ModelarDB-RS/actions/workflows/build-lint-test-and-upload.yml)
 
 ModelarDB is an efficient high-performance time series management system that is designed to efficiently ingest,
 transfer, store, and analyze high-frequency time series across the edge, cloud, and client. It provides state-of-the-art


### PR DESCRIPTION
This fixes a broken link to one of the GitHub Actions in the README. This bug was caused by the name of the main GitHub Action being changed by #365.