### PR TITLE
Use modelardb_embedded Client in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3528,6 +3528,7 @@ dependencies = [
  "dirs",
  "futures",
  "modelardb_embedded",
+ "modelardb_types",
  "rustyline",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,14 +3524,12 @@ name = "modelardb_client"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-flight",
- "bytes",
  "clap",
  "dirs",
- "modelardb_auth",
+ "futures",
+ "modelardb_embedded",
  "rustyline",
  "tokio",
- "tonic",
 ]
 
 [[package]]

--- a/crates/modelardb_client/Cargo.toml
+++ b/crates/modelardb_client/Cargo.toml
@@ -24,12 +24,10 @@ name = "modelardb"
 path = "src/main.rs"
 
 [dependencies]
-arrow-flight.workspace = true
 arrow = { workspace = true, features = ["prettyprint"] }
-bytes.workspace = true
 clap.workspace = true
 dirs.workspace = true
-modelardb_auth.workspace = true
+futures.workspace = true
+modelardb_embedded.workspace = true
 rustyline.workspace = true
 tokio.workspace = true
-tonic.workspace = true

--- a/crates/modelardb_client/Cargo.toml
+++ b/crates/modelardb_client/Cargo.toml
@@ -29,5 +29,6 @@ clap.workspace = true
 dirs.workspace = true
 futures.workspace = true
 modelardb_embedded.workspace = true
+modelardb_types.workspace = true
 rustyline.workspace = true
 tokio.workspace = true

--- a/crates/modelardb_client/src/error.rs
+++ b/crates/modelardb_client/src/error.rs
@@ -21,9 +21,8 @@ use std::io::Error as IoError;
 use std::result::Result as StdResult;
 
 use arrow::error::ArrowError;
+use modelardb_embedded::error::ModelarDbEmbeddedError;
 use rustyline::error::ReadlineError as RustyLineError;
-use tonic::Status as TonicStatusError;
-use tonic::transport::Error as TonicTransportError;
 
 /// Result type used throughout `modelardb_client`.
 pub type Result<T> = StdResult<T, ModelarDbClientError>;
@@ -37,12 +36,10 @@ pub enum ModelarDbClientError {
     InvalidArgument(String),
     /// Error returned from IO operations.
     Io(IoError),
+    /// Error returned by modelardb_embedded.
+    ModelarDbEmbedded(ModelarDbEmbeddedError),
     /// Error returned by RustyLine.
     RustyLine(RustyLineError),
-    /// Status returned by Tonic.
-    TonicStatus(Box<TonicStatusError>),
-    /// Error returned by Tonic.
-    TonicTransport(TonicTransportError),
 }
 
 impl Display for ModelarDbClientError {
@@ -51,9 +48,8 @@ impl Display for ModelarDbClientError {
             Self::Arrow(reason) => write!(f, "Arrow Error: {reason}"),
             Self::InvalidArgument(reason) => write!(f, "Invalid Argument Error: {reason}"),
             Self::Io(reason) => write!(f, "Io Error: {reason}"),
+            Self::ModelarDbEmbedded(reason) => write!(f, "ModelarDB Embedded Error: {reason}"),
             Self::RustyLine(reason) => write!(f, "RustyLine Error: {reason}"),
-            Self::TonicStatus(reason) => write!(f, "Tonic Status Error: {reason}"),
-            Self::TonicTransport(reason) => write!(f, "Tonic Transport Error: {reason}"),
         }
     }
 }
@@ -65,9 +61,8 @@ impl Error for ModelarDbClientError {
             Self::Arrow(reason) => Some(reason),
             Self::InvalidArgument(_reason) => None,
             Self::Io(reason) => Some(reason),
+            Self::ModelarDbEmbedded(reason) => Some(reason),
             Self::RustyLine(reason) => Some(reason),
-            Self::TonicStatus(reason) => Some(reason),
-            Self::TonicTransport(reason) => Some(reason),
         }
     }
 }
@@ -84,20 +79,14 @@ impl From<IoError> for ModelarDbClientError {
     }
 }
 
+impl From<ModelarDbEmbeddedError> for ModelarDbClientError {
+    fn from(error: ModelarDbEmbeddedError) -> Self {
+        Self::ModelarDbEmbedded(error)
+    }
+}
+
 impl From<RustyLineError> for ModelarDbClientError {
     fn from(error: RustyLineError) -> Self {
         Self::RustyLine(error)
-    }
-}
-
-impl From<TonicStatusError> for ModelarDbClientError {
-    fn from(error: TonicStatusError) -> Self {
-        Self::TonicStatus(Box::new(error))
-    }
-}
-
-impl From<TonicTransportError> for ModelarDbClientError {
-    fn from(error: TonicTransportError) -> Self {
-        Self::TonicTransport(error)
     }
 }

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -218,7 +218,7 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
             Ok(())
         }
         // Update a setting in the configuration of the node.
