### PR TITLE
Use Rust 1.97.1 to compile on Windows

### DIFF
--- a/.github/workflows/build-lint-test-and-upload.yml
+++ b/.github/workflows/build-lint-test-and-upload.yml
@@ -78,8 +78,6 @@ jobs:
         az storage container create -n modelardb --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;'
 
     # Update Rust.
-    - name: Rustup Update
-      run: rustup update
     - name: Rustup Add llvm-tools
       run: rustup component add llvm-tools-preview
     - name: Cargo Install grcov

--- a/.github/workflows/build-lint-test-and-upload.yml
+++ b/.github/workflows/build-lint-test-and-upload.yml
@@ -77,9 +77,7 @@ jobs:
         sleep 5 # Ensure azurite has fully finished creating the endpoint.
         az storage container create -n modelardb --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;'
 
-    # Update Rust.
-    - name: Rustup Add llvm-tools
-      run: rustup component add llvm-tools-preview
+    # Install Cargo Tools.
     - name: Cargo Install grcov
       run: cargo install grcov
     - name: Cargo Install machete
@@ -141,10 +139,6 @@ jobs:
     # Retrieve Code.
     - name: Checkout
       uses: actions/checkout@v4
-
-    # Update Rust.
-    - name: Rustup Update
-      run: rustup update
 
     # Build Rust Binaries.
     - name: Cargo Build Binaries

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -37,7 +37,8 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
 
 ### All
 
-2. Install Rust 1.97.1 [Rust Toolchain](https://rustup.rs/).
+2. Install version 1.97.1 of the [Rust Toolchain](https://rustup.rs/).
+   - If your use `rustup` it will automatically install the correct toolchain when you run `cargo` commands.
 3. Clone the repository: `git clone https://github.com/ModelarData/ModelarDB-RS`
 4. Build, test, and run the system using Cargo:
    - Debug Build: `cargo build`

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -37,7 +37,7 @@ The following commands are for Ubuntu Server. However, equivalent commands shoul
 
 ### All
 
-2. Install the latest stable [Rust Toolchain](https://rustup.rs/).
+2. Install Rust 1.97.1 [Rust Toolchain](https://rustup.rs/).
 3. Clone the repository: `git clone https://github.com/ModelarData/ModelarDB-RS`
 4. Build, test, and run the system using Cargo:
    - Debug Build: `cargo build`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.97.1"
+components = ["clippy"]
+profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.97.1"
-components = ["clippy"]
+components = ["clippy", "llvm-tools-preview"]
 profile = "minimal"


### PR DESCRIPTION
This PR specifies a specific Rust version to use to avoid Rust 1.98.0, as it segfaults on Microsoft Windows when running our tests. @CGodiksen verified that it also happens with `main` and not just #424 and #425, so it seems to be a problem with Rust 1.98.0. I have not verified what causes this segfault, but it may be this issue rust-lang/rust#161441 as it was introduced in Rust 1.98.0 and should be a near guaranteed segfault according to the comments.