### PR TITLE
Switch from minio/minio to pgsty/minio

### DIFF
--- a/.github/workflows/build-lint-test-and-upload.yml
+++ b/.github/workflows/build-lint-test-and-upload.yml
@@ -58,7 +58,7 @@ jobs:
         'Linux')
           curl -L -O https://github.com/pgsty/minio/releases/download/RELEASE.2026-06-18T00-00-00Z/minio_20260618000000.0.0_linux_amd64.tar.gz ;;
         'Darwin')
-          curl -L -O https://github.com/pgsty/minio/releases/download/RELEASE.2026-06-18T00-00-00Z/minio_20260618000000.0.0_darwin_amd64.tar.gz ;;
+          curl -L -O https://github.com/pgsty/minio/releases/download/RELEASE.2026-06-18T00-00-00Z/minio_20260618000000.0.0_darwin_arm64.tar.gz ;;
         *)
           curl -L -O https://github.com/pgsty/minio/releases/download/RELEASE.2026-06-18T00-00-00Z/minio_20260618000000.0.0_windows_amd64.tar.gz ;;
         esac

--- a/.github/workflows/build-lint-test-and-upload.yml
+++ b/.github/workflows/build-lint-test-and-upload.yml
@@ -65,6 +65,7 @@ jobs:
 
         tar -xf minio_*.tar.gz
         ./minio server minio_data_folder --console-address :9001 &
+        sleep 5 # Ensure minio has fully finished creating the endpoint.
         aws s3 mb s3://modelardb --endpoint-url http://localhost:9000
 
     # Setup Azurite.
@@ -73,6 +74,7 @@ jobs:
       run: |
         npm install azurite
         node_modules/.bin/azurite --skipApiVersionCheck --location azurite_data_folder &
+        sleep 5 # Ensure azurite has fully finished creating the endpoint.
         az storage container create -n modelardb --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;'
 
     # Setup Protobuf Compiler.

--- a/.github/workflows/build-lint-test-and-upload.yml
+++ b/.github/workflows/build-lint-test-and-upload.yml
@@ -56,14 +56,14 @@ jobs:
       run: |
         case $(uname) in
         'Linux')
-          curl -L https://dl.min.io/server/minio/release/linux-amd64/minio -o minio ;;
+          curl -L -O https://github.com/pgsty/minio/releases/download/RELEASE.2026-06-18T00-00-00Z/minio_20260618000000.0.0_linux_amd64.tar.gz ;;
         'Darwin')
-          curl -L https://dl.min.io/server/minio/release/darwin-arm64/minio -o minio ;;
+          curl -L -O https://github.com/pgsty/minio/releases/download/RELEASE.2026-06-18T00-00-00Z/minio_20260618000000.0.0_darwin_amd64.tar.gz ;;
         *)
-          curl -L https://dl.min.io/server/minio/release/windows-amd64/minio.exe -o minio ;;
+          curl -L -O https://github.com/pgsty/minio/releases/download/RELEASE.2026-06-18T00-00-00Z/minio_20260618000000.0.0_windows_amd64.tar.gz ;;
         esac
 
-        chmod +x minio
+        tar -xf minio_*.tar.gz
         ./minio server minio_data_folder --console-address :9001 &
         aws s3 mb s3://modelardb --endpoint-url http://localhost:9000
 

--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -22,7 +22,7 @@ x-aws-variables: &aws-variables
 services:
   # Object store services.
   minio-server:
-    image: minio/minio
+    image: pgsty/minio
     container_name: minio-server
     ports:
       - "9000:9000"
@@ -33,7 +33,7 @@ services:
     command: server --console-address ":9001" /data
 
   create-bucket:
-    image: minio/mc
+    image: pgsty/mc
     container_name: create-bucket
     depends_on:
       - minio-server

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -99,7 +99,7 @@ AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
 ```
 
-For example, to use a local instance of [MinIO](https://min.io/), assuming the access key id `KURo1eQeMhDeVsrz` and the
+For example, to use a local instance of [MinIO](https://github.com/pgsty/minio), assuming the access key id `KURo1eQeMhDeVsrz` and the
 secret access key `sp7TDyD2ZruJ0VdFHmkacT1Y90PVPF7p` have been created through MinIO's command line tool or web
 interface, set the environment variables as follows:
 


### PR DESCRIPTION
This PR fixed #356 by switching from `minio/minio` to `pgsty/minio` as neither `RustFS` and `VersityGW` seems suitable for a production deployment. `RustFS` may become production-ready in the future, but at the moment, it is still beta software.