-        "\\s" => {
+        "\\sc" => {
             let name =
                 command_and_arguments
                     .next()
@@ -258,7 +258,7 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
                  \\dc                           Print the configuration of the node.\n\
                  \\dn                           Print the nodes in the cluster.\n\
                  \\dm                           Print the resource usage metrics of the node.\n\
-                 \\s SETTING [VALUE]            Set SETTING to VALUE, or unset SETTING if VALUE is omitted.\n\
+                 \\sc SETTING [VALUE]           Set SETTING to VALUE, or unset SETTING if VALUE is omitted.\n\
                  \\f                            Flushes data in memory to disk.\n\
                  \\F                            Flushes data in memory and disk to the object store.\n\
                  \\h                            Print documentation for all supported commands.\n\

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -247,6 +247,11 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
         "\\f" => client.flush_memory().await.map_err(|error| error.into()),
         // Flushes all data the server currently has in memory and disk to the object store.
         "\\F" => client.flush_node().await.map_err(|error| error.into()),
+        // Kill the node and quit, the connection is dead once the node process exits.
+        "\\k" => {
+            client.kill_node().await?;
+            process::exit(0);
+        }
         // Print helpful information, explanations with \\ must be indented more to be aligned.
         "\\h" => {
             println!(

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -253,17 +253,17 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
                 "CREATE [TIME SERIES] TABLE     Execute a CREATE TABLE or CREATE TIME SERIES TABLE statement.\n\
                  INSERT INTO                    Execute an INSERT INTO statement. Must include generated columns.\n\
                  SELECT                         Execute a SELECT statement.\n\
-                 \\d TABLE_NAME                 Print the schema of a table with TABLE_NAME.\n\
-                 \\dt                           Print the name of all the tables.\n\
-                 \\dc                           Print the configuration of the node.\n\
-                 \\dn                           Print the nodes in the cluster.\n\
-                 \\dm                           Print the resource usage metrics of the node.\n\
-                 \\sc SETTING [VALUE]           Set SETTING to VALUE, or unset SETTING if VALUE is omitted.\n\
-                 \\f                            Flushes data in memory to disk.\n\
-                 \\F                            Flushes data in memory and disk to the object store.\n\
-                 \\h                            Print documentation for all supported commands.\n\
-                 \\k                            Flush data to disk, kill the node, and quit modelardb.\n\
-                 \\q                            Quit modelardb."
+                 \\d TABLE_NAME                  Print the schema of a table with TABLE_NAME.\n\
+                 \\dt                            Print the name of all the tables.\n\
+                 \\dc                            Print the configuration of the node.\n\
+                 \\dn                            Print the nodes in the cluster.\n\
+                 \\dm                            Print the resource usage metrics of the node.\n\
+                 \\sc SETTING [VALUE]            Set SETTING to VALUE, or unset SETTING if VALUE is omitted.\n\
+                 \\f                             Flushes data in memory to disk.\n\
+                 \\F                             Flushes data in memory and disk to the object store.\n\
+                 \\h                             Print documentation for all supported commands.\n\
+                 \\k                             Flush data to disk, kill the node, and quit modelardb.\n\
+                 \\q                             Quit modelardb."
             );
             Ok(())
         }

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -130,7 +130,15 @@ async fn execute_queries_from_a_repl(mut client: Client) -> Result<()> {
     // Execute commands and queries and print the result.
     while let Ok(line) = editor.readline("ModelarDB> ") {
         editor.add_history_entry(line.as_str())?;
-        execute_and_print_command_or_query(&mut client, &line).await
+        execute_and_print_command_or_query(&mut client, &line).await;
+
+        // Refresh the table names for tab-completion if a table may have been created or dropped.
+        let first_word = line.split_whitespace().next().unwrap_or("");
+        if first_word.eq_ignore_ascii_case("CREATE") || first_word.eq_ignore_ascii_case("DROP") {
+            if let Ok(table_names) = client.tables().await {
+                editor.set_helper(Some(ClientHelper::new(table_names)));
+            }
+        }
     }
 
     // Append the executed commands and queries to the history file.

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -164,6 +164,8 @@ async fn execute_and_print_command_or_query(client: &mut Client, command_or_quer
 /// * The command could not be executed.
 /// * The result could not be retrieved.
 async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Result<()> {
+    let mut command_and_arguments = command_and_arguments.split_whitespace();
+    match command_and_arguments
         .next()
         .ok_or(ModelarDbClientError::InvalidArgument(
             "No command was provided.".to_owned(),
@@ -171,18 +173,13 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
         // Print the schema of a table on the server.
         "\\d" => {
             let table_name =
-                command_and_argument
+                command_and_arguments
                     .next()
                     .ok_or(ModelarDbClientError::InvalidArgument(
                         "No table name was provided.".to_owned(),
                     ))?;
-            let flight_descriptor = FlightDescriptor::new_path(vec![table_name.to_owned()]);
-            let request = Request::new(flight_descriptor);
-            let schema_result = flight_service_client
-                .get_schema(request)
-                .await?
-                .into_inner();
-            let schema = convert::try_schema_from_ipc_buffer(&schema_result.schema)?;
+
+            let schema = client.schema(table_name).await?;
             for field in schema.fields() {
                 print!("{}: {}", field.name(), field.data_type());
                 for (metadata_name, metadata_value) in field.metadata() {
@@ -194,17 +191,15 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
         }
         // Print the name of the tables on the server.
         "\\dt" => {
-            if let Ok(tables) = retrieve_table_names(flight_service_client).await {
-                for table in tables {
-                    println!("{table}");
-                }
+            for table_name in client.tables().await? {
+                println!("{table_name}");
             }
             Ok(())
         }
         // Flushes all data the server currently has in memory to disk.
-        "\\f" => execute_action(flight_service_client, "FlushMemory", "").await,
+        "\\f" => client.flush_memory().await.map_err(|error| error.into()),
         // Flushes all data the server currently has in memory and disk to the object store.
-        "\\F" => execute_action(flight_service_client, "FlushNode", "").await,
+        "\\F" => client.flush_node().await.map_err(|error| error.into()),
         // Print helpful information, explanations with \\ must be indented more to be aligned.
         "\\h" => {
             println!(

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -31,6 +31,7 @@ use modelardb_embedded::error::ModelarDbEmbeddedError;
 use modelardb_embedded::operations::Operations;
 use modelardb_embedded::operations::client::Client;
 use modelardb_types::flight::protocol;
+use modelardb_types::flight::protocol::update_configuration::Setting;
 use rustyline::Editor;
 use rustyline::history::FileHistory;
 
@@ -214,6 +215,32 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
         "\\dm" => {
             let node_metrics = client.node_metrics().await?;
             print_node_metrics(&node_metrics);
+            Ok(())
+        }
+        // Update a setting in the configuration of the node.
+        "\\s" => {
+            let name =
+                command_and_arguments
+                    .next()
+                    .ok_or(ModelarDbClientError::InvalidArgument(
+                        "No setting was provided.".to_owned(),
+                    ))?;
+
+            let setting = Setting::from_str_name(&name.to_uppercase()).ok_or(
+                ModelarDbClientError::InvalidArgument(format!("Unknown setting: {name}.")),
+            )?;
+
+            // Omitting the value unsets the setting if it is optional.
+            let new_value = match command_and_arguments.next() {
+                Some(value) => Some(value.parse::<u64>().map_err(|_error| {
+                    ModelarDbClientError::InvalidArgument(format!(
+                        "{value} is not a valid value for {name}."
+                    ))
+                })?),
+                None => None,
+            };
+
+            client.update_configuration(setting, new_value).await?;
             Ok(())
         }
         // Flushes all data the server currently has in memory to disk.

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -114,8 +114,7 @@ async fn execute_queries_from_a_file(mut client: Client, query_file: &StdPath) -
 async fn execute_queries_from_a_repl(mut client: Client) -> Result<()> {
     // Create the read-eval-print loop.
     let mut editor = Editor::<ClientHelper, FileHistory>::new()?;
-    let table_names = client.tables().await?;
-    editor.set_helper(Some(ClientHelper::new(table_names)));
+    editor.set_helper(Some(ClientHelper::new(client.tables().await?)));
 
     // Read previously executed commands and queries from the history file.
     let history_file_name = ".modelardb_history";
@@ -134,10 +133,10 @@ async fn execute_queries_from_a_repl(mut client: Client) -> Result<()> {
 
         // Refresh the table names for tab-completion if a table may have been created or dropped.
         let first_word = line.split_whitespace().next().unwrap_or("");
-        if first_word.eq_ignore_ascii_case("CREATE") || first_word.eq_ignore_ascii_case("DROP") {
-            if let Ok(table_names) = client.tables().await {
-                editor.set_helper(Some(ClientHelper::new(table_names)));
-            }
+        if (first_word.eq_ignore_ascii_case("CREATE") || first_word.eq_ignore_ascii_case("DROP"))
+            && let Ok(table_names) = client.tables().await
+        {
+            editor.set_helper(Some(ClientHelper::new(table_names)));
         }
     }
 

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -265,9 +265,10 @@ fn confirm_printing_next_batch() -> Result<bool> {
             return Ok(false);
         }
 
-        match user_input.as_str() {
-            "\n" => return Ok(true),
-            "q\n" => return Ok(false),
+        // The line includes the line ending, which is \r\n on Windows and \n everywhere else.
+        match user_input.trim() {
+            "" => return Ok(true),
+            "q" => return Ok(false),
             _ => (),
         }
     }

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -224,67 +224,23 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
     }
 }
 
+/// Execute a query and print each batch in the result set. If standard output is a terminal, ask
+/// the user for confirmation before printing each batch after the first. Returns
+/// [`ModelarDbClientError`] if the query could not be executed or the batches in the result set
+/// could not be printed.
+async fn execute_query_and_print_result(client: &mut Client, query: &str) -> Result<()> {
+    let mut record_batch_stream = client.read(query).await?;
 
-
-/// Execute a query and print each batch in the result set. Returns [`ModelarDbClientError`] if the
-/// query could not be executed or the batches in the result set could not be printed.
-async fn execute_query_and_print_result(
-    flight_service_client: &mut AuthenticatedFlightClient,
-    query: &str,
-) -> Result<()> {
-    // Execute the query.
-    let ticket = Ticket {
-        ticket: query.to_owned().into(),
-    };
-    let mut stream = flight_service_client.do_get(ticket).await?.into_inner();
-
-    // Get the schema of the data in the query result.
-    let flight_data = stream
-        .message()
-        .await?
-        .ok_or(ModelarDbClientError::InvalidArgument(
-            TRANSPORT_ERROR.to_owned(),
-        ))?;
-    let schema = Arc::new(Schema::try_from(&flight_data)?);
-    let dictionaries_by_id = HashMap::new();
-
-    if io::stdout().is_terminal() {
-        print_batches_with_confirmation(stream, schema, &dictionaries_by_id).await
-    } else {
-        print_batches_without_confirmation(stream, schema, &dictionaries_by_id).await
-    }
-}
-
-/// Print each batch in the result set with confirmation from the user before printing each batch.
-/// Returns [`ModelarDbClientError`] if the batches in the result set could not be printed.
-async fn print_batches_with_confirmation(
-    mut stream: Streaming<FlightData>,
-    schema: Arc<Schema>,
-    dictionaries_by_id: &HashMap<i64, ArrayRef>,
-) -> Result<()> {
-    let mut user_input = String::new();
+    let print_confirmation = io::stdout().is_terminal();
     let mut multiple_batches = false;
 
-    while let Some(flight_data) = stream.message().await? {
-        let record_batch =
-            utils::flight_data_to_arrow_batch(&flight_data, schema.clone(), dictionaries_by_id)?;
-
+    while let Some(record_batch) = record_batch_stream.next().await {
         // Only ask for confirmation to print the next batch if there are multiple batches.
-        if multiple_batches {
-            loop {
-                user_input.clear();
-                print!("Press Enter for next batch and q+Enter to quit> ");
-                io::stdout().flush()?;
-                io::stdin().read_line(&mut user_input)?;
-
-                match user_input.as_str() {
-                    "\n" => break,
-                    "q\n" => return Ok(()),
-                    _ => (),
-                }
-            }
+        if print_confirmation && multiple_batches && !confirm_printing_next_batch()? {
+            return Ok(());
         }
 
+        let record_batch = record_batch.map_err(ModelarDbEmbeddedError::from)?;
         pretty::print_batches(&[record_batch])?;
         multiple_batches = true;
     }
@@ -292,19 +248,27 @@ async fn print_batches_with_confirmation(
     Ok(())
 }
 
-/// Print each batch in the result set without user input. Returns [`ModelarDbClientError`] if the
-/// batches in the result set could not be printed.
-async fn print_batches_without_confirmation(
-    mut stream: Streaming<FlightData>,
-    schema: Arc<Schema>,
-    dictionaries_by_id: &HashMap<i64, ArrayRef>,
-) -> Result<()> {
-    while let Some(flight_data) = stream.message().await? {
-        let record_batch =
-            utils::flight_data_to_arrow_batch(&flight_data, schema.clone(), dictionaries_by_id)?;
+/// Ask the user for confirmation before printing the next batch in a result set. Returns false if
+/// the user chose to stop printing batches. Returns [`ModelarDbClientError`] if the input could not
+/// be read.
+fn confirm_printing_next_batch() -> Result<bool> {
+    let mut user_input = String::new();
 
-        pretty::print_batches(&[record_batch])?;
+    loop {
+        user_input.clear();
+        print!("Press Enter for next batch and q+Enter to quit> ");
+        io::stdout().flush()?;
+
+        // A read of zero bytes means standard input reached end-of-file, so no more batches can be
+        // confirmed.
+        if io::stdin().read_line(&mut user_input)? == 0 {
+            return Ok(false);
+        }
+
+        match user_input.as_str() {
+            "\n" => return Ok(true),
+            "q\n" => return Ok(false),
+            _ => (),
+        }
     }
-
-    Ok(())
 }

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -207,8 +207,7 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
         }
         // Print the configuration of the node.
         "\\dc" => {
-            let configuration = client.configuration().await?;
-            print_configuration(&configuration);
+            print_configuration(&client.configuration().await?);
             Ok(())
         }
         // Print the nodes that are currently part of the cluster.
@@ -220,8 +219,7 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
         }
         // Print the resource usage metrics of the node.
         "\\dm" => {
-            let node_metrics = client.node_metrics().await?;
-            print_node_metrics(&node_metrics);
+            print_node_metrics(&client.node_metrics().await?);
             Ok(())
         }
         // Update a setting in the configuration of the node.
@@ -238,7 +236,7 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
             )?;
 
             // Omitting the value unsets the setting if it is optional.
-            let new_value = match command_and_arguments.next() {
+            let maybe_new_value = match command_and_arguments.next() {
                 Some(value) => Some(value.parse::<u64>().map_err(|_error| {
                     ModelarDbClientError::InvalidArgument(format!(
                         "{value} is not a valid value for {name}."
@@ -247,7 +245,9 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
                 None => None,
             };
 
-            client.update_configuration(setting, new_value).await?;
+            client
+                .update_configuration(setting, maybe_new_value)
+                .await?;
             Ok(())
         }
         // Flushes all data the server currently has in memory to disk.

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -210,6 +210,12 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
             }
             Ok(())
         }
+        // Print the resource usage metrics of the node.
+        "\\dm" => {
+            let node_metrics = client.node_metrics().await?;
+            print_node_metrics(&node_metrics);
+            Ok(())
+        }
         // Flushes all data the server currently has in memory to disk.
         "\\f" => client.flush_memory().await.map_err(|error| error.into()),
         // Flushes all data the server currently has in memory and disk to the object store.
@@ -324,4 +330,53 @@ fn print_configuration(configuration: &protocol::Configuration) {
     println!("compression_threads: {}", configuration.compression_threads);
     println!("writer_threads: {}", configuration.writer_threads);
     println!("wal_enabled: {}", configuration.wal_enabled);
+}
+
+/// Print each field in `node_metrics` on its own line.
+fn print_node_metrics(node_metrics: &protocol::NodeMetrics) {
+    println!(
+        "cpu_usage_percentage: {}",
+        node_metrics.cpu_usage_percentage
+    );
+    println!("cpu_count: {}", node_metrics.cpu_count);
+    println!(
+        "used_memory_in_bytes: {}",
+        node_metrics.used_memory_in_bytes
+    );
+    println!(
+        "total_memory_in_bytes: {}",
+        node_metrics.total_memory_in_bytes
+    );
+    println!(
+        "used_disk_space_in_bytes: {}",
+        node_metrics.used_disk_space_in_bytes
+    );
+    println!(
+        "total_disk_space_in_bytes: {}",
+        node_metrics.total_disk_space_in_bytes
+    );
+    println!(
+        "ingested_used_memory_in_bytes: {}",
+        node_metrics.ingested_used_memory_in_bytes
+    );
+    println!(
+        "ingested_reserved_memory_in_bytes: {}",
+        node_metrics.ingested_reserved_memory_in_bytes
+    );
+    println!(
+        "uncompressed_used_memory_in_bytes: {}",
+        node_metrics.uncompressed_used_memory_in_bytes
+    );
+    println!(
+        "uncompressed_reserved_memory_in_bytes: {}",
+        node_metrics.uncompressed_reserved_memory_in_bytes
+    );
+    println!(
+        "compressed_used_memory_in_bytes: {}",
+        node_metrics.compressed_used_memory_in_bytes
+    );
+    println!(
+        "compressed_reserved_memory_in_bytes: {}",
+        node_metrics.compressed_reserved_memory_in_bytes
+    );
 }

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -354,7 +354,6 @@ fn print_configuration(configuration: &protocol::Configuration) {
         wal_enabled,
     } = configuration;
 
-    // Data is only transferred on an explicit flush if the batch size is not set.
     let transfer_batch_size_in_bytes =
         transfer_batch_size_in_bytes.map_or("not set".to_owned(), |value| value.to_string());
 

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -247,11 +247,6 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
         "\\f" => client.flush_memory().await.map_err(|error| error.into()),
         // Flushes all data the server currently has in memory and disk to the object store.
         "\\F" => client.flush_node().await.map_err(|error| error.into()),
-        // Kill the node and quit, the connection is dead once the node process exits.
-        "\\k" => {
-            client.kill_node().await?;
-            process::exit(0);
-        }
         // Print helpful information, explanations with \\ must be indented more to be aligned.
         "\\h" => {
             println!(
@@ -260,12 +255,22 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
                  SELECT                         Execute a SELECT statement.\n\
                  \\d TABLE_NAME                 Print the schema of a table with TABLE_NAME.\n\
                  \\dt                           Print the name of all the tables.\n\
+                 \\dc                           Print the configuration of the node.\n\
+                 \\dn                           Print the nodes in the cluster.\n\
+                 \\dm                           Print the resource usage metrics of the node.\n\
+                 \\s SETTING [VALUE]            Set SETTING to VALUE, or unset SETTING if VALUE is omitted.\n\
                  \\f                            Flushes data in memory to disk.\n\
                  \\F                            Flushes data in memory and disk to the object store.\n\
                  \\h                            Print documentation for all supported commands.\n\
+                 \\k                            Kill the node and quit modelardb.\n\
                  \\q                            Quit modelardb."
             );
             Ok(())
+        }
+        // Kill the node and quit, the connection is dead once the node process exits.
+        "\\k" => {
+            client.kill_node().await?;
+            process::exit(0);
         }
         "\\q" => {
             process::exit(0);

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -36,13 +36,6 @@ use rustyline::history::FileHistory;
 use crate::error::{ModelarDbClientError, Result};
 use crate::helper::ClientHelper;
 
-/// Error to emit when the server does not provide a response when one is expected.
-const TRANSPORT_ERROR: &str = "transport error: no messages received.";
-
-/// [`FlightServiceClient`] with a [`BearerInterceptor`] that attaches an authorization header.
-type AuthenticatedFlightClient =
-    FlightServiceClient<InterceptedService<Channel, BearerInterceptor>>;
-
 /// Command line arguments for the ModelarDB client.
 #[derive(Parser)]
 #[command(

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -91,25 +91,6 @@ async fn main() -> Result<()> {
     }
 }
 
-/// Connect to the server at `host`:`port` with an optional bearer `maybe_token`. Returns
-/// [`ModelarDbClientError`] if a connection to the server cannot be established or the token is
-/// not a valid ASCII metadata value.
-async fn connect(
-    host: &str,
-    port: u16,
-    maybe_token: Option<String>,
-) -> Result<AuthenticatedFlightClient> {
-    let interceptor = BearerInterceptor::try_new(maybe_token.as_deref())?;
-
-    let address = format!("grpc://{host}:{port}");
-    let connection = Endpoint::new(address)?.connect().await?;
-
-    Ok(FlightServiceClient::with_interceptor(
-        connection,
-        interceptor,
-    ))
-}
-
 /// Execute the commands and queries in `query_file`.
 async fn execute_queries_from_a_file(
     mut flight_service_client: AuthenticatedFlightClient,

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -92,10 +92,7 @@ async fn main() -> Result<()> {
 }
 
 /// Execute the commands and queries in `query_file`.
-async fn execute_queries_from_a_file(
-    mut flight_service_client: AuthenticatedFlightClient,
-    query_file: &StdPath,
-) -> Result<()> {
+async fn execute_queries_from_a_file(mut client: Client, query_file: &StdPath) -> Result<()> {
     let file = File::open(query_file)?;
     let lines = BufReader::new(file).lines();
 
@@ -111,7 +108,7 @@ async fn execute_queries_from_a_file(
         // Execute the query.
         if !query.is_empty() {
             println!("{query}");
-            execute_and_print_command_or_query(&mut flight_service_client, &query).await
+            execute_and_print_command_or_query(&mut client, &query).await
         }
     }
 
@@ -119,12 +116,10 @@ async fn execute_queries_from_a_file(
 }
 
 /// Execute commands and queries in a read-eval-print loop.
-async fn execute_queries_from_a_repl(
-    mut flight_service_client: AuthenticatedFlightClient,
-) -> Result<()> {
+async fn execute_queries_from_a_repl(mut client: Client) -> Result<()> {
     // Create the read-eval-print loop.
     let mut editor = Editor::<ClientHelper, FileHistory>::new()?;
-    let table_names = retrieve_table_names(&mut flight_service_client).await?;
+    let table_names = client.tables().await?;
     editor.set_helper(Some(ClientHelper::new(table_names)));
 
     // Read previously executed commands and queries from the history file.
@@ -140,7 +135,7 @@ async fn execute_queries_from_a_repl(
     // Execute commands and queries and print the result.
     while let Ok(line) = editor.readline("ModelarDB> ") {
         editor.add_history_entry(line.as_str())?;
-        execute_and_print_command_or_query(&mut flight_service_client, &line).await
+        execute_and_print_command_or_query(&mut client, &line).await
     }
 
     // Append the executed commands and queries to the history file.
@@ -154,17 +149,14 @@ async fn execute_queries_from_a_repl(
 
 /// Execute a command or a query. Returns [`ModelarDbClientError`] if the command or query could not
 /// be executed or their result could not be retrieved.
-async fn execute_and_print_command_or_query(
-    flight_service_client: &mut AuthenticatedFlightClient,
-    command_or_query: &str,
-) {
+async fn execute_and_print_command_or_query(client: &mut Client, command_or_query: &str) {
     let start_time = Instant::now();
     let command_or_query = command_or_query.trim();
 
     let result = if command_or_query.starts_with('\\') {
-        execute_command(flight_service_client, command_or_query).await
+        execute_command(client, command_or_query).await
     } else {
-        execute_query_and_print_result(flight_service_client, command_or_query).await
+        execute_query_and_print_result(client, command_or_query).await
     };
 
     if let Err(message) = result {
@@ -178,12 +170,7 @@ async fn execute_and_print_command_or_query(
 /// * An incorrect argument for the command was provided.
 /// * The command could not be executed.
 /// * The result could not be retrieved.
-async fn execute_command(
-    flight_service_client: &mut AuthenticatedFlightClient,
-    command_and_argument: &str,
-) -> Result<()> {
-    let mut command_and_argument = command_and_argument.split(' ');
-    match command_and_argument
+async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Result<()> {
         .next()
         .ok_or(ModelarDbClientError::InvalidArgument(
             "No command was provided.".to_owned(),

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -262,7 +262,7 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
                  \\f                            Flushes data in memory to disk.\n\
                  \\F                            Flushes data in memory and disk to the object store.\n\
                  \\h                            Print documentation for all supported commands.\n\
-                 \\k                            Kill the node and quit modelardb.\n\
+                 \\k                            Flush data to disk, kill the node, and quit modelardb.\n\
                  \\q                            Quit modelardb."
             );
             Ok(())

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -101,9 +101,9 @@ async fn execute_queries_from_a_file(mut client: Client, query_file: &StdPath) -
         };
 
         // Execute the query.
-        if !query.is_empty() {
+        if !query.trim().is_empty() {
             println!("{query}");
-            execute_and_print_command_or_query(&mut client, &query).await
+            execute_and_print_command_or_query(&mut client, &query).await;
         }
     }
 
@@ -154,6 +154,11 @@ async fn execute_queries_from_a_repl(mut client: Client) -> Result<()> {
 async fn execute_and_print_command_or_query(client: &mut Client, command_or_query: &str) {
     let start_time = Instant::now();
     let command_or_query = command_or_query.trim();
+
+    // Nothing to execute if Enter was pressed without any input.
+    if command_or_query.is_empty() {
+        return;
+    }
 
     let result = if command_or_query.starts_with('\\') {
         execute_command(client, command_or_query).await

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -18,29 +18,20 @@
 mod error;
 mod helper;
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, IsTerminal, Write};
 use std::path::{Path as StdPath, PathBuf};
 use std::process;
-use std::sync::Arc;
 use std::time::Instant;
 
-use arrow::array::ArrayRef;
-use arrow::datatypes::Schema;
-use arrow::ipc::convert;
 use arrow::util::pretty;
-use arrow_flight::flight_service_client::FlightServiceClient;
-use arrow_flight::{Action, Criteria, FlightData, FlightDescriptor, Ticket, utils};
-use bytes::Bytes;
 use clap::Parser;
-use modelardb_auth::BearerInterceptor;
+use futures::StreamExt;
+use modelardb_embedded::error::ModelarDbEmbeddedError;
+use modelardb_embedded::operations::Operations;
+use modelardb_embedded::operations::client::Client;
 use rustyline::Editor;
 use rustyline::history::FileHistory;
-use tonic::codegen::InterceptedService;
-use tonic::transport::{Channel, Endpoint};
-use tonic::{Request, Streaming};
 
 use crate::error::{ModelarDbClientError, Result};
 use crate::helper::ClientHelper;
@@ -88,12 +79,15 @@ async fn main() -> Result<()> {
     // Parse the command line arguments.
     let args = ClientArgs::parse();
 
+    // Connect to the server.
+    let url = format!("grpc://{}:{}", args.host, args.port);
+    let client = Client::connect(&url, args.token.as_deref()).await?;
+
     // Execute the queries.
-    let flight_service_client = connect(&args.host, args.port, args.token).await?;
     if let Some(query_file) = args.query_file {
-        execute_queries_from_a_file(flight_service_client, &query_file).await
+        execute_queries_from_a_file(client, &query_file).await
     } else {
-        execute_queries_from_a_repl(flight_service_client).await
+        execute_queries_from_a_repl(client).await
     }
 }
 

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -340,87 +340,64 @@ fn confirm_printing_next_batch() -> Result<bool> {
 
 /// Print each field in `configuration` on its own line.
 fn print_configuration(configuration: &protocol::Configuration) {
-    println!(
-        "ingested_reserved_memory_in_bytes: {}",
-        configuration.ingested_reserved_memory_in_bytes
-    );
-    println!(
-        "uncompressed_reserved_memory_in_bytes: {}",
-        configuration.uncompressed_reserved_memory_in_bytes
-    );
-    println!(
-        "compressed_reserved_memory_in_bytes: {}",
-        configuration.compressed_reserved_memory_in_bytes
-    );
+    let protocol::Configuration {
+        ingested_reserved_memory_in_bytes,
+        uncompressed_reserved_memory_in_bytes,
+        compressed_reserved_memory_in_bytes,
+        transfer_batch_size_in_bytes,
+        segment_size_threshold_in_bytes,
+        optimize_target_file_size_in_bytes,
+        vacuum_retention_period_in_seconds,
+        ingestion_threads,
+        compression_threads,
+        writer_threads,
+        wal_enabled,
+    } = configuration;
 
-    let transfer_batch_size_in_bytes = configuration
-        .transfer_batch_size_in_bytes
-        .map_or("not set".to_owned(), |value| value.to_string());
+    // Data is only transferred on an explicit flush if the batch size is not set.
+    let transfer_batch_size_in_bytes =
+        transfer_batch_size_in_bytes.map_or("not set".to_owned(), |value| value.to_string());
+
+    println!("ingested_reserved_memory_in_bytes: {ingested_reserved_memory_in_bytes}");
+    println!("uncompressed_reserved_memory_in_bytes: {uncompressed_reserved_memory_in_bytes}");
+    println!("compressed_reserved_memory_in_bytes: {compressed_reserved_memory_in_bytes}");
     println!("transfer_batch_size_in_bytes: {transfer_batch_size_in_bytes}");
-
-    println!(
-        "segment_size_threshold_in_bytes: {}",
-        configuration.segment_size_threshold_in_bytes
-    );
-    println!(
-        "optimize_target_file_size_in_bytes: {}",
-        configuration.optimize_target_file_size_in_bytes
-    );
-    println!(
-        "vacuum_retention_period_in_seconds: {}",
-        configuration.vacuum_retention_period_in_seconds
-    );
-    println!("ingestion_threads: {}", configuration.ingestion_threads);
-    println!("compression_threads: {}", configuration.compression_threads);
-    println!("writer_threads: {}", configuration.writer_threads);
-    println!("wal_enabled: {}", configuration.wal_enabled);
+    println!("segment_size_threshold_in_bytes: {segment_size_threshold_in_bytes}");
+    println!("optimize_target_file_size_in_bytes: {optimize_target_file_size_in_bytes}");
+    println!("vacuum_retention_period_in_seconds: {vacuum_retention_period_in_seconds}");
+    println!("ingestion_threads: {ingestion_threads}");
+    println!("compression_threads: {compression_threads}");
+    println!("writer_threads: {writer_threads}");
+    println!("wal_enabled: {wal_enabled}");
 }
 
 /// Print each field in `node_metrics` on its own line.
 fn print_node_metrics(node_metrics: &protocol::NodeMetrics) {
-    println!(
-        "cpu_usage_percentage: {}",
-        node_metrics.cpu_usage_percentage
-    );
-    println!("cpu_count: {}", node_metrics.cpu_count);
-    println!(
-        "used_memory_in_bytes: {}",
-        node_metrics.used_memory_in_bytes
-    );
-    println!(
-        "total_memory_in_bytes: {}",
-        node_metrics.total_memory_in_bytes
-    );
-    println!(
-        "used_disk_space_in_bytes: {}",
-        node_metrics.used_disk_space_in_bytes
-    );
-    println!(
-        "total_disk_space_in_bytes: {}",
-        node_metrics.total_disk_space_in_bytes
-    );
-    println!(
-        "ingested_used_memory_in_bytes: {}",
-        node_metrics.ingested_used_memory_in_bytes
-    );
-    println!(
-        "ingested_reserved_memory_in_bytes: {}",
-        node_metrics.ingested_reserved_memory_in_bytes
-    );
-    println!(
-        "uncompressed_used_memory_in_bytes: {}",
-        node_metrics.uncompressed_used_memory_in_bytes
-    );
-    println!(
-        "uncompressed_reserved_memory_in_bytes: {}",
-        node_metrics.uncompressed_reserved_memory_in_bytes
-    );
-    println!(
-        "compressed_used_memory_in_bytes: {}",
-        node_metrics.compressed_used_memory_in_bytes
-    );
-    println!(
-        "compressed_reserved_memory_in_bytes: {}",
-        node_metrics.compressed_reserved_memory_in_bytes
-    );
+    let protocol::NodeMetrics {
+        cpu_usage_percentage,
+        cpu_count,
+        used_memory_in_bytes,
+        total_memory_in_bytes,
+        used_disk_space_in_bytes,
+        total_disk_space_in_bytes,
+        ingested_used_memory_in_bytes,
+        ingested_reserved_memory_in_bytes,
+        uncompressed_used_memory_in_bytes,
+        uncompressed_reserved_memory_in_bytes,
+        compressed_used_memory_in_bytes,
+        compressed_reserved_memory_in_bytes,
+    } = node_metrics;
+
+    println!("cpu_usage_percentage: {cpu_usage_percentage}");
+    println!("cpu_count: {cpu_count}");
+    println!("used_memory_in_bytes: {used_memory_in_bytes}");
+    println!("total_memory_in_bytes: {total_memory_in_bytes}");
+    println!("used_disk_space_in_bytes: {used_disk_space_in_bytes}");
+    println!("total_disk_space_in_bytes: {total_disk_space_in_bytes}");
+    println!("ingested_used_memory_in_bytes: {ingested_used_memory_in_bytes}");
+    println!("ingested_reserved_memory_in_bytes: {ingested_reserved_memory_in_bytes}");
+    println!("uncompressed_used_memory_in_bytes: {uncompressed_used_memory_in_bytes}");
+    println!("uncompressed_reserved_memory_in_bytes: {uncompressed_reserved_memory_in_bytes}");
+    println!("compressed_used_memory_in_bytes: {compressed_used_memory_in_bytes}");
+    println!("compressed_reserved_memory_in_bytes: {compressed_reserved_memory_in_bytes}");
 }

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -203,6 +203,13 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
             print_configuration(&configuration);
             Ok(())
         }
+        // Print the nodes that are currently part of the cluster.
+        "\\dn" => {
+            for node in client.list_nodes().await? {
+                println!("{} ({})", node.url, node.mode);
+            }
+            Ok(())
+        }
         // Flushes all data the server currently has in memory to disk.
         "\\f" => client.flush_memory().await.map_err(|error| error.into()),
         // Flushes all data the server currently has in memory and disk to the object store.

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -30,6 +30,7 @@ use futures::StreamExt;
 use modelardb_embedded::error::ModelarDbEmbeddedError;
 use modelardb_embedded::operations::Operations;
 use modelardb_embedded::operations::client::Client;
+use modelardb_types::flight::protocol;
 use rustyline::Editor;
 use rustyline::history::FileHistory;
 
@@ -196,6 +197,12 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
             }
             Ok(())
         }
+        // Print the configuration of the node.
+        "\\dc" => {
+            let configuration = client.configuration().await?;
+            print_configuration(&configuration);
+            Ok(())
+        }
         // Flushes all data the server currently has in memory to disk.
         "\\f" => client.flush_memory().await.map_err(|error| error.into()),
         // Flushes all data the server currently has in memory and disk to the object store.
@@ -272,4 +279,42 @@ fn confirm_printing_next_batch() -> Result<bool> {
             _ => (),
         }
     }
+}
+
+/// Print each field in `configuration` on its own line.
+fn print_configuration(configuration: &protocol::Configuration) {
+    println!(
+        "ingested_reserved_memory_in_bytes: {}",
+        configuration.ingested_reserved_memory_in_bytes
+    );
+    println!(
+        "uncompressed_reserved_memory_in_bytes: {}",
+        configuration.uncompressed_reserved_memory_in_bytes
+    );
+    println!(
+        "compressed_reserved_memory_in_bytes: {}",
+        configuration.compressed_reserved_memory_in_bytes
+    );
+
+    let transfer_batch_size_in_bytes = configuration
+        .transfer_batch_size_in_bytes
+        .map_or("not set".to_owned(), |value| value.to_string());
+    println!("transfer_batch_size_in_bytes: {transfer_batch_size_in_bytes}");
+
+    println!(
+        "segment_size_threshold_in_bytes: {}",
+        configuration.segment_size_threshold_in_bytes
+    );
+    println!(
+        "optimize_target_file_size_in_bytes: {}",
+        configuration.optimize_target_file_size_in_bytes
+    );
+    println!(
+        "vacuum_retention_period_in_seconds: {}",
+        configuration.vacuum_retention_period_in_seconds
+    );
+    println!("ingestion_threads: {}", configuration.ingestion_threads);
+    println!("compression_threads: {}", configuration.compression_threads);
+    println!("writer_threads: {}", configuration.writer_threads);
+    println!("wal_enabled: {}", configuration.wal_enabled);
 }

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -237,28 +237,6 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
 }
 
 
-/// Execute an action. Returns [`ModelarDbClientError`] if the action could not be executed.
-async fn execute_action(
-    flight_service_client: &mut AuthenticatedFlightClient,
-    action_type: &str,
-    action_body: &str,
-) -> Result<()> {
-    let action = Action {
-        r#type: action_type.to_owned(),
-        body: action_body.to_owned().into(),
-    };
-
-    let request = Request::new(action);
-
-    flight_service_client
-        .do_action(request)
-        .await?
-        .into_inner()
-        .message()
-        .await?;
-
-    Ok(())
-}
 
 /// Execute a query and print each batch in the result set. Returns [`ModelarDbClientError`] if the
 /// query could not be executed or the batches in the result set could not be printed.

--- a/crates/modelardb_client/src/main.rs
+++ b/crates/modelardb_client/src/main.rs
@@ -236,37 +236,6 @@ async fn execute_command(client: &mut Client, command_and_arguments: &str) -> Re
     }
 }
 
-/// Retrieve the names of the tables available on the server. Returns [`ModelarDbClientError`] if
-/// the request could not be performed or the tables names could not be retrieved.
-async fn retrieve_table_names(
-    flight_service_client: &mut AuthenticatedFlightClient,
-) -> Result<Vec<String>> {
-    let criteria = Criteria {
-        expression: Bytes::new(),
-    };
-    let request = Request::new(criteria);
-
-    let mut stream = flight_service_client
-        .list_flights(request)
-        .await?
-        .into_inner();
-
-    let flight_infos = stream
-        .message()
-        .await?
-        .ok_or(ModelarDbClientError::InvalidArgument(
-            TRANSPORT_ERROR.to_owned(),
-        ))?;
-
-    let mut table_names = vec![];
-    if let Some(flight_descriptor) = flight_infos.flight_descriptor {
-        for table_name in flight_descriptor.path {
-            table_names.push(table_name);
-        }
-    }
-
-    Ok(table_names)
-}
 
 /// Execute an action. Returns [`ModelarDbClientError`] if the action could not be executed.
 async fn execute_action(

--- a/crates/modelardb_embedded/src/operations/client.rs
+++ b/crates/modelardb_embedded/src/operations/client.rs
@@ -114,9 +114,9 @@ impl Client {
 
     /// Flushes all data to disk, removes the node from the cluster if necessary, and kills the node
     /// process. Data is not transferred to the remote object store. Call [`Client::flush_node`]
-    /// first if that is required. Since the process is killed, a conventional response cannot be
-    /// returned, so a dropped connection is not treated as an error. If the data could not be
-    /// flushed before the node was killed, [`ModelarDbEmbeddedError`] is returned.
+    /// first if that is required. The node exits while handling the request, so a response cannot
+    /// be returned. Errors are therefore ignored and [`Ok`] is returned even if the node rejected
+    /// the request or failed to flush its data.
     pub async fn kill_node(&mut self) -> Result<()> {
         // The node exits while handling this action, so the response stream is dropped.
         let _ = self.send_action("KillNode", vec![]).await;

--- a/crates/modelardb_embedded/src/operations/client.rs
+++ b/crates/modelardb_embedded/src/operations/client.rs
@@ -112,11 +112,11 @@ impl Client {
         Ok(())
     }
 
-    /// Flushes all data to disk, transfers it to the remote object store, removes the node from the
-    /// cluster if necessary, and kills the node process. Since the process is killed, a
-    /// conventional response cannot be returned, so a dropped connection is not treated as an
-    /// error. If the data could not be flushed before the node was killed,
-    /// [`ModelarDbEmbeddedError`] is returned.
+    /// Flushes all data to disk, removes the node from the cluster if necessary, and kills the node
+    /// process. Data is not transferred to the remote object store. Call [`Client::flush_node`]
+    /// first if that is required. Since the process is killed, a conventional response cannot be
+    /// returned, so a dropped connection is not treated as an error. If the data could not be
+    /// flushed before the node was killed, [`ModelarDbEmbeddedError`] is returned.
     pub async fn kill_node(&mut self) -> Result<()> {
         // The node exits while handling this action, so the response stream is dropped.
         let _ = self.send_action("KillNode", vec![]).await;

--- a/crates/modelardb_server/src/remote/mod.rs
+++ b/crates/modelardb_server/src/remote/mod.rs
@@ -1133,9 +1133,10 @@ impl FlightService for FlightServiceHandler {
 
         let kill_node_action = ActionType {
             r#type: "KillNode".to_owned(),
-            description: "Flush uncompressed data to disk by compressing and saving the data and \
-                          kill the process running the server. Data is not transferred to the \
-                          remote object store. Use FlushNode first if that is required."
+            description: "Flush uncompressed data to disk by compressing and saving the data, \
+                          remove the node from the cluster if necessary, and kill the process \
+                          running the server. Data is not transferred to the remote object store. \
+                          Use FlushNode first if that is required."
                 .to_owned(),
         };
 

--- a/crates/modelardb_server/src/remote/mod.rs
+++ b/crates/modelardb_server/src/remote/mod.rs
@@ -886,10 +886,11 @@ impl FlightService for FlightServiceHandler {
     /// currently in memory to disk and then flushes all compressed data on disk to the remote
     /// object store. Note that data is only transferred to the remote object store if one was
     /// provided when starting the server.
-    /// * `KillNode`: An extension of the `FlushNode` action that first flushes all data to disk,
-    /// then flushes all compressed data to the remote object store, then removes the node
-    /// from the cluster if necessary, and finally kills the process that is running the server.
-    /// Note that since the process is killed, a conventional response cannot be returned.
+    /// * `KillNode`: An extension of the `FlushMemory` action that first flushes all data that is
+    /// currently in memory to disk, then removes the node from the cluster if necessary, and
+    /// finally kills the process that is running the server. Data is not transferred to the remote
+    /// object store. Use `FlushNode` first if that is required. Note that since the process is
+    /// killed, a conventional response cannot be returned.
     /// * `GetConfiguration`: Get the current server configuration. The value of each setting in the
     /// configuration is returned in a [`Configuration`](protocol::Configuration) protobuf message.
     /// * `UpdateConfiguration`: Update a single setting in the configuration. The setting to update
@@ -954,13 +955,11 @@ impl FlightService for FlightServiceHandler {
             // Confirm the data was flushed.
             Ok(Response::new(Box::pin(stream::empty())))
         } else if action.r#type == "KillNode" {
-            let mut storage_engine = self.context.storage_engine.write().await;
-            storage_engine
-                .flush()
+            self.context
+                .storage_engine
+                .write()
                 .await
-                .map_err(error_to_status_internal)?;
-            storage_engine
-                .transfer()
+                .flush()
                 .await
                 .map_err(error_to_status_internal)?;
 
@@ -1134,9 +1133,9 @@ impl FlightService for FlightServiceHandler {
 
         let kill_node_action = ActionType {
             r#type: "KillNode".to_owned(),
-            description: "Flush uncompressed data to disk by compressing and saving the data, \
-                          transfer all compressed data to the remote object store, and kill the \
-                          process running the server."
+            description: "Flush uncompressed data to disk by compressing and saving the data and \
+                          kill the process running the server. Data is not transferred to the \
+                          remote object store. Use FlushNode first if that is required."
                 .to_owned(),
         };
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -263,10 +263,20 @@ instance executes the `SELECT` statement on the data it manages and forwards the
 the provided addresses. Afterwards, the `modelardbd` instance that initially received the query, unions the result from
 all `modelardbd` instances and returns it to the client. As an example, this can be used to execute a `SELECT` statement
 on both the data in the cloud and a specific edge node. Although, be aware that this does not make the edge node
-transfer the data it manages to the cloud, only the result of the query. In addition to SQL statements, the REPL also
-supports listing all tables using `\dt`, printing the schema of a table using `\d table_name`, flushing data in memory
-to disk using `\f`, flushing data in memory and on disk to an object store using `\F`, and printing operations supported
-by the client using `\h`.
+transfer the data it manages to the cloud, only the result of the query.
+
+In addition to SQL statements, the REPL supports the following commands:
+- `\d table_name` - Print the schema of the table with `table_name`.
+- `\dt` - Print the name of all the tables.
+- `\dc` - Print the configuration of the node.
+- `\dn` - Print the nodes in the cluster.
+- `\dm` - Print the resource usage metrics of the node.
+- `\sc setting [value]` - Set `setting` to `value`, or unset `setting` if `value` is omitted.
+- `\f` - Flush data in memory to disk.
+- `\F` - Flush data in memory and on disk to an object store.
+- `\h` - Print documentation for all supported commands.
+- `\k` - Flush data to disk, kill the node, and quit `modelardb`.
+- `\q` - Quit `modelardb`.
 
 ```sql
 ModelarDB> \dt


### PR DESCRIPTION
This PR closes https://github.com/ModelarData/ModelarDB-RS/issues/417 by refactoring the CLI in `modelardb_client` to use `Client` from `modelardb_embedded` instead of a separate manual Apache Arrow Flight client. This unifies the way we access the server in the system and removes unnecessary code in the CLI. Other than refactoring the existing functionality, new commands have also been added to the CLI so it supports all the relevant methods that we expose through the `Client` API.

The PR also changes tab completion slightly so we now update the possible completions when we create or drop tables, and it updates the `KillNode` action to make it consistent with how we handle `ctrl+c` in the server. We now no longer try to transfer data when killing a node, and now only flush to disk. If a user wants to flush to the remote object store before killing a node, they can call `FlushNode` separately. 
