### PR TITLE
Handle TRUNCATE operations in the WAL

### DIFF
--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -345,6 +345,7 @@ impl Context {
         // If the table is a time series table, truncate the table log file from the write-ahead
         // log to ensure data is not retained and replayed upon restart.
         if local_data_folder.is_time_series_table(table_name).await? {
+            // We use a read lock since the specific table log is locked internally before being truncated.
             let write_ahead_log = self.write_ahead_log.read().await;
             write_ahead_log.truncate_table_log(table_name)?;
         }

--- a/crates/modelardb_server/src/context.rs
+++ b/crates/modelardb_server/src/context.rs
@@ -329,8 +329,8 @@ impl Context {
     }
 
     /// Delete all data from the table with `table_name` if it exists. The table data is deleted
-    /// from the storage engine and Delta Lake. If the table does not exist or if it could not be
-    /// truncated, [`ModelarDbServerError`] is returned.
+    /// from the storage engine, write-ahead log, and Delta Lake. If the table does not exist or if
+    /// it could not be truncated, [`ModelarDbServerError`] is returned.
     pub async fn truncate_table(&self, table_name: &str) -> Result<()> {
         // Deleting the table from the storage engine does not require the table to exist, so the
         // table is checked first.
@@ -340,11 +340,17 @@ impl Context {
 
         self.drop_table_from_storage_engine(table_name).await?;
 
+        let local_data_folder = &self.data_folders.local_data_folder;
+
+        // If the table is a time series table, truncate the table log file from the write-ahead
+        // log to ensure data is not retained and replayed upon restart.
+        if local_data_folder.is_time_series_table(table_name).await? {
+            let write_ahead_log = self.write_ahead_log.read().await;
+            write_ahead_log.truncate_table_log(table_name)?;
+        }
+
         // Delete the table data from the Delta Lake.
-        self.data_folders
-            .local_data_folder
-            .truncate_table(table_name)
-            .await?;
+        local_data_folder.truncate_table(table_name).await?;
 
         Ok(())
     }

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -1572,6 +1572,26 @@ mod tests {
         assert!(unpersisted.is_empty());
     }
 
+    #[test]
+    fn test_truncate_segmented_log_maintains_batch_ids() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (_folder_path, segmented_log) = new_segmented_log(&temp_dir);
+
+        // Fill one full segment and write two more into the active segment.
+        let batch = table::uncompressed_time_series_table_record_batch(10);
+        let segment_batch_count = fill_segment_to_threshold(&segmented_log, &batch);
+        segmented_log.append_and_sync(&batch).unwrap();
+        segmented_log.append_and_sync(&batch).unwrap();
+
+        let expected_next_id = segment_batch_count + 2;
+
+        // Truncate should reset the state but carry over the next_batch_id.
+        segmented_log.truncate().unwrap();
+
+        let active = segmented_log.active_segment.lock().unwrap();
+        assert_eq!(active.start_id, expected_next_id);
+    }
+
     /// Fill the segment with `batch` until it reaches [`SEGMENT_SIZE_THRESHOLD_IN_BYTES`]. Return
     /// the number of batches that were appended.
     fn fill_segment_to_threshold(segmented_log: &SegmentedLog, batch: &RecordBatch) -> u64 {

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -571,6 +571,55 @@ impl SegmentedLog {
 
         Ok(all_batches)
     }
+
+    /// Truncate all data in the log by deleting all closed segment files from disk and starting a
+    /// new active segment file. If the active segment could not be closed or a new active segment
+    /// could not be started, return [`ModelarDbStorageError`].
+    fn truncate(&self) -> Result<()> {
+        // Acquire the mutexes to ensure the log is not being written to while truncating.
+        let mut persisted_batch_ids = self
+            .persisted_batch_ids
+            .lock()
+            .expect("Mutex should not be poisoned.");
+
+        let mut active = self
+            .active_segment
+            .lock()
+            .expect("Mutex should not be poisoned.");
+
+        let mut closed_segments = self
+            .closed_segments
+            .lock()
+            .expect("Mutex should not be poisoned.");
+
+        persisted_batch_ids.clear();
+
+        // Delete all closed segments from disk.
+        for segment in closed_segments.drain(..) {
+            debug!(
+                path = %segment.path.display(),
+                "Deleting closed WAL segment due to table truncate."
+            );
+
+            std::fs::remove_file(&segment.path)?;
+        }
+
+        // Delete the active segment from disk.
+        debug!(
+            path = %active.path.display(),
+            "Deleting active WAL segment due to table truncate."
+        );
+
+        std::fs::remove_file(&active.path)?;
+
+        // Continue generating ids matching the end of the deleted segments to avoid id collisions.
+        let next_id = active.next_batch_id;
+
+        // Open a new active segment
+        *active = ActiveSegment::try_new(self.folder_path.clone(), &self.schema, next_id)?;
+
+        Ok(())
+    }
 }
 
 /// If a leftover active segment (`{start_id}-.arrows`) exists in `folder_path`, rename it to

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -194,6 +194,14 @@ impl WriteAheadLog {
         table_log.unpersisted_batches()
     }
 
+    /// Truncate the table log for the given table name, removing all closed segment files from
+    /// disk, and starting a new active segment file. If the table log does not exist or the data
+    /// could not be truncated, return [`ModelarDbStorageError`].
+    pub fn truncate_table_log(&self, table_name: &str) -> Result<()> {
+        let table_log = self.table_log(table_name)?;
+        table_log.truncate()
+    }
+
     /// Get the table log for the table with the given name. If the table log does not exist, return
     /// [`ModelarDbStorageError`].
     fn table_log(&self, table_name: &str) -> Result<&SegmentedLog> {

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -1536,6 +1536,42 @@ mod tests {
         assert_eq!(unpersisted.last().unwrap(), &(segment_batch_count, batch));
     }
 
+    #[test]
+    fn test_truncate_segmented_log_clears_files_and_state() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (folder_path, segmented_log) = new_segmented_log(&temp_dir);
+
+        // Fill five full segments and write two more into the active segment.
+        let batch = table::uncompressed_time_series_table_record_batch(10);
+        for _ in 0..5 {
+            fill_segment_to_threshold(&segmented_log, &batch);
+        }
+
+        segmented_log
+            .mark_batches_as_persisted(HashSet::from([0, 1, 2]))
+            .unwrap();
+
+        segmented_log.append_and_sync(&batch).unwrap();
+        segmented_log.append_and_sync(&batch).unwrap();
+
+        // Ensure we have five closed segments in memory and on disk, and one active segment.
+        assert_eq!(segmented_log.closed_segments.lock().unwrap().len(), 5);
+        assert_eq!(std::fs::read_dir(&folder_path).unwrap().count(), 6);
+
+        segmented_log.truncate().unwrap();
+
+        // Verify in-memory state is cleared.
+        assert_eq!(segmented_log.closed_segments.lock().unwrap().len(), 0);
+        assert_eq!(segmented_log.persisted_batch_ids.lock().unwrap().len(), 0);
+
+        // Verify the old closed segments and the old active segment were deleted from disk,
+        // and exactly one new active segment was created.
+        assert_eq!(std::fs::read_dir(&folder_path).unwrap().count(), 1);
+
+        let unpersisted = segmented_log.unpersisted_batches().unwrap();
+        assert!(unpersisted.is_empty());
+    }
+
     /// Fill the segment with `batch` until it reaches [`SEGMENT_SIZE_THRESHOLD_IN_BYTES`]. Return
     /// the number of batches that were appended.
     fn fill_segment_to_threshold(segmented_log: &SegmentedLog, batch: &RecordBatch) -> u64 {

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -194,9 +194,9 @@ impl WriteAheadLog {
         table_log.unpersisted_batches()
     }
 
-    /// Truncate the table log for the given table name, removing all closed segment files from
-    /// disk, and starting a new active segment file. If the table log does not exist or the data
-    /// could not be truncated, return [`ModelarDbStorageError`].
+    /// Truncate the table log for the given table name, removing all closed segment files and the
+    /// active segment file from disk, and starting a new active segment file. If the table log does
+    /// not exist or the data could not be truncated, return [`ModelarDbStorageError`].
     pub fn truncate_table_log(&self, table_name: &str) -> Result<()> {
         let table_log = self.table_log(table_name)?;
         table_log.truncate()

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -610,11 +610,13 @@ impl SegmentedLog {
 
         std::fs::remove_file(&active.path)?;
 
-        // Continue generating ids from the next unused batch id to avoid id collisions.
+        // Continue from the next unused batch id instead of resetting to 0. Historical batch
+        // ids may still be referenced by Delta commit metadata, so reusing them could cause
+        // old and new WAL batch ids to collide, for example after a rollback.
         let next_id = active.next_batch_id;
         let new_active = ActiveSegment::try_new(self.folder_path.clone(), &self.schema, next_id)?;
 
-        // Commit the in-memory state transition only after all filesystem work succeeds.
+        // Commit the in-memory state transition only after all filesystem operations succeed.
         persisted_batch_ids.clear();
         closed_segments.clear();
         *active = new_active;

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -592,10 +592,8 @@ impl SegmentedLog {
             .lock()
             .expect("Mutex should not be poisoned.");
 
-        persisted_batch_ids.clear();
-
         // Delete all closed segments from disk.
-        for segment in closed_segments.drain(..) {
+        for segment in closed_segments.iter() {
             debug!(
                 path = %segment.path.display(),
                 "Deleting closed WAL segment due to table truncate."
@@ -614,9 +612,12 @@ impl SegmentedLog {
 
         // Continue generating ids from the next unused batch id to avoid id collisions.
         let next_id = active.next_batch_id;
+        let new_active = ActiveSegment::try_new(self.folder_path.clone(), &self.schema, next_id)?;
 
-        // Open a new active segment.
-        *active = ActiveSegment::try_new(self.folder_path.clone(), &self.schema, next_id)?;
+        // Commit the in-memory state transition only after all filesystem work succeeds.
+        persisted_batch_ids.clear();
+        closed_segments.clear();
+        *active = new_active;
 
         Ok(())
     }

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -989,6 +989,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_truncate_table_log_fails_if_table_log_does_not_exist() {
+        let (_temp_dir, wal) = new_empty_write_ahead_log().await;
+
+        let result = wal.truncate_table_log(TIME_SERIES_TABLE_NAME);
+
+        assert_eq!(
+            result.err().unwrap().to_string(),
+            format!(
+                "Invalid State Error: Table log for table '{TIME_SERIES_TABLE_NAME}' does not exist.",
+            )
+        );
+    }
+
+    #[tokio::test]
     async fn test_set_segment_size_threshold_in_bytes_updates_existing_table_logs() {
         let (_temp_dir, data_folder) = create_data_folder_with_time_series_table().await;
         let mut wal = WriteAheadLog::try_new(&data_folder, SEGMENT_SIZE_THRESHOLD_IN_BYTES)

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -989,6 +989,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_truncate_table_log_clears_unpersisted_batches_and_preserves_batch_ids() {
+        let (_temp_dir, data_folder) = create_data_folder_with_time_series_table().await;
+        let wal = WriteAheadLog::try_new(&data_folder, SEGMENT_SIZE_THRESHOLD_IN_BYTES)
+            .await
+            .unwrap();
+
+        let batch = table::uncompressed_time_series_table_record_batch(10);
+
+        assert_eq!(
+            wal.append_to_table_log(TIME_SERIES_TABLE_NAME, &batch)
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            wal.append_to_table_log(TIME_SERIES_TABLE_NAME, &batch)
+                .unwrap(),
+            1
+        );
+
+        let unpersisted = wal
+            .unpersisted_batches_in_table_log(TIME_SERIES_TABLE_NAME)
+            .unwrap();
+        assert_eq!(unpersisted.len(), 2);
+
+        wal.truncate_table_log(TIME_SERIES_TABLE_NAME).unwrap();
+
+        let unpersisted = wal
+            .unpersisted_batches_in_table_log(TIME_SERIES_TABLE_NAME)
+            .unwrap();
+        assert!(unpersisted.is_empty());
+
+        assert_eq!(
+            wal.append_to_table_log(TIME_SERIES_TABLE_NAME, &batch)
+                .unwrap(),
+            2
+        );
+    }
+
+    #[tokio::test]
     async fn test_truncate_table_log_fails_if_table_log_does_not_exist() {
         let (_temp_dir, wal) = new_empty_write_ahead_log().await;
 

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -612,7 +612,7 @@ impl SegmentedLog {
 
         std::fs::remove_file(&active.path)?;
 
-        // Continue generating ids matching the end of the deleted segments to avoid id collisions.
+        // Continue generating ids from the next unused batch id to avoid id collisions.
         let next_id = active.next_batch_id;
 
         // Open a new active segment
@@ -1590,6 +1590,7 @@ mod tests {
 
         let active = segmented_log.active_segment.lock().unwrap();
         assert_eq!(active.start_id, expected_next_id);
+        assert_eq!(active.next_batch_id, expected_next_id);
     }
 
     #[test]

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -615,7 +615,7 @@ impl SegmentedLog {
         // Continue generating ids from the next unused batch id to avoid id collisions.
         let next_id = active.next_batch_id;
 
-        // Open a new active segment
+        // Open a new active segment.
         *active = ActiveSegment::try_new(self.folder_path.clone(), &self.schema, next_id)?;
 
         Ok(())

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -1592,6 +1592,30 @@ mod tests {
         assert_eq!(active.start_id, expected_next_id);
     }
 
+    #[test]
+    fn test_truncate_empty_segmented_log() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (folder_path, segmented_log) = new_segmented_log(&temp_dir);
+
+        // Truncate the segmented log before appending any data.
+        segmented_log.truncate().unwrap();
+
+        // Verify in-memory state remains empty.
+        assert!(segmented_log.closed_segments.lock().unwrap().is_empty());
+        assert!(segmented_log.persisted_batch_ids.lock().unwrap().is_empty());
+
+        // Verify the active segment ID is still 0, so it has not artificially incremented.
+        let active = segmented_log.active_segment.lock().unwrap();
+        assert_eq!(active.start_id, 0);
+        assert_eq!(active.next_batch_id, 0);
+        drop(active);
+
+        // Verify the old active segment was successfully replaced and exactly one file remains.
+        assert_eq!(std::fs::read_dir(&folder_path).unwrap().count(), 1);
+        let unpersisted = segmented_log.unpersisted_batches().unwrap();
+        assert!(unpersisted.is_empty());
+    }
+
     /// Fill the segment with `batch` until it reaches [`SEGMENT_SIZE_THRESHOLD_IN_BYTES`]. Return
     /// the number of batches that were appended.
     fn fill_segment_to_threshold(segmented_log: &SegmentedLog, batch: &RecordBatch) -> u64 {

--- a/crates/modelardb_storage/src/write_ahead_log.rs
+++ b/crates/modelardb_storage/src/write_ahead_log.rs
@@ -573,8 +573,8 @@ impl SegmentedLog {
     }
 
     /// Truncate all data in the log by deleting all closed segment files from disk and starting a
-    /// new active segment file. If the active segment could not be closed or a new active segment
-    /// could not be started, return [`ModelarDbStorageError`].
+    /// new active segment file. If a closed segment file or the active segment file could not be
+    /// deleted or a new active segment file could not be created, return [`ModelarDbStorageError`].
     fn truncate(&self) -> Result<()> {
         // Acquire the mutexes to ensure the log is not being written to while truncating.
         let mut persisted_batch_ids = self
@@ -1576,7 +1576,7 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_segmented_log_clears_files_and_state() {
+    fn test_truncate_clears_files_and_state() {
         let temp_dir = tempfile::tempdir().unwrap();
         let (folder_path, segmented_log) = new_segmented_log(&temp_dir);
 
@@ -1612,7 +1612,7 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_segmented_log_maintains_batch_ids() {
+    fn test_truncate_preserves_batch_ids() {
         let temp_dir = tempfile::tempdir().unwrap();
         let (_folder_path, segmented_log) = new_segmented_log(&temp_dir);
 


### PR DESCRIPTION
This PR closes #393 by adding support for explicitly truncating a table log in the WAL. This is necessary to clean up active segments and any orphaned closed segments that were not deleted when the storage engine was flushed and the flushed data was marked as persisted. 

An explicity method to truncate also seems preferable due to the complexity of the interaction between the WAL and the Delta Lake. If we are explicit with all operations, it should be easier to keep them in sync. 