### PR TITLE
Use uint64 in C-API instead of string workaround

### DIFF
--- a/crates/modelardb_embedded/bindings/c/modelardb_embedded.h
+++ b/crates/modelardb_embedded/bindings/c/modelardb_embedded.h
@@ -197,13 +197,13 @@ int modelardb_embedded_drop(void* maybe_operations_ptr,
 int modelardb_embedded_vacuum(void* maybe_operations_ptr,
                               bool is_data_folder,
                               const char* table_name_ptr,
-                              const char* retention_period_in_seconds_ptr);
+                              const uint64_t* retention_period_in_seconds_ptr);
 
 // Optimize the table by compacting its many small files into fewer larger files.
 int modelardb_embedded_optimize(void* maybe_operations_ptr,
                                 bool is_data_folder,
                                 const char* table_name_ptr,
-                                const char* target_size_in_bytes_ptr);
+                                const uint64_t* target_size_in_bytes_ptr);
 
 // Return a human-readable representation of the last error on this thread.
 const char* modelardb_embedded_error();

--- a/crates/modelardb_embedded/bindings/python/modelardb/operations.py
+++ b/crates/modelardb_embedded/bindings/python/modelardb/operations.py
@@ -668,12 +668,7 @@ class Operations:
         table_name_ptr = ffi.new("char[]", bytes(table_name, "UTF-8"))
 
         if retention_period_in_seconds is not None:
-            # Convert the retention period to a string to avoid issues with converting an int to a C type that uses
-            # an inconsistent amount of bits across platforms and then converting that to a 64-bit integer in Rust.
-            # The string is converted directly to an unsigned 64-bit integer in Rust.
-            retention_period_in_seconds_ptr = ffi.new(
-                "char[]", bytes(str(retention_period_in_seconds), "UTF-8")
-            )
+            retention_period_in_seconds_ptr = ffi.new("uint64_t*", retention_period_in_seconds)
         else:
             retention_period_in_seconds_ptr = ffi.NULL
 
@@ -699,12 +694,7 @@ class Operations:
         table_name_ptr = ffi.new("char[]", bytes(table_name, "UTF-8"))
 
         if target_size_in_bytes is not None:
-            # Convert the target size to a string to avoid issues with converting an int to a C type that uses
-            # an inconsistent amount of bits across platforms and then converting that to a 64-bit integer in Rust.
-            # The string is converted directly to an unsigned 64-bit integer in Rust.
-            target_size_in_bytes_ptr = ffi.new(
-                "char[]", bytes(str(target_size_in_bytes), "UTF-8")
-            )
+            target_size_in_bytes_ptr = ffi.new("uint64_t*", target_size_in_bytes)
         else:
             target_size_in_bytes_ptr = ffi.NULL
 

--- a/crates/modelardb_embedded/src/capi.rs
+++ b/crates/modelardb_embedded/src/capi.rs
@@ -967,18 +967,17 @@ unsafe fn drop(
 }
 
 /// Vacuums the table with the name in `table_name_ptr` in the [`DataFolder`] or [`Client`] in
-/// `maybe_operations_ptr` by deleting stale files that are older than `retention_period_in_seconds_ptr`
-/// seconds. Assumes `maybe_operations_ptr` points to a [`DataFolder`] or [`Client`];
-/// `table_name_ptr` points to a valid C string; and `retention_period_in_seconds_ptr` points to a
-/// valid C string, or is null to use the default retention period. A C string is used for the
-/// retention period to avoid issues with different platforms using an inconsistent amount of bits
-/// for integer types. The string is converted directly to an unsigned 64-bit integer in Rust.
+/// `maybe_operations_ptr` by deleting stale files that are older than
+/// `retention_period_in_seconds_ptr` seconds. Assumes `maybe_operations_ptr` points to a
+/// [`DataFolder`] or [`Client`]; `table_name_ptr` points to a valid C string; and
+/// `retention_period_in_seconds_ptr` points to a valid `u64`, or is null to use the default
+/// retention period.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn modelardb_embedded_vacuum(
     maybe_operations_ptr: *mut c_void,
     is_data_folder: bool,
     table_name_ptr: *const c_char,
