### PR TITLE
Update ast-grep rules to use the latest version

### DIFF
--- a/.github/workflows/ast-grep-scan.yml
+++ b/.github/workflows/ast-grep-scan.yml
@@ -30,4 +30,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Ast-grep Scan
-        uses: ast-grep/action@latest
+	uses: ast-grep/action@v1.5.0

--- a/.github/workflows/ast-grep-scan.yml
+++ b/.github/workflows/ast-grep-scan.yml
@@ -30,6 +30,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Ast-grep Scan
-        uses: ast-grep/action@v1.5
-        with:
-          version: 0.21.4  # Version 0.22.0 breaks the missing_punctuation rule.
+        uses: ast-grep/action@latest

--- a/.github/workflows/ast-grep-scan.yml
+++ b/.github/workflows/ast-grep-scan.yml
@@ -30,4 +30,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Ast-grep Scan
-	uses: ast-grep/action@v1.5.0
+        uses: ast-grep/action@v1.5.0

--- a/rules/missing_punctuation.yml
+++ b/rules/missing_punctuation.yml
@@ -6,7 +6,8 @@ language: Rust
 rule:
   kind: line_comment
   all:
-    - regex: '.+[^\\.]$'
+    - not:
+        regex: '.\.\s*$'
     - not:
         regex: '.*https?://.*'
   precedes:

--- a/rules/test_not_named_test.yml
+++ b/rules/test_not_named_test.yml
@@ -2,7 +2,7 @@ id: test_not_named_test
 message: Test function not named test_.
 severity: error
 language: Rust
-# Test functions (annotated with #[test] or #[tokio::test]) must be named test_ etc.
+# Test functions (annotated with #[test], #[property_test], and #[tokio::test]) must be named test_ etc.
 rule:
   kind: function_item
   not:
@@ -11,4 +11,5 @@ rule:
     kind: attribute_item
     any:
       - pattern: '#[test]'
+      - pattern: '#[property_test]'
       - pattern: '#[tokio::test]'


### PR DESCRIPTION
Update the `ast-grep` rules so they work with the latest version of `ast-grep` to fix #192. The `ast-grep` GitHub Action has also been updated to always use the latest version of `ast-grep`.