### PR TITLE
Remove coverage from RUSTFLAGS in build_and_upload_binaries

### DIFF
--- a/.github/workflows/build-lint-test-and-upload.yml
+++ b/.github/workflows/build-lint-test-and-upload.yml
@@ -23,7 +23,7 @@ on:
 env:
   # General.
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -C instrument-coverage -C strip=symbols -D warnings
+  RUSTFLAGS: -C strip=symbols -D warnings
   RUSTDOCFLAGS: -D warnings
   LLVM_PROFILE_FILE: modelardb-%p-%m.profraw
 
@@ -37,6 +37,8 @@ env:
 jobs:
   build_lint_and_test:
     name: Build, Lint, and Test
+    env:
+      RUSTFLAGS: -C instrument-coverage -C strip=symbols -D warnings
 
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -135,8 +137,6 @@ jobs:
     name: Build and Upload Binaries
     needs: build_lint_and_test
     if: github.ref == 'refs/heads/main'
-    env:
-      RUSTFLAGS: -C strip=symbols -D warnings
 
     runs-on: ${{ matrix.operating-system }}
     strategy:


### PR DESCRIPTION
When using the wheel files from the artifacts created in the "build_and_upload_binaries", a minor bug was found where a ".profraw" code coverage file was generated every time the Python code importing the Library was executed. We still want to generate the code coverage report for the other steps but for the built artifacts, this should not be necessary.