-    retention_period_in_seconds_ptr: *const c_char,
+    retention_period_in_seconds_ptr: *const u64,
 ) -> c_int {
     let maybe_unit = unsafe {
         vacuum(
@@ -996,24 +995,12 @@ unsafe fn vacuum(
     maybe_operations_ptr: *mut c_void,
     is_data_folder: bool,
     table_name_ptr: *const c_char,
-    retention_period_in_seconds_ptr: *const c_char,
+    retention_period_in_seconds_ptr: *const u64,
 ) -> Result<()> {
     let modelardb = unsafe { c_void_to_operations(maybe_operations_ptr, is_data_folder)? };
     let table_name = unsafe { c_char_ptr_to_str(table_name_ptr)? };
-    let maybe_retention_period_in_seconds_str =
-        unsafe { c_char_ptr_to_maybe_str(retention_period_in_seconds_ptr)? };
-
-    let maybe_retention_period_in_seconds = maybe_retention_period_in_seconds_str
-        .map(|retention_period_in_seconds_str| {
-            retention_period_in_seconds_str
-                .parse::<u64>()
-                .map_err(|error| {
-                    ModelarDbEmbeddedError::InvalidArgument(format!(
-                        "Retention period is not a valid u64: {error}"
-                    ))
-                })
-        })
-        .transpose()?;
+    let maybe_retention_period_in_seconds =
+        unsafe { retention_period_in_seconds_ptr.as_ref().copied() };
 
     TOKIO_RUNTIME.block_on(modelardb.vacuum(table_name, maybe_retention_period_in_seconds))
 }
@@ -1022,16 +1009,13 @@ unsafe fn vacuum(
 /// `maybe_operations_ptr` by compacting its many small files into fewer larger files of
 /// approximately `target_size_in_bytes_ptr` bytes. Assumes `maybe_operations_ptr` points to a
 /// [`DataFolder`] or [`Client`]; `table_name_ptr` points to a valid C string; and
-/// `target_size_in_bytes_ptr` points to a valid C string, or is null to use the default target
-/// size. A C string is used for the target size to avoid issues with different platforms using an
-/// inconsistent amount of bits for integer types. The string is converted directly to an unsigned
-/// 64-bit integer in Rust.
+/// `target_size_in_bytes_ptr` points to a valid `u64`, or is null to use the default target size.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn modelardb_embedded_optimize(
     maybe_operations_ptr: *mut c_void,
     is_data_folder: bool,
     table_name_ptr: *const c_char,
-    target_size_in_bytes_ptr: *const c_char,
+    target_size_in_bytes_ptr: *const u64,
 ) -> c_int {
     let maybe_unit = unsafe {
         optimize(
@@ -1049,22 +1033,11 @@ unsafe fn optimize(
     maybe_operations_ptr: *mut c_void,
     is_data_folder: bool,
     table_name_ptr: *const c_char,
-    target_size_in_bytes_ptr: *const c_char,
+    target_size_in_bytes_ptr: *const u64,
 ) -> Result<()> {
     let modelardb = unsafe { c_void_to_operations(maybe_operations_ptr, is_data_folder)? };
     let table_name = unsafe { c_char_ptr_to_str(table_name_ptr)? };
-    let maybe_target_size_in_bytes_str =
-        unsafe { c_char_ptr_to_maybe_str(target_size_in_bytes_ptr)? };
-
-    let maybe_target_size_in_bytes = maybe_target_size_in_bytes_str
-        .map(|target_size_in_bytes_str| {
-            target_size_in_bytes_str.parse::<u64>().map_err(|error| {
-                ModelarDbEmbeddedError::InvalidArgument(format!(
-                    "Target size is not a valid u64: {error}"
-                ))
-            })
-        })
-        .transpose()?;
+    let maybe_target_size_in_bytes = unsafe { target_size_in_bytes_ptr.as_ref().copied() };
 
     TOKIO_RUNTIME.block_on(modelardb.optimize(table_name, maybe_target_size_in_bytes))
 }


### PR DESCRIPTION
This PR changes the C-API and C header to use unsigned 64-bit integers for the vacuum() and optimize() arguments instead of the previous workaround that used a string and converted the string to u64 in the C-